### PR TITLE
Release Tatami 1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,22 @@ an Install / Update section when publishing). Sparkle's in-app update dialog
 accumulates every patch in a release's minor series, so each section here only
 needs its own version's changes.
 
+## 1.12.0 (2026-08-31)
+
+### New
+- **Automate Tatami with a domain-based CLI:** The bundled `tatami` command now groups actions under profile, workspace, window, display, layout, and app subcommands, with hook inspection alongside them. Select profiles and workspaces by name or UUID, target inactive profiles where supported, and request stable JSON for scripts. The CLI exposes all 38 executable actions available to trackpad gestures. Gesture-equivalent commands other than profile and workspace activation reuse the same dispatcher as hotkeys and gestures. Activation commands wait for their activation pipeline to finish before returning. The original flat commands remain available as compatibility aliases.
+- **Run programs from lifecycle hooks:** Run a program when Tatami launches, the active profile changes, or a workspace becomes visible on a display. Add and test hooks in Settings or keep them in `config.toml`; each run receives versioned JSON and convenience environment variables, with explicit argv, working directory, environment, and timeout controls. Failures appear under Problems without blocking the profile or workspace change.
+
+### Improvements
+- **Review profile and workspace duplication before applying it:** Profile and workspace context menus now support Rename, and both kinds of Duplicate use the same selectable preview as Copy from. Choose individual workspaces, apps, settings, and saved layouts. Profile duplicates start without a switch shortcut or auto-activation rule, while same-profile workspace duplicates start without shortcut identities that would immediately conflict.
+- **Keep automation changes transactional:** CLI mutations and reviewed duplication check the current configuration before saving. Layout copies are prepared before the duplicate is published and cleaned up if the configuration cannot be committed.
+- **Keep command documentation close to Tatami:** Open the bundled CLI guide from Settings or read the live reference rendered from `docs/CLI.md` on pangmo5.dev/Tatami. It covers selectors, JSON contracts, hook behavior, exit status, and scripting examples.
+- **Read shortcut conflicts at any width:** Shortcut recorders now show the same compact warning at every size and expose the complete conflicting action in a popover and to VoiceOver.
+
+### Fixes
+- **Workspace shortcuts respect profile boundaries:** The same workspace key or explicit shortcut can now be reused in different profiles without a false conflict. Global shortcuts remain checked against every profile.
+- **Copy and Duplicate cannot silently introduce shortcut conflicts:** Their previews identify conflicting choices and revalidate the current configuration before saving. A real conflict rejects the whole mutation instead of applying a partial copy.
+
 ## 1.11.5 (2026-08-22)
 
 ### Changed

--- a/Project.swift
+++ b/Project.swift
@@ -69,6 +69,7 @@ let project = Project(
       resources: [
         "Tatami/Resources/**",
         "CHANGELOG.md",
+        "docs/CLI.md",
         "LICENSE",
         "NOTICE.md",
         "THIRD_PARTY_NOTICES.md",
@@ -150,6 +151,7 @@ let project = Project(
         .external(name: "Magnet"),
         .external(name: "TOML"),
         .external(name: "Sparkle"),
+        .external(name: "Subprocess"),
         .external(name: "YYJSON"),
         .external(name: "OrderedCollections"),
         .external(name: "DequeModule"),
@@ -196,6 +198,7 @@ let project = Project(
       sources: ["TatamiTests/Sources/**"],
       dependencies: [
         .target(name: "TatamiKit"),
+        .target(name: "TatamiCLIProtocol"),
         .external(name: "ComposableArchitecture"),
       ]
     ),

--- a/Project.swift
+++ b/Project.swift
@@ -12,7 +12,7 @@ let developmentTeam = Environment.developmentTeam.getString(default: "")
 let sparklePublicEDKey = Environment.sparklePublicEdKey.getString(default: "")
 // Single source of truth for the marketing version. The release workflow
 // verifies the pushed tag matches this before building.
-let appVersion = "1.11.5"
+let appVersion = "1.12.0"
 // Build number is injected by CI (github.run_number); 1 for local builds.
 let buildNumber = Environment.buildNumber.getString(default: "1")
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ scripting required.
 <a href="Resources/Marketing/screenshots/guided-setup.png">Guided Setup</a> ·
 <a href="Resources/Marketing/screenshots/workspaces.png">Workspaces</a> ·
 <a href="Resources/Marketing/screenshots/borrow.png">Borrow</a><br />
-Captured on an earlier version. Some labels differ in 1.12.</sub></p>
+Captured on an earlier version. Some labels have changed since these screenshots.</sub></p>
 
 ## Demo
 
@@ -50,24 +50,6 @@ Captured on an earlier version. Some labels differ in 1.12.</sub></p>
 - **Cross-display control:** Jump focus between displays or move the focused app to another workspace.
 - **Shared apps:** Add apps that should join every workspace.
 
-### Profiles
-
-- **Independent profiles:** Group workspaces and switch the whole set at once. Each profile keeps its own workspaces, app assignments, and shortcuts.
-- **Fast profile switching:** Switch by hotkey or from the menu bar. Every display re-tiles for the new profile, and Tatami returns to the right profile after relaunch.
-- **Display-aware activation:** Auto-activate a profile by monitor count or by specific displays being connected or disconnected. Tatami warns when rules overlap at the same priority.
-- **Profile identity:** Give each profile an SF Symbol shown in the sidebar, menu bar, and profile-switch feedback.
-- **Profile-scoped workspace shortcuts:** Reuse a workspace key or explicit workspace shortcut in another profile. Global shortcuts still remain unique across every profile.
-- **Reviewable copying and duplication:** **Copy from** and **Duplicate** share one preview where you keep or skip each workspace, app, setting, and saved layout before anything changes.
-
-### Borrow: compose two workspaces
-
-- **Side-by-side composition:** Pull another workspace beside the current one, dock it to any screen edge, and tile both blocks independently. Windows cannot cross the boundary.
-- **Live and bidirectional:** The borrowed block is the real workspace, so edits persist back to it.
-- **Directional placement:** Press the borrow modifier with a workspace key, then use `h`, `j`, `k`, `l`, or an arrow. You can also set a default edge and size globally or per workspace.
-- **Cross-boundary focus and switching:** Directional focus and MFF move between blocks. Host and borrowed tiled windows share one app / window switching order until the borrowed workspace is returned. Activating a borrowed workspace switches to it fully, borrowing it again returns it by default, and `esc` cancels placement.
-- **Visible ownership:** Borrowed windows show the borrowed workspace's icon.
-- **Scratchpads:** Borrow-only workspaces stay out of regular switching, never activate alone, and auto-open their apps when summoned.
-
 ### Window tiling (BSP)
 
 - **Automatic BSP layout:** Insert new windows at the shallowest tile.
@@ -78,6 +60,23 @@ Captured on an earlier version. Some labels differ in 1.12.</sub></p>
 - **Drag editing:** Swap or re-insert a window with a live placement preview. Manual edge resizing synchronizes back into the tree.
 - **Persistent layouts:** Keep each workspace's tree and ratios across workspace switches, relaunches, and system sleep.
 - **Configurable spacing:** Set inner and outer gaps.
+
+### Profiles
+
+- **Independent profiles:** Group workspaces and switch the whole set at once. Each profile keeps its own workspaces, app assignments, and shortcuts.
+- **Fast profile switching:** Switch by hotkey or from the menu bar. Every display re-tiles for the new profile, and Tatami returns to the right profile after relaunch.
+- **Display-aware activation:** Auto-activate a profile by monitor count or by specific displays being connected or disconnected. Tatami warns when rules overlap at the same priority.
+- **Profile identity:** Give each profile an SF Symbol shown in the sidebar, menu bar, and profile-switch feedback.
+- **Reuse an existing setup:** **Copy from** and **Duplicate** share one preview where you keep or skip each workspace, app, setting, and saved layout before anything changes.
+
+### Borrow: compose two workspaces
+
+- **Side-by-side composition:** Pull another workspace beside the current one, dock it to any screen edge, and tile both blocks independently. Windows cannot cross the boundary.
+- **Live and bidirectional:** The borrowed block is the real workspace, so edits persist back to it.
+- **Directional placement:** Press the borrow modifier with a workspace key, then use `h`, `j`, `k`, `l`, or an arrow. You can also set a default edge and size globally or per workspace.
+- **Cross-boundary focus and switching:** Directional focus and MFF move between blocks. Host and borrowed tiled windows share one app / window switching order until the borrowed workspace is returned. Activating a borrowed workspace switches to it fully, borrowing it again returns it by default, and `esc` cancels placement.
+- **Visible ownership:** Borrowed windows show the borrowed workspace's icon.
+- **Scratchpads:** Borrow-only workspaces stay out of regular switching, never activate alone, and auto-open their apps when summoned.
 
 ### Always on Top
 
@@ -142,7 +141,22 @@ tuist install && tuist generate --no-open
 open Tatami.xcworkspace
 ```
 
-## Command line
+## Configuration and automation
+
+### Configuration
+
+Settings live in `~/.config/tatami/config.toml`, grouped into tables such as
+`[settings.layout]`, `[settings.focus]`, `[settings.gestures]`,
+`[settings.shortcuts]`, and so on. Workspaces, their app assignments, and
+shared apps are stored in the same file. Lifecycle hooks can be managed in
+**Settings → Hooks** or as `[[hooks]]` entries in the file. The GUI keeps the
+executable and each argv value separate rather than treating `command` as a
+shell string. Edits made in the app or by hand are picked up live.
+
+See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for the full reference:
+every key, its default, and the shortcut syntax.
+
+### Command line
 
 Tatami ships a `tatami` CLI inside the app bundle. Install it from
 **Settings → General → Command Line → Install**. This symlinks `tatami` into
@@ -163,19 +177,6 @@ be running.
 
 Read the [full CLI reference](docs/CLI.md), or view its live web rendering on
 [pangmo5.dev/Tatami](https://pangmo5.dev/Tatami/cli.html).
-
-## Configuration
-
-Settings live in `~/.config/tatami/config.toml`, grouped into tables such as
-`[settings.layout]`, `[settings.focus]`, `[settings.gestures]`,
-`[settings.shortcuts]`, and so on. Workspaces, their app assignments, and
-shared apps are stored in the same file. Lifecycle hooks can be managed in
-**Settings → Hooks** or as `[[hooks]]` entries in the file. The GUI keeps the
-executable and each argv value separate rather than treating `command` as a
-shell string. Edits made in the app or by hand are picked up live.
-
-See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for the full reference:
-every key, its default, and the shortcut syntax.
 
 ## Tech stack
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ scripting required.
 <p align="center"><sub>Full size:
 <a href="Resources/Marketing/screenshots/guided-setup.png">Guided Setup</a> ·
 <a href="Resources/Marketing/screenshots/workspaces.png">Workspaces</a> ·
-<a href="Resources/Marketing/screenshots/borrow.png">Borrow</a></sub></p>
+<a href="Resources/Marketing/screenshots/borrow.png">Borrow</a><br />
+Captured on an earlier version. Some labels differ in 1.12.</sub></p>
 
 ## Demo
 
@@ -55,6 +56,7 @@ scripting required.
 - **Fast profile switching:** Switch by hotkey or from the menu bar. Every display re-tiles for the new profile, and Tatami returns to the right profile after relaunch.
 - **Display-aware activation:** Auto-activate a profile by monitor count or by specific displays being connected or disconnected. Tatami warns when rules overlap at the same priority.
 - **Profile identity:** Give each profile an SF Symbol shown in the sidebar, menu bar, and profile-switch feedback.
+- **Profile-scoped workspace shortcuts:** Reuse a workspace key or explicit workspace shortcut in another profile. Global shortcuts still remain unique across every profile.
 - **Reviewable copying and duplication:** **Copy from** and **Duplicate** share one preview where you keep or skip each workspace, app, setting, and saved layout before anything changes.
 
 ### Borrow: compose two workspaces
@@ -154,11 +156,12 @@ tatami window focus left
 tatami layout balance
 ```
 
-The CLI covers profile/workspace management, hooks, stable JSON output, and the
-same focus, layout, app, tiling, cycling, and Borrow commands available to
-trackpad gestures, organized under domain subcommands. Tatami must be running.
+The CLI covers profile/workspace management, hook inspection, stable JSON
+output, and the same focus, layout, app, tiling, cycling, and Borrow commands
+available to trackpad gestures, organized under domain subcommands. Tatami must
+be running.
 
-Read the [full CLI reference](docs/CLI.md), or view the same document on
+Read the [full CLI reference](docs/CLI.md), or view its live web rendering on
 [pangmo5.dev/Tatami](https://pangmo5.dev/Tatami/cli.html).
 
 ## Configuration

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ scripting required.
 - **Fast profile switching:** Switch by hotkey or from the menu bar. Every display re-tiles for the new profile, and Tatami returns to the right profile after relaunch.
 - **Display-aware activation:** Auto-activate a profile by monitor count or by specific displays being connected or disconnected. Tatami warns when rules overlap at the same priority.
 - **Profile identity:** Give each profile an SF Symbol shown in the sidebar, menu bar, and profile-switch feedback.
-- **Reviewable copying:** Use **Copy from** to compare another profile or workspace, then keep or skip each app and settings change.
+- **Reviewable copying and duplication:** **Copy from** and **Duplicate** share one preview where you keep or skip each workspace, app, setting, and saved layout before anything changes.
 
 ### Borrow: compose two workspaces
 
@@ -99,7 +99,8 @@ scripting required.
 - **Native settings:** Configure Tatami in SwiftUI.
 - **skhd-style shortcuts:** For example, `ctrl + alt - h`.
 - **Plain TOML:** Edit `~/.config/tatami/config.toml` with XDG support and live reloads.
-- **Scriptable CLI:** Run commands such as `tatami activate <workspace>` and `tatami list-workspaces`.
+- **Native hook editor:** Add, edit, delete, enable, or disable lifecycle hooks in **Settings → Hooks**, including their executable, argv, environment, working directory, and timeout.
+- **Scriptable CLI:** Use domain commands such as `tatami workspace activate <workspace>` and `tatami workspace list`.
 - **Automatic updates:** Receive releases through Sparkle.
 
 ### Guided setup
@@ -146,22 +147,29 @@ Tatami ships a `tatami` CLI inside the app bundle. Install it from
 `/usr/local/bin` (you'll be asked for your password once). Then:
 
 ```sh
-tatami list-workspaces          # workspace names in the active profile
-tatami list-apps <workspace>    # bundle IDs assigned to a workspace
-tatami activate <workspace>     # activate a workspace
-tatami version                  # version of the running app
+tatami workspace list
+tatami workspace activate "Browser"
+tatami profile activate "Dual"
+tatami window focus left
+tatami layout balance
 ```
 
-The CLI talks to the running app over a local socket, so Tatami must be
-running. (Homebrew installs are detected automatically.)
+The CLI covers profile/workspace management, hooks, stable JSON output, and the
+same focus, layout, app, tiling, cycling, and Borrow commands available to
+trackpad gestures, organized under domain subcommands. Tatami must be running.
+
+Read the [full CLI reference](docs/CLI.md), or view the same document on
+[pangmo5.dev/Tatami](https://pangmo5.dev/Tatami/cli.html).
 
 ## Configuration
 
 Settings live in `~/.config/tatami/config.toml`, grouped into tables such as
 `[settings.layout]`, `[settings.focus]`, `[settings.gestures]`,
 `[settings.shortcuts]`, and so on. Workspaces, their app assignments, and
-shared apps are stored in the same file. Edits made in the app or by hand are
-picked up live.
+shared apps are stored in the same file. Lifecycle hooks can be managed in
+**Settings → Hooks** or as `[[hooks]]` entries in the file. The GUI keeps the
+executable and each argv value separate rather than treating `command` as a
+shell string. Edits made in the app or by hand are picked up live.
 
 See [docs/CONFIGURATION.md](docs/CONFIGURATION.md) for the full reference:
 every key, its default, and the shortcut syntax.
@@ -173,6 +181,7 @@ every key, its default, and the shortcut syntax.
 - **swift-sharing:** Cross-feature state sharing
 - **swift-collections:** Ordered sets, dictionaries, and deques on tiling hot paths
 - **swift-toml:** Config persistence
+- **swift-subprocess:** Cancellable, bounded hook execution
 - **swift-yyjson:** Fast JSON for the layout store and CLI protocol
 - **Magnet:** Carbon-based global hotkeys
 - **SFSafeSymbols:** Type-safe SF Symbol catalog

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1009,6 +1009,435 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 SOFTWARE.
 ~~~~
 
+## swift-subprocess 1.0.0
+
+Source: https://github.com/swiftlang/swift-subprocess
+
+Revision: `b3937ab85dd32f6e9435914599c1519074769c1a`
+
+~~~~text
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+~~~~
+
+## swift-system 1.8.1
+
+Source: https://github.com/apple/swift-system
+
+Revision: `869129b7bf4ecc57b97d0193ad29690ca2134750`
+
+~~~~text
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+    1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+    2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+    3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+    4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+    5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+    6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+    7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+    8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+    9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+    END OF TERMS AND CONDITIONS
+
+    APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+    Copyright [yyyy] [name of copyright owner]
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+
+
+## Runtime Library Exception to the Apache 2.0 License: ##
+
+
+    As an exception, if you use this Software to compile your source code and
+    portions of this Software are embedded into the binary product as a result,
+    you may redistribute such product without providing attribution as would
+    otherwise be required by Sections 4(a), 4(b) and 4(d) of the License.
+~~~~
 ## swift-syntax 601.0.1
 
 Source: https://github.com/swiftlang/swift-syntax.git

--- a/Tatami/Resources/Localizable.xcstrings
+++ b/Tatami/Resources/Localizable.xcstrings
@@ -5381,6 +5381,40 @@
         }
       }
     },
+    "Advanced": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고급"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "詳細設定"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "高级"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "進階"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Advanced"
+          }
+        }
+      }
+    },
     "Accessibility": {
       "localizations": {
         "ko": {
@@ -19015,36 +19049,36 @@
         }
       }
     },
-    "Keep SIP enabled, avoid shell scripts, and retain a readable TOML configuration.": {
+    "Keep SIP enabled, use native controls, and retain a readable TOML configuration.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "SIP은 켜둔 채로 셸 스크립트 없이, 읽기 쉬운 TOML 설정을 유지해요."
+            "value": "SIP을 켜둔 채로 네이티브 제어 기능을 사용하고, 읽기 쉬운 TOML 설정을 유지해요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "SIPを有効に保ち、シェルスクリプトを使わず、読みやすいTOML設定を維持します。"
+            "value": "SIPを有効に保ち、ネイティブの操作を使い、読みやすいTOML設定を維持します。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "保持 SIP 启用，不依赖 shell 脚本，并保留易读的 TOML 配置。"
+            "value": "保持 SIP 启用，使用原生控制，并保留易读的 TOML 配置。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "保持 SIP 啟用，不依賴 shell script，並保留易讀的 TOML 設定。"
+            "value": "保持 SIP 啟用，使用原生控制，並保留易讀的 TOML 設定。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keep SIP enabled, avoid shell scripts, and retain a readable TOML configuration."
+            "value": "Keep SIP enabled, use native controls, and retain a readable TOML configuration."
           }
         }
       }
@@ -21429,36 +21463,37 @@
         }
       }
     },
-    "New": {
+    "Highlights": {
+      "comment": "Section title for the feature highlights in What's New.",
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "새로 만들기"
+            "value": "주요 변경 사항"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "新規"
+            "value": "主な変更点"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "新建"
+            "value": "主要更新"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "新增"
+            "value": "主要更新"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "New"
+            "value": "Highlights"
           }
         }
       }

--- a/Tatami/Resources/Localizable.xcstrings
+++ b/Tatami/Resources/Localizable.xcstrings
@@ -1,6 +1,3137 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "Enter an identifier.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "식별자를 입력해 주세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "識別子を入力してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请输入标识符。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請輸入識別碼。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter an identifier."
+          }
+        }
+      }
+    },
+    "Use only ASCII letters, numbers, period, underscore, or hyphen in the identifier.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "식별자에는 ASCII 영문자, 숫자, 마침표, 밑줄 또는 하이픈만 사용할 수 있어요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "識別子にはASCII英字、数字、ピリオド、アンダースコア、ハイフンのみを使用してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标识符只能使用 ASCII 字母、数字、句点、下划线或连字符。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "識別碼只能使用 ASCII 英文字母、數字、句點、底線或連字號。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Use only ASCII letters, numbers, period, underscore, or hyphen in the identifier."
+          }
+        }
+      }
+    },
+    "Choose a unique identifier.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "고유한 식별자를 입력해 주세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "一意の識別子を指定してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择唯一的标识符。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請選擇唯一的識別碼。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a unique identifier."
+          }
+        }
+      }
+    },
+    "Choose an executable.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 파일을 선택해 주세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行ファイルを選択してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择可执行文件。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請選擇執行檔。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose an executable."
+          }
+        }
+      }
+    },
+    "Executable and arguments cannot contain NUL.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 파일과 인자에는 NUL을 포함할 수 없어요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行ファイルと引数にNULを含めることはできません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可执行文件和参数不能包含 NUL。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行檔與引數不能包含 NUL。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executable and arguments cannot contain NUL."
+          }
+        }
+      }
+    },
+    "Timeout must be between 100 and 300000 milliseconds.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시간 제한은 100밀리초에서 300000밀리초 사이여야 해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムアウトは100ミリ秒から300000ミリ秒の範囲で指定してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超时时间必须介于 100 到 300000 毫秒之间。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "逾時時間必須介於 100 到 300000 毫秒之間。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout must be between 100 and 300000 milliseconds."
+          }
+        }
+      }
+    },
+    "Working directory must be absolute or start with ~/.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 디렉터리는 절대 경로이거나 ~/로 시작해야 해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作業ディレクトリは絶対パスまたは ~/ で始まる必要があります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作目录必须是绝对路径或以 ~/ 开头。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作目錄必須是絕對路徑或以 ~/ 開頭。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Working directory must be absolute or start with ~/."
+          }
+        }
+      }
+    },
+    "Environment variable names must be valid and values cannot contain NUL.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환경 변수 이름은 유효해야 하며 값에는 NUL을 포함할 수 없어요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数名は有効な形式である必要があり、値にNULを含めることはできません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量名称必须有效，并且值不能包含 NUL。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境變數名稱必須有效，而且值不能包含 NUL。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment variable names must be valid and values cannot contain NUL."
+          }
+        }
+      }
+    },
+    "Run a program when Tatami launches, changes profile, or activates a workspace.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami가 실행되거나 프로필을 변경하거나 작업 공간을 활성화할 때 프로그램을 실행해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatamiの起動時、プロファイルの変更時、またはワークスペースの有効化時にプログラムを実行します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Tatami 启动、更改配置方案或启用工作区时运行程序。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Tatami 啟動、變更設定組合或啟用工作空間時執行程式。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run a program when Tatami launches, changes profile, or activates a workspace."
+          }
+        }
+      }
+    },
+    "Commands run directly with the arguments and environment shown below. A shell is never added automatically.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "명령은 아래의 인자와 환경을 사용해 직접 실행돼요. 셸은 자동으로 추가되지 않아요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コマンドは以下の引数と環境を使って直接実行されます。シェルが自動で追加されることはありません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "命令会使用下方显示的参数和环境直接运行。Tatami 不会自动添加 shell。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "指令會使用下方顯示的引數與環境直接執行。Tatami 不會自動加入 shell。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Commands run directly with the arguments and environment shown below. A shell is never added automatically."
+          }
+        }
+      }
+    },
+    "Add Hook": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅 추가"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックを追加"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Hook"
+          }
+        }
+      }
+    },
+    "Event Hooks": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이벤트 훅"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベントフック"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event Hooks"
+          }
+        }
+      }
+    },
+    "No Hooks": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅이 없어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックはありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No Hooks"
+          }
+        }
+      }
+    },
+    "Add a hook to automate work outside Tatami.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅을 추가해 Tatami 밖의 작업을 자동화해 보세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックを追加して、Tatamiの外部で行う処理を自動化できます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加钩子以自动执行 Tatami 之外的工作。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入 Hook 以自動執行 Tatami 之外的工作。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add a hook to automate work outside Tatami."
+          }
+        }
+      }
+    },
+    "Configured Hooks": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정한 훅"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定済みのフック"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已配置的钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已設定的 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configured Hooks"
+          }
+        }
+      }
+    },
+    "Hooks receive a JSON event on standard input. Disabled or invalid hooks do not run.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅은 표준 입력으로 JSON 이벤트를 받아요. 비활성화했거나 잘못된 훅은 실행되지 않아요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックは標準入力でJSONイベントを受け取ります。無効または設定に問題があるフックは実行されません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子通过标准输入接收 JSON 事件。已停用或无效的钩子不会运行。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 會透過標準輸入接收 JSON 事件。已停用或無效的 Hook 不會執行。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hooks receive a JSON event on standard input. Disabled or invalid hooks do not run."
+          }
+        }
+      }
+    },
+    "Unnamed Hook": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이름 없는 훅"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "名前のないフック"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未命名钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未命名 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Unnamed Hook"
+          }
+        }
+      }
+    },
+    "· %lld arguments": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· 인자 %lld개"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· 引数%lld個"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· %lld 个参数"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· %lld 個引數"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "· %lld arguments"
+          }
+        }
+      }
+    },
+    "Needs attention": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인이 필요해요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "確認が必要です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要检查"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "需要檢查"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Needs attention"
+          }
+        }
+      }
+    },
+    "Enabled": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "활성화"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "有効"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已启用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已啟用"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enabled"
+          }
+        }
+      }
+    },
+    "Disable this hook": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 훅 비활성화"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフックを無効にする"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用此钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "停用這個 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Disable this hook"
+          }
+        }
+      }
+    },
+    "Enable this hook": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 훅 활성화"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフックを有効にする"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "启用此钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "啟用這個 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enable this hook"
+          }
+        }
+      }
+    },
+    "Edit": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit"
+          }
+        }
+      }
+    },
+    "More actions for %@": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 추가 동작"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@のその他の操作"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的更多操作"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ 的更多操作"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "More actions for %@"
+          }
+        }
+      }
+    },
+    "Executable not set": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 파일이 지정되지 않음"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行ファイルが未設定です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未设置可执行文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "尚未設定執行檔"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executable not set"
+          }
+        }
+      }
+    },
+    "Save Error": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장 오류"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存エラー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存错误"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存錯誤"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save Error"
+          }
+        }
+      }
+    },
+    "Save": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "儲存"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Save"
+          }
+        }
+      }
+    },
+    "Hook": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フック"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook"
+          }
+        }
+      }
+    },
+    "Identifier": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "식별자"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "識別子"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标识符"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "識別碼"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Identifier"
+          }
+        }
+      }
+    },
+    "Hook identifier": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅 식별자"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックの識別子"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子标识符"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 識別碼"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook identifier"
+          }
+        }
+      }
+    },
+    "Event": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이벤트"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "イベント"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "事件"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Event"
+          }
+        }
+      }
+    },
+    "Choose a unique name for this hook, such as notify-team. Tatami also sends it as TATAMI_HOOK_ID.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 훅에 notify-team 같은 고유한 이름을 지정하세요. Tatami는 이 이름을 TATAMI_HOOK_ID로도 전달해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフックにnotify-teamのような一意の名前を付けてください。Tatamiはその名前をTATAMI_HOOK_IDとしても渡します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请为此钩子指定一个唯一名称，例如 notify-team。Tatami 也会通过 TATAMI_HOOK_ID 传递此名称。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請為這個 Hook 指定唯一名稱，例如 notify-team。Tatami 也會透過 TATAMI_HOOK_ID 傳遞這個名稱。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a unique name for this hook, such as notify-team. Tatami also sends it as TATAMI_HOOK_ID."
+          }
+        }
+      }
+    },
+    "Executable": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행 파일"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行ファイル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "可执行文件"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行檔"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Executable"
+          }
+        }
+      }
+    },
+    "Choose...": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "선택..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選択..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose..."
+          }
+        }
+      }
+    },
+    "Argument": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인자"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "参数"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引數"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Argument"
+          }
+        }
+      }
+    },
+    "Remove argument": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인자 제거"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数を削除"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除参数"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除引數"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove argument"
+          }
+        }
+      }
+    },
+    "Add Argument": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "인자 추가"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "引数を追加"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加参数"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入引數"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Argument"
+          }
+        }
+      }
+    },
+    "Program": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로그램"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プログラム"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "程序"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "程式"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Program"
+          }
+        }
+      }
+    },
+    "Each argument is passed exactly as one argv value. To use shell syntax, choose a shell executable and add its flags explicitly. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "각 인자는 정확히 하나의 argv 값으로 전달돼요. 셸 문법을 사용하려면 셸 실행 파일을 선택하고 플래그를 직접 추가하세요. macOS 앱을 열려면 실행 파일로 `/usr/bin/open`을 사용하고 `-a`와 앱 이름을 각각 별도 인자로 추가하세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "各引数は正確に1つのargv値として渡されます。シェル構文を使う場合はシェルの実行ファイルを選び、フラグを明示的に追加してください。macOSアプリを開くには、実行ファイルに`/usr/bin/open`を指定し、`-a`とアプリ名を別々の引数として追加してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每个参数都会原样作为一个 argv 值传递。如需使用 shell 语法，请选择 shell 可执行文件并明确添加其选项。如需打开 macOS App，请将 `/usr/bin/open` 设为可执行文件，并把 `-a` 和 App 名称分别添加为参数。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "每個引數都會原樣作為一個 argv 值傳入。如需使用 shell 語法，請選擇 shell 執行檔並明確加入其選項。如需開啟 macOS App，請將 `/usr/bin/open` 設為執行檔，並把 `-a` 與 App 名稱分別加入為引數。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Each argument is passed exactly as one argv value. To use shell syntax, choose a shell executable and add its flags explicitly. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments."
+          }
+        }
+      }
+    },
+    "Execution": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "실행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "実行"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "执行"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Execution"
+          }
+        }
+      }
+    },
+    "Working Directory": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 디렉터리"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作業ディレクトリ"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作目录"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作目錄"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Working Directory"
+          }
+        }
+      }
+    },
+    "Tatami configuration directory (default)": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 구성 디렉터리(기본값)"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatamiの設定ディレクトリ（デフォルト）"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 配置目录（默认）"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 設定目錄（預設）"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami configuration directory (default)"
+          }
+        }
+      }
+    },
+    "Timeout": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "시간 제한"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "タイムアウト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "超时"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "逾時"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Timeout"
+          }
+        }
+      }
+    },
+    "ms": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ms"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ms"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "毫秒"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "毫秒"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ms"
+          }
+        }
+      }
+    },
+    "Value": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "값"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "値"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "值"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "值"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Value"
+          }
+        }
+      }
+    },
+    "Remove environment variable": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환경 변수 제거"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数を削除"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除环境变量"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "移除環境變數"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Remove environment variable"
+          }
+        }
+      }
+    },
+    "Add Environment Variable": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환경 변수 추가"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数を追加"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "添加环境变量"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "加入環境變數"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Add Environment Variable"
+          }
+        }
+      }
+    },
+    "Environment": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환경"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment"
+          }
+        }
+      }
+    },
+    "These values are added to Tatami's inherited environment for this hook.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 값들은 이 훅을 위해 Tatami가 상속한 환경에 추가돼요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "これらの値は、このフック用にTatamiが継承した環境へ追加されます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "这些值会添加到 Tatami 为此钩子继承的环境中。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這些值會加入 Tatami 為這個 Hook 繼承的環境。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "These values are added to Tatami's inherited environment for this hook."
+          }
+        }
+      }
+    },
+    "No normal workspaces": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "일반 작업 공간이 없어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "通常のワークスペースはありません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "没有普通工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "沒有一般工作空間"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "No normal workspaces"
+          }
+        }
+      }
+    },
+    "Running test...": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 실행 중..."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストを実行中..."
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在运行测试..."
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在執行測試..."
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Running test..."
+          }
+        }
+      }
+    },
+    "Cancel Test": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 취소"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストをキャンセル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消测试"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "取消測試"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Cancel Test"
+          }
+        }
+      }
+    },
+    "Run Test": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 실행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストを実行"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行测试"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行測試"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Run Test"
+          }
+        }
+      }
+    },
+    "Test": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テスト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "測試"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test"
+          }
+        }
+      }
+    },
+    "Runs the current draft once with a sample event. Testing does not save the hook.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "현재 초안을 샘플 이벤트로 한 번 실행해요. 테스트해도 훅은 저장되지 않아요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "現在の下書きをサンプルイベントで1回実行します。テストしてもフックは保存されません。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用示例事件运行一次当前草稿。测试不会保存钩子。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用範例事件執行一次目前的草稿。測試不會儲存 Hook。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Runs the current draft once with a sample event. Testing does not save the hook."
+          }
+        }
+      }
+    },
+    "Test succeeded": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 성공"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストに成功しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试成功"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "測試成功"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test succeeded"
+          }
+        }
+      }
+    },
+    "Test cancelled": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트가 취소됐어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストをキャンセルしました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "测试已取消"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "測試已取消"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Test cancelled"
+          }
+        }
+      }
+    },
+    "Standard Output": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표준 출력"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準出力"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标准输出"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準輸出"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard Output"
+          }
+        }
+      }
+    },
+    "Standard Error": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "표준 오류"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準エラー"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "标准错误"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "標準錯誤"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Standard Error"
+          }
+        }
+      }
+    },
+    "Check These Fields": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "다음 필드를 확인해 주세요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "次の項目を確認してください"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请检查以下字段"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請檢查下列欄位"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Check These Fields"
+          }
+        }
+      }
+    },
+    "Profile Changed": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로필 변경"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイル変更"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置方案已更改"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定組合已變更"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile Changed"
+          }
+        }
+      }
+    },
+    "Workspace Activated": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 활성화"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペース有効化"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作区已启用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作空間已啟用"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Workspace Activated"
+          }
+        }
+      }
+    },
+    "Edit Hook": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅 편집"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックを編集"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Edit Hook"
+          }
+        }
+      }
+    },
+    "The hook changed while it was being edited": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "편집하는 동안 훅이 변경됐어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編集中にフックが変更されました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "编辑期间钩子已更改"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "編輯期間 Hook 已變更"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The hook changed while it was being edited"
+          }
+        }
+      }
+    },
+    "Environment variable names must be unique": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "환경 변수 이름은 서로 달라야 해요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境変数名は重複できません"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "环境变量名称必须唯一"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "環境變數名稱必須是唯一的"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Environment variable names must be unique"
+          }
+        }
+      }
+    },
+    "A profile is required to run this hook": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 훅을 실행하려면 프로필이 필요해요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このフックを実行するにはプロファイルが必要です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "运行此钩子需要配置方案"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "執行這個 Hook 需要設定組合"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A profile is required to run this hook"
+          }
+        }
+      }
+    },
+    "Choose a workspace for the test event": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "테스트 이벤트에 사용할 작업 공간을 선택해 주세요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "テストイベントに使うワークスペースを選択してください"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "请选择用于测试事件的工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "請選擇測試事件要使用的工作空間"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose a workspace for the test event"
+          }
+        }
+      }
+    },
+    "Delete hook \"%@\"?": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" 훅을 삭제할까요?"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フック「%@」を削除しますか？"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要删除钩子“%@”吗？"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要刪除 Hook「%@」嗎？"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Delete hook \"%@\"?"
+          }
+        }
+      }
+    },
+    "The hook will no longer run for future events.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 훅은 이후 이벤트에서 더 이상 실행되지 않아요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "今後のイベントでは、このフックは実行されなくなります。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此钩子将不再为后续事件运行。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "這個 Hook 將不再於後續事件執行。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The hook will no longer run for future events."
+          }
+        }
+      }
+    },
+    "OK": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "확인"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "好"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "OK"
+          }
+        }
+      }
+    },
+    "The hook was not changed. Review the latest configuration and try again.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅을 변경하지 않았어요. 최신 구성을 확인한 뒤 다시 시도하세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックは変更されませんでした。最新の設定を確認してから、もう一度お試しください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子未更改。请检查最新配置后重试。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 未變更。請檢查最新設定後再試一次。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The hook was not changed. Review the latest configuration and try again."
+          }
+        }
+      }
+    },
+    "Hook could not be saved": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅을 저장할 수 없어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックを保存できませんでした"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "无法保存钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "無法儲存 Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook could not be saved"
+          }
+        }
+      }
+    },
+    "Tatami Launched": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 실행"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami起動"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 已启动"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 已啟動"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami Launched"
+          }
+        }
+      }
+    },
+    "Working Directory is the hook process's current directory. Relative paths used by the program are resolved from it. Leave it empty to use Tatami's configuration directory. Timeout stops the process after the specified number of milliseconds.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 디렉터리는 훅 프로세스의 현재 디렉터리예요. 프로그램에서 사용하는 상대 경로는 이 디렉터리를 기준으로 해석돼요. 비워 두면 Tatami 구성 디렉터리를 사용해요. 시간 제한에 지정한 밀리초가 지나면 프로세스를 중단해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "作業ディレクトリはフックプロセスの現在のディレクトリです。プログラムが使う相対パスはこのディレクトリを基準に解決されます。空欄にするとTatamiの設定ディレクトリを使います。タイムアウトに指定したミリ秒が経過するとプロセスを停止します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作目录是钩子进程的当前目录。程序使用的相对路径会以此目录为基准解析。留空时使用 Tatami 配置目录。达到超时设置的毫秒数后，进程会停止。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "工作目錄是 Hook 程序的目前目錄。程式使用的相對路徑會以此目錄為基準解析。留白時使用 Tatami 設定目錄。達到逾時設定的毫秒數後，程序會停止。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Working Directory is the hook process's current directory. Relative paths used by the program are resolved from it. Leave it empty to use Tatami's configuration directory. Timeout stops the process after the specified number of milliseconds."
+          }
+        }
+      }
+    },
+    "Show error details": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "오류 세부 정보 보기"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "エラーの詳細を表示"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "显示错误详情"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "顯示錯誤詳細資訊"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Show error details"
+          }
+        }
+      }
+    },
+    "JSON Standard Input": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON 표준 입력"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON標準入力"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON 标准输入"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON 標準輸入"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "JSON Standard Input"
+          }
+        }
+      }
+    },
+    "Tatami Environment Variables": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 환경 변수"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatamiの環境変数"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 环境变量"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami 環境變數"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami Environment Variables"
+          }
+        }
+      }
+    },
+    "A question mark means the value is included only when available.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "물음표는 값을 사용할 수 있을 때만 포함된다는 뜻이에요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "疑問符は、値が利用できる場合にのみ含まれることを示します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "问号表示仅在值可用时才会包含该值。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "問號表示只有在值可用時才會包含該值。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "A question mark means the value is included only when available."
+          }
+        }
+      }
+    },
+    "Provides the new profile and, when available, the previous profile.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "새 프로필과, 사용할 수 있는 경우 이전 프로필을 제공해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "新しいプロファイルと、利用できる場合は以前のプロファイルを提供します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供新的配置方案，并在可用时提供之前的配置方案。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供新的設定組合，並在可用時提供先前的設定組合。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provides the new profile and, when available, the previous profile."
+          }
+        }
+      }
+    },
+    "Provides the current profile when Tatami finishes launching.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatami가 실행을 마치면 현재 프로필을 제공해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Tatamiの起動が完了したときに現在のプロファイルを提供します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Tatami 完成启动时提供当前配置方案。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "在 Tatami 完成啟動時提供目前的設定組合。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provides the current profile when Tatami finishes launching."
+          }
+        }
+      }
+    },
+    "Provides the profile, workspace, and, when available, the display.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로필과 작업 공간을 제공하고, 사용할 수 있는 경우 디스플레이도 제공해요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイルとワークスペースに加え、利用できる場合はディスプレイも提供します。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供配置方案和工作区，并在可用时提供显示器。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "提供設定組合與工作空間，並在可用時提供顯示器。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Provides the profile, workspace, and, when available, the display."
+          }
+        }
+      }
+    },
+    "Enter the path to a program, an executable script, or a command-line shell such as `/bin/zsh` or `/opt/homebrew/bin/fish`. Shell locations vary, so use the full path returned by `which fish`. For a script without execute permission, choose its command-line shell and add the script path as the first argument.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로그램, 실행 가능한 스크립트, 또는 `/bin/zsh`나 `/opt/homebrew/bin/fish` 같은 명령줄 셸의 경로를 입력하세요. 셸 위치는 환경마다 다르므로 `which fish`가 반환한 전체 경로를 사용하세요. 실행 권한이 없는 스크립트는 사용할 명령줄 셸을 지정하고 스크립트 경로를 첫 번째 인자로 추가하세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プログラム、実行可能なスクリプト、または `/bin/zsh` や `/opt/homebrew/bin/fish` のようなコマンドラインシェルのパスを入力してください。シェルの場所は環境によって異なるため、`which fish` が返すフルパスを使用してください。実行権限のないスクリプトでは、使用するコマンドラインシェルを指定し、スクリプトのパスを最初の引数として追加してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "输入程序、可执行脚本，或 `/bin/zsh`、`/opt/homebrew/bin/fish` 等命令行 Shell 的路径。Shell 的位置因环境而异，请使用 `which fish` 返回的完整路径。对于没有执行权限的脚本，请指定要使用的命令行 Shell，并将脚本路径作为第一个参数。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "輸入程式、可執行腳本，或 `/bin/zsh`、`/opt/homebrew/bin/fish` 等命令列 Shell 的路徑。Shell 的位置因環境而異，請使用 `which fish` 回傳的完整路徑。對於沒有執行權限的腳本，請指定要使用的命令列 Shell，並將腳本路徑作為第一個引數。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Enter the path to a program, an executable script, or a command-line shell such as `/bin/zsh` or `/opt/homebrew/bin/fish`. Shell locations vary, so use the full path returned by `which fish`. For a script without execute permission, choose its command-line shell and add the script path as the first argument."
+          }
+        }
+      }
+    },
+    "Configuration changed": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "구성이 변경됨"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "構成が変更されました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置已更改"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定已變更"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration changed"
+          }
+        }
+      }
+    },
+    "Copy failed": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복사 실패"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "コピーに失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制失败"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製失敗"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy failed"
+          }
+        }
+      }
+    },
+    "Conflicts with %@": {
+      "comment": "Copy preview warning. The variable lists shortcuts and the actions that already use them.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@와 충돌"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%@ と競合します"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "与 %@ 冲突"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "與 %@ 衝突"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Conflicts with %@"
+          }
+        }
+      }
+    },
+    "Deselect the conflicting shortcut changes before applying.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "적용하기 전에 충돌하는 단축키 변경을 선택 해제하세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "適用する前に、競合するショートカットの変更を選択解除してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "应用前，请取消选择冲突的快捷键更改。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "套用前，請取消選取衝突的快速鍵變更。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deselect the conflicting shortcut changes before applying."
+          }
+        }
+      }
+    },
+    "Deselect the highlighted shortcut changes to continue.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "계속하려면 강조된 단축키 변경을 선택 해제하세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "続行するには、強調表示されたショートカットの変更を選択解除してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要继续，请取消选择突出显示的快捷键更改。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "若要繼續，請取消選取醒目提示的快速鍵變更。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deselect the highlighted shortcut changes to continue."
+          }
+        }
+      }
+    },
+    "Deselect this change to resolve the shortcut conflict.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키 충돌을 해결하려면 이 변경을 선택 해제하세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットの競合を解決するには、この変更を選択解除してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "要解决快捷键冲突，请取消选择此更改。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "若要解決快速鍵衝突，請取消選取此變更。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Deselect this change to resolve the shortcut conflict."
+          }
+        }
+      }
+    },
+    "Nothing was copied. Deselect the conflicting shortcut changes and try again: %@": {
+      "comment": "Atomic Copy failure. The variable lists conflicting shortcuts and their current owners.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아무것도 복사하지 않았습니다. 충돌하는 단축키 변경을 선택 해제한 후 다시 시도하세요: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "何もコピーされませんでした。競合するショートカットの変更を選択解除して、もう一度お試しください：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未复制任何内容。请取消选择冲突的快捷键更改，然后重试：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未複製任何內容。請取消選取衝突的快速鍵變更，然後再試一次：%@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing was copied. Deselect the conflicting shortcut changes and try again: %@"
+          }
+        }
+      }
+    },
+    "Nothing was copied because the configuration changed while the review was open. Reopen Copy and review the latest changes.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "검토를 연 동안 구성이 변경되어 아무것도 복사하지 않았습니다. 복사를 다시 열고 최신 변경 사항을 검토하세요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "レビューを開いている間に構成が変更されたため、何もコピーされませんでした。コピーを開き直して、最新の変更内容を確認してください。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "审核期间配置已更改，因此未复制任何内容。请重新打开“复制”并审核最新更改。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢視期間設定已變更，因此未複製任何內容。請重新開啟「複製」並檢視最新變更。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing was copied because the configuration changed while the review was open. Reopen Copy and review the latest changes."
+          }
+        }
+      }
+    },
+    "Nothing was duplicated. Deselect the conflicting shortcut changes and try again: %@": {
+      "comment": "Atomic Duplicate failure. The variable lists conflicting shortcuts and their current owners.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "아무것도 복제하지 않았습니다. 충돌하는 단축키 변경을 선택 해제한 후 다시 시도하세요: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "何も複製されませんでした。競合するショートカットの変更を選択解除して、もう一度お試しください：%@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未复制任何内容。请取消选择冲突的快捷键更改，然后重试：%@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未複製任何內容。請取消選取衝突的快速鍵變更，然後再試一次：%@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Nothing was duplicated. Deselect the conflicting shortcut changes and try again: %@"
+          }
+        }
+      }
+    },
+    "Shortcut conflicts": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "단축키 충돌"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ショートカットの競合"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快捷键冲突"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "快速鍵衝突"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Shortcut conflicts"
+          }
+        }
+      }
+    },
     "": {
       "localizations": {
         "ko": {
@@ -4455,7 +7586,7 @@
         }
       }
     },
-    "Auto-activation overlaps another profile at the same priority — order decides which one activates.": {
+    "Auto-activation overlaps another profile at the same priority. Order decides which one activates.": {
       "localizations": {
         "ko": {
           "stringUnit": {
@@ -4484,7 +7615,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Auto-activation overlaps another profile at the same priority — order decides which one activates."
+            "value": "Auto-activation overlaps another profile at the same priority. Order decides which one activates."
           }
         }
       }
@@ -7379,6 +10510,40 @@
         }
       }
     },
+    "CLI Guide": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 사용법"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLIガイド"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 指南"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 指南"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI Guide"
+          }
+        }
+      }
+    },
     "Clear key": {
       "localizations": {
         "ko": {
@@ -7821,7 +10986,7 @@
         }
       }
     },
-    "config.toml could not be parsed — keeping previous settings": {
+    "config.toml could not be parsed. Keeping previous settings": {
       "localizations": {
         "ko": {
           "stringUnit": {
@@ -14991,6 +18156,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "Inner gap: %lld px"
+          }
+        }
+      }
+    },
+    "In use": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "사용 중"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "使用中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已占用"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已佔用"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "In use"
           }
         }
       }
@@ -26657,36 +29856,36 @@
         }
       }
     },
-    "Symlinks `tatami` into /usr/local/bin so you can script Tatami from the terminal — e.g. `tatami activate <workspace>`, `tatami list-workspaces`.": {
+    "Symlinks `tatami` into /usr/local/bin for terminal scripting. For example: `tatami workspace list`, `tatami workspace activate <workspace>`.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "터미널에서 Tatami를 스크립트로 제어할 수 있도록 `tatami`를 /usr/local/bin에 심볼릭 링크해요. 예: `tatami activate <workspace>`, `tatami list-workspaces`."
+            "value": "터미널에서 Tatami를 스크립트로 제어할 수 있도록 `tatami`를 /usr/local/bin에 심볼릭 링크해요. 예: `tatami workspace list`, `tatami workspace activate <workspace>`."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ターミナルからTatamiをスクリプト操作できるよう、`tatami`を/usr/local/binへシンボリックリンクします。例：`tatami activate <workspace>`、`tatami list-workspaces`。"
+            "value": "ターミナルからTatamiをスクリプト操作できるよう、`tatami`を/usr/local/binへシンボリックリンクします。例：`tatami workspace list`、`tatami workspace activate <workspace>`。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "将 `tatami` 符号链接到 /usr/local/bin，便于从终端编写脚本控制 Tatami，例如 `tatami activate <workspace>`、`tatami list-workspaces`。"
+            "value": "将 `tatami` 符号链接到 /usr/local/bin，便于从终端编写脚本控制 Tatami，例如 `tatami workspace list`、`tatami workspace activate <workspace>`。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "將 `tatami` 符號連結至 /usr/local/bin，方便從終端機撰寫 script 控制 Tatami，例如 `tatami activate <workspace>`、`tatami list-workspaces`。"
+            "value": "將 `tatami` 符號連結至 /usr/local/bin，方便從終端機撰寫 script 控制 Tatami，例如 `tatami workspace list`、`tatami workspace activate <workspace>`。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Symlinks `tatami` into /usr/local/bin so you can script Tatami from the terminal — e.g. `tatami activate <workspace>`, `tatami list-workspaces`."
+            "value": "Symlinks `tatami` into /usr/local/bin for terminal scripting. For example: `tatami workspace list`, `tatami workspace activate <workspace>`."
           }
         }
       }
@@ -28251,6 +31450,41 @@
           "stringUnit": {
             "state": "translated",
             "value": "This removes the workspace and its app assignments, shortcuts, and layout. This can't be undone."
+          }
+        }
+      }
+    },
+    "This shortcut is already used by %@.": {
+      "comment": "Shortcut recorder conflict. The variable is the action already using the shortcut.",
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "이 단축키는 이미 %@에서 사용 중이에요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "このショートカットはすでに%@で使用されています。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此快捷键已被%@使用。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "此快捷鍵已被%@使用。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "This shortcut is already used by %@."
           }
         }
       }
@@ -30563,6 +33797,40 @@
           "stringUnit": {
             "state": "translated",
             "value": "View Changelog…"
+          }
+        }
+      }
+    },
+    "View CLI Guide…": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLI 사용법 보기…"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "CLIガイドを表示…"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "查看 CLI 指南…"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "檢視 CLI 指南…"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "View CLI Guide…"
           }
         }
       }
@@ -33181,6 +36449,482 @@
           "stringUnit": {
             "state": "translated",
             "value": "Third-Party Notices"
+          }
+        }
+      }
+    },
+    "Choose the apps, settings, and saved layout to include. Workspace keys and explicit shortcuts are always left blank to avoid conflicts.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "포함할 앱, 설정, 저장된 레이아웃을 선택하세요. 충돌을 막기 위해 작업 공간 키와 명시적 단축키는 항상 비워 둡니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "含めるアプリ、設定、保存済みレイアウトを選択してください。競合を避けるため、ワークスペースキーと明示的なショートカットは常に空のままにします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择要包含的 App、设置和已存布局。为避免冲突，工作区按键和显式快捷键始终留空。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇要包含的 App、設定和已儲存佈局。為避免衝突，工作空間按鍵和明確快速鍵一律留空。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose the apps, settings, and saved layout to include. Workspace keys and explicit shortcuts are always left blank to avoid conflicts."
+          }
+        }
+      }
+    },
+    "Choose which workspaces and content to include. The profile switch shortcut and auto-activation are left off; workspace shortcuts can be copied because the new profile is independently scoped.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "포함할 작업 공간과 콘텐츠를 선택하세요. 프로필 전환 단축키와 자동 활성화는 비워 두지만, 새 프로필은 범위가 독립적이므로 작업 공간 단축키는 복사할 수 있습니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "含めるワークスペースと内容を選択してください。プロファイル切り替えショートカットと自動アクティベーションは空のままにしますが、新しいプロファイルは独立したスコープなのでワークスペースのショートカットはコピーできます。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "选择要包含的工作区和内容。配置方案切换快捷键和自动激活将留空；由于新配置方案作用域独立，可以复制工作区快捷键。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "選擇要包含的工作空間和內容。設定組合切換快速鍵和自動啟用會留空；由於新設定組合作用範圍獨立，可以複製工作空間快速鍵。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Choose which workspaces and content to include. The profile switch shortcut and auto-activation are left off; workspace shortcuts can be copied because the new profile is independently scoped."
+          }
+        }
+      }
+    },
+    "Copy its apps, settings, and saved layout.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "앱과 설정, 저장된 레이아웃을 복사합니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "アプリ、設定、保存済みレイアウトをコピーします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制其 App、设置和已存布局。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製其 App、設定和已儲存佈局。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy its apps, settings, and saved layout."
+          }
+        }
+      }
+    },
+    "Copy its settings and saved layout.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "설정과 저장된 레이아웃을 복사합니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定と保存済みレイアウトをコピーします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制其设置和已存布局。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製其設定和已儲存佈局。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy its settings and saved layout."
+          }
+        }
+      }
+    },
+    "Copy the profile's appearance.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로필 모양을 복사합니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイルの外観をコピーします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制配置方案外观。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製設定組合外觀。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy the profile's appearance."
+          }
+        }
+      }
+    },
+    "Copy the saved tiling tree, if one exists.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 타일링 트리가 있으면 복사합니다."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済みのタイリングツリーがあればコピーします。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制已存的平铺树（若存在）。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製已儲存的平鋪樹（若存在）。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Copy the saved tiling tree, if one exists."
+          }
+        }
+      }
+    },
+    "Duplicate “%@”": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "“%@” 복제"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "「%@」を複製"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制“%@”"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製「%@」"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Duplicate “%@”"
+          }
+        }
+      }
+    },
+    "Include workspace": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 포함"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "ワークスペースを含める"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含工作区"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "包含工作空間"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Include workspace"
+          }
+        }
+      }
+    },
+    "Profile": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로필"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイル"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置方案"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定組合"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile"
+          }
+        }
+      }
+    },
+    "Profile icon": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "프로필 아이콘"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "プロファイルアイコン"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "配置方案图标"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "設定組合圖示"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Profile icon"
+          }
+        }
+      }
+    },
+    "Saved layout": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "저장된 레이아웃"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "保存済みレイアウト"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已存布局"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "已儲存佈局"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Saved layout"
+          }
+        }
+      }
+    },
+    "%@: %@": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "%1$@: %2$@"
+          }
+        }
+      }
+    },
+    "Key equivalent: %@": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "작업 공간 키: %@"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "キー相当: %@"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "对应按键: %@"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "對應按鍵: %@"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Key equivalent: %@"
+          }
+        }
+      }
+    },
+    "Recording": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "기록 중"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "記録中"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在录制"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "正在記錄"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Recording"
           }
         }
       }

--- a/Tatami/Resources/Localizable.xcstrings
+++ b/Tatami/Resources/Localizable.xcstrings
@@ -1,6 +1,521 @@
 {
   "sourceLanguage": "en",
   "strings": {
+    "· 1 argument": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "· 인자 1개" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "· 引数1個" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "· 1 个参数" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "· 1 個引數" } },
+        "en": { "stringUnit": { "state": "translated", "value": "· 1 argument" } }
+      }
+    },
+    "Ask": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "물어보기" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "毎回確認" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "每次询问" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "每次詢問" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Ask" } }
+      }
+    },
+    "Not set": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "설정 안 됨" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "未設定" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "未设置" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "未設定" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Not set" } }
+      }
+    },
+    "another workspace": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "다른 작업 공간" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "別のワークスペース" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "其他工作区" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "其他工作空間" } },
+        "en": { "stringUnit": { "state": "translated", "value": "another workspace" } }
+      }
+    },
+    "the hovered window": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "가리킨 창" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ポインタを合わせたウインドウ" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "指针悬停的窗口" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "游標停留的視窗" } },
+        "en": { "stringUnit": { "state": "translated", "value": "the hovered window" } }
+      }
+    },
+    "this workspace": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "이 작업 공간" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "このワークスペース" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "此工作区" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "此工作空間" } },
+        "en": { "stringUnit": { "state": "translated", "value": "this workspace" } }
+      }
+    },
+    "Its %@ workspace shortcut takes this same Borrow path.": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "%@ 작업 공간 단축키도 같은 빌려오기 방식으로 동작해요." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "%@ のワークスペースショートカットも同じ借りる操作になります。" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "%@ 工作区快捷键也使用相同的借用流程。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "%@ 工作空間快速鍵也使用相同的借用流程。" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Its %@ workspace shortcut takes this same Borrow path." } }
+      }
+    },
+    "Its workspace shortcut takes this same Borrow path.": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "작업 공간 단축키도 같은 빌려오기 방식으로 동작해요." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ワークスペースショートカットも同じ借りる操作になります。" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "工作区快捷键也使用相同的借用流程。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "工作空間快速鍵也使用相同的借用流程。" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Its workspace shortcut takes this same Borrow path." } }
+      }
+    },
+    "Command is empty": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "명령이 비어 있어요" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "コマンドが空です" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "命令为空" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "指令是空的" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Command is empty" } }
+      }
+    },
+    "Timed out after %@ ms": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "%@ms 시간 제한을 초과했어요" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "制限時間の%@msを超えました" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "超过 %@ 毫秒后超时" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "超過 %@ 毫秒後逾時" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Timed out after %@ ms" } }
+      }
+    },
+    "Exited with status %@": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "종료 상태: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "終了ステータス: %@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "退出状态：%@" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "結束狀態：%@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Exited with status %@" } }
+      }
+    },
+    "Terminated by signal %@": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "신호로 종료됨: %@" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "シグナルで終了: %@" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "被信号终止：%@" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已被訊號終止：%@" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Terminated by signal %@" } }
+      }
+    },
+    "Always on Top. Kept above the tiles and shared with every workspace.": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "항상 위에 둬요. 모든 작업 공간에서 타일 위에 표시돼요." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "常に手前に表示します。すべてのワークスペースでタイルより手前に表示されます。" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保持置顶，并在每个工作区中显示于平铺窗口上方。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "保持置頂，並在每個工作空間中顯示於並排視窗上方。" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Always on Top. Kept above the tiles and shared with every workspace." } }
+      }
+    },
+    "Always on Top. Kept above the tiles in this workspace.": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "항상 위에 둬요. 이 작업 공간의 타일 위에 표시돼요." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "常に手前に表示します。このワークスペースでタイルより手前に表示されます。" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保持置顶，并在此工作区中显示于平铺窗口上方。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "保持置頂，並在此工作空間中顯示於並排視窗上方。" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Always on Top. Kept above the tiles in this workspace." } }
+      }
+    },
+    "Leave As Is. Kept in place and shared with every workspace.": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "그대로 둬요. 모든 작업 공간에 속하지만 창 위치는 바꾸지 않아요." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "そのままにします。すべてのワークスペースに所属したまま、ウインドウの位置は変えません。" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保持原样。窗口属于每个工作区，但不会改变位置。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "維持原狀。視窗屬於每個工作空間，但不會變更位置。" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Leave As Is. Kept in place and shared with every workspace." } }
+      }
+    },
+    "Leave As Is. Kept in place in this workspace.": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "그대로 둬요. 이 작업 공간에 속하지만 창 위치는 바꾸지 않아요." } },
+        "ja": { "stringUnit": { "state": "translated", "value": "そのままにします。このワークスペースに所属したまま、ウインドウの位置は変えません。" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "保持原样。窗口属于此工作区，但不会改变位置。" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "維持原狀。視窗屬於此工作空間，但不會變更位置。" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Leave As Is. Kept in place in this workspace." } }
+      }
+    },
+    "Rotate 90°": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "90° 회전" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "90°回転" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "旋转 90°" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "旋轉 90°" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Rotate 90°" } }
+      }
+    },
+    "Flip left ↔ right": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "좌우 뒤집기" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "左右反転" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "左右翻转" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "左右翻轉" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Flip left ↔ right" } }
+      }
+    },
+    "Flip top ↔ bottom": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "상하 뒤집기" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "上下反転" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "上下翻转" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "上下翻轉" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Flip top ↔ bottom" } }
+      }
+    },
+    "Balance all splits equally": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "모든 분할을 같은 크기로 맞추기" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "すべての分割を均等にする" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "均衡所有分区" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "平均調整所有分割" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Balance all splits equally" } }
+      }
+    },
+    "Toggle split orientation of the selected tile": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "선택한 타일의 분할 방향 전환" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "選択したタイルの分割方向を切り替え" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "切换所选分区的拆分方向" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "切換所選區塊的分割方向" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Toggle split orientation of the selected tile" } }
+      }
+    },
+    "Fullscreen the selected tile": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "선택한 타일을 전체 화면으로 표시" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "選択したタイルをフルスクリーン表示" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "全屏显示所选分区" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "以全螢幕顯示所選區塊" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Fullscreen the selected tile" } }
+      }
+    },
+    "Borrowed": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "빌려온 작업 공간" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "借りたワークスペース" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "已借用的工作区" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "已借用的工作空間" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Borrowed" } }
+      }
+    },
+    "Default": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "기본값" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "デフォルト" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "默认值" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "預設值" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Default" } }
+      }
+    },
+    "Most recent": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "가장 최근" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "最近使った項目" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "最近使用" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "最近使用" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Most recent" } }
+      }
+    },
+    "No Scratchpad configured yet": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "아직 임시 공간을 설정하지 않았어요" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "一時スペースがまだ設定されていません" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "尚未设置暂存区" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "尚未設定暫存區" } },
+        "en": { "stringUnit": { "state": "translated", "value": "No Scratchpad configured yet" } }
+      }
+    },
+    "Window": {
+      "localizations": {
+        "ko": { "stringUnit": { "state": "translated", "value": "창" } },
+        "ja": { "stringUnit": { "state": "translated", "value": "ウインドウ" } },
+        "zh-Hans": { "stringUnit": { "state": "translated", "value": "窗口" } },
+        "zh-Hant": { "stringUnit": { "state": "translated", "value": "視窗" } },
+        "en": { "stringUnit": { "state": "translated", "value": "Window" } }
+      }
+    },
+    "Assign focused app here": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "포커스된 앱을 여기에 할당"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フォーカス中のAppをここに割り当て"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "将当前聚焦的应用分配到这里"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "將目前聚焦的 App 指派到這裡"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Assign focused app here"
+          }
+        }
+      }
+    },
+    "Configuration changed before duplication finished": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복제가 끝나기 전에 구성이 변경되었어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製が完了する前に設定が変更されました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制完成前，配置已发生变化"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製完成前，設定已發生變更"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration changed before duplication finished"
+          }
+        }
+      }
+    },
+    "Configuration changed before duplication started": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복제를 시작하기 전에 구성이 변경되었어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製を開始する前に設定が変更されました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "开始复制前，配置已发生变化"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "開始複製前，設定已發生變更"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Configuration changed before duplication started"
+          }
+        }
+      }
+    },
+    "Hook \"%@\" failed": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "\"%@\" 훅이 실패했어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フック「%@」が失敗しました"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子“%@”执行失败"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook「%@」執行失敗"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook \"%@\" failed"
+          }
+        }
+      }
+    },
+    "Hook configuration is invalid": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅 구성이 올바르지 않아요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フックの設定が無効です"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子配置无效"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook 設定無效"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook configuration is invalid"
+          }
+        }
+      }
+    },
+    "Hooks": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "훅"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "フック"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "钩子"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hook"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Hooks"
+          }
+        }
+      }
+    },
+    "Incomplete duplicate layout cleanup": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복제 레이아웃 정리를 완료하지 못했어요"
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製したレイアウトを完全に消去できませんでした"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未能完整清理复制的布局"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "未能完整清理複製的版面"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "Incomplete duplicate layout cleanup"
+          }
+        }
+      }
+    },
+    "The duplicate was not added to the configuration.": {
+      "localizations": {
+        "ko": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "복제 항목은 구성에 추가되지 않았어요."
+          }
+        },
+        "ja": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製した項目は設定に追加されませんでした。"
+          }
+        },
+        "zh-Hans": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "复制项未添加到配置中。"
+          }
+        },
+        "zh-Hant": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "複製項目未加入設定。"
+          }
+        },
+        "en": {
+          "stringUnit": {
+            "state": "translated",
+            "value": "The duplicate was not added to the configuration."
+          }
+        }
+      }
+    },
     "Enter an identifier.": {
       "localizations": {
         "ko": {
@@ -1293,36 +1808,36 @@
         }
       }
     },
-    "Each argument is passed exactly as one argv value. To use shell syntax, choose a shell executable and add its flags explicitly. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments.": {
+    "Each argument is passed exactly as one argv value. To use shell syntax, choose a command-line shell and add its flags explicitly. For fish, use `/opt/homebrew/bin/fish` and add `-c` and `command ls` as separate arguments. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "각 인자는 정확히 하나의 argv 값으로 전달돼요. 셸 문법을 사용하려면 셸 실행 파일을 선택하고 플래그를 직접 추가하세요. macOS 앱을 열려면 실행 파일로 `/usr/bin/open`을 사용하고 `-a`와 앱 이름을 각각 별도 인자로 추가하세요."
+            "value": "각 인자는 정확히 하나의 argv 값으로 전달돼요. 셸 문법을 사용하려면 명령줄 셸을 선택하고 플래그를 직접 추가하세요. fish는 `/opt/homebrew/bin/fish`를 실행 파일로 지정하고 `-c`와 `command ls`를 각각 별도 인자로 추가하세요. macOS 앱을 열려면 실행 파일로 `/usr/bin/open`을 사용하고 `-a`와 앱 이름을 각각 별도 인자로 추가하세요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "各引数は正確に1つのargv値として渡されます。シェル構文を使う場合はシェルの実行ファイルを選び、フラグを明示的に追加してください。macOSアプリを開くには、実行ファイルに`/usr/bin/open`を指定し、`-a`とアプリ名を別々の引数として追加してください。"
+            "value": "各引数は正確に1つのargv値として渡されます。シェル構文を使う場合はコマンドラインシェルを選び、フラグを明示的に追加してください。fishでは実行ファイルに`/opt/homebrew/bin/fish`を指定し、`-c`と`command ls`を別々の引数として追加します。macOSアプリを開くには、実行ファイルに`/usr/bin/open`を指定し、`-a`とアプリ名を別々の引数として追加してください。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "每个参数都会原样作为一个 argv 值传递。如需使用 shell 语法，请选择 shell 可执行文件并明确添加其选项。如需打开 macOS App，请将 `/usr/bin/open` 设为可执行文件，并把 `-a` 和 App 名称分别添加为参数。"
+            "value": "每个参数都会原样作为一个 argv 值传递。如需使用 shell 语法，请选择命令行 shell 并明确添加其选项。使用 fish 时，请将 `/opt/homebrew/bin/fish` 设为可执行文件，并把 `-c` 和 `command ls` 分别添加为参数。如需打开 macOS App，请将 `/usr/bin/open` 设为可执行文件，并把 `-a` 和 App 名称分别添加为参数。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "每個引數都會原樣作為一個 argv 值傳入。如需使用 shell 語法，請選擇 shell 執行檔並明確加入其選項。如需開啟 macOS App，請將 `/usr/bin/open` 設為執行檔，並把 `-a` 與 App 名稱分別加入為引數。"
+            "value": "每個引數都會原樣作為一個 argv 值傳入。如需使用 shell 語法，請選擇命令列 shell 並明確加入其選項。使用 fish 時，請將 `/opt/homebrew/bin/fish` 設為執行檔，並把 `-c` 與 `command ls` 分別加入為引數。如需開啟 macOS App，請將 `/usr/bin/open` 設為執行檔，並把 `-a` 與 App 名稱分別加入為引數。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Each argument is passed exactly as one argv value. To use shell syntax, choose a shell executable and add its flags explicitly. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments."
+            "value": "Each argument is passed exactly as one argv value. To use shell syntax, choose a command-line shell and add its flags explicitly. For fish, use `/opt/homebrew/bin/fish` and add `-c` and `command ls` as separate arguments. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments."
           }
         }
       }
@@ -1633,36 +2148,36 @@
         }
       }
     },
-    "These values are added to Tatami's inherited environment for this hook.": {
+    "These values are added to Tatami's inherited environment for this hook. Tatami event variables take precedence when names match.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "이 값들은 이 훅을 위해 Tatami가 상속한 환경에 추가돼요."
+            "value": "이 값들은 이 훅을 위해 Tatami가 상속한 환경에 추가돼요. 이름이 같으면 Tatami 이벤트 변수가 우선해요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "これらの値は、このフック用にTatamiが継承した環境へ追加されます。"
+            "value": "これらの値は、このフック用にTatamiが継承した環境へ追加されます。同じ名前の場合はTatamiのイベント変数が優先されます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "这些值会添加到 Tatami 为此钩子继承的环境中。"
+            "value": "这些值会添加到 Tatami 为此钩子继承的环境中。名称相同时，Tatami 事件变量优先。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "這些值會加入 Tatami 為這個 Hook 繼承的環境。"
+            "value": "這些值會加入 Tatami 為這個 Hook 繼承的環境。名稱相同時，以 Tatami 事件變數為準。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "These values are added to Tatami's inherited environment for this hook."
+            "value": "These values are added to Tatami's inherited environment for this hook. Tatami event variables take precedence when names match."
           }
         }
       }
@@ -3506,7 +4021,7 @@
         }
       }
     },
-    "%lld apps assigned — scratchpads work best with exactly one.": {
+    "%lld apps assigned. Scratchpads work best with exactly one.": {
       "localizations": {
         "ko": {
           "stringUnit": {
@@ -3535,7 +4050,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "%lld apps assigned — scratchpads work best with exactly one."
+            "value": "%lld apps assigned. Scratchpads work best with exactly one."
           }
         }
       }
@@ -6221,7 +6736,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Also matches %@ at the same priority — profile order decides which one activates. Make one more specific, or reorder them in the sidebar."
+            "value": "Also matches %@ at the same priority. Profile order decides which one activates. Make one more specific, or reorder them in the sidebar."
           }
         }
       }
@@ -10267,7 +10782,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Choose Ignore. The app still belongs to this workspace, but Tatami stops writing its frame or replacing it with a mirror."
+            "value": "Choose Leave As Is. The app still belongs to this workspace, but Tatami stops changing its position or replacing it with a mirror."
           }
         }
       }
@@ -12987,7 +13502,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Display the active profile's icon — only when you have more than one profile."
+            "value": "Display the active profile's icon only when you have more than one profile."
           }
         }
       }
@@ -13021,7 +13536,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Display the active profile's name — only when you have more than one profile."
+            "value": "Display the active profile's name only when you have more than one profile."
           }
         }
       }
@@ -13701,7 +14216,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Each new tiled window splits one region into two. Tatami stores that structure as a BSP tree, using the apps you assigned—not a canned demo."
+            "value": "Each new tiled window splits one region into two. Tatami stores that structure as a BSP tree, using the apps you assigned, not a canned demo."
           }
         }
       }
@@ -13735,7 +14250,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Each uses its modifier (Settings → Workspace Keys) + this workspace's key equivalent; record a shortcut to override. Borrow pulls this workspace in beside the current one — then a direction key places it unless a default is set below."
+            "value": "Each uses its modifier (Settings → Workspace Keys) + this workspace's key equivalent; record a shortcut to override. Borrow pulls this workspace in beside the current one. A direction key then places it unless a default is set below."
           }
         }
       }
@@ -16947,25 +17462,25 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "許可済み — ウインドウをタイル表示より手前に表示できます。"
+            "value": "許可済み。ウインドウをタイル表示より手前に表示できます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已授权 — 可以将窗口镜像置顶到平铺布局上方。"
+            "value": "已授权。可以将窗口镜像置顶到平铺布局上方。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "已允許 — 可以將視窗鏡像置頂至並排佈局上方。"
+            "value": "已允許。可以將視窗鏡像置頂至並排佈局上方。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Allowed — Tatami can keep mirrored windows above the tiled layout."
+            "value": "Allowed. Tatami can keep mirrored windows above the tiled layout."
           }
         }
       }
@@ -16981,25 +17496,25 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "許可済み — このMacで「常に手前」を使用できます。"
+            "value": "許可済み。このMacで「常に手前」を使用できます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已授权 — 可以在这台 Mac 上使用置顶窗口。"
+            "value": "已授权。可以在这台 Mac 上使用置顶窗口。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "已允許 — 可以在這台 Mac 上使用置頂視窗。"
+            "value": "已允許。可以在這台 Mac 上使用置頂視窗。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Allowed — always-on-top windows are available on this Mac."
+            "value": "Allowed. Always-on-top windows are available on this Mac."
           }
         }
       }
@@ -17015,25 +17530,25 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "許可済み — Tatamiでウインドウの移動、サイズ変更、フォーカスができます。"
+            "value": "許可済み。Tatamiでウインドウの移動、サイズ変更、フォーカスができます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已授权 — Tatami 可以移动、调整窗口大小并聚焦窗口。"
+            "value": "已授权。Tatami 可以移动、调整窗口大小并聚焦窗口。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "已允許 — Tatami 可以移動、調整視窗大小並聚焦視窗。"
+            "value": "已允許。Tatami 可以移動、調整視窗大小並聚焦視窗。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Granted — Tatami can move, resize, and focus windows."
+            "value": "Granted. Tatami can move, resize, and focus windows."
           }
         }
       }
@@ -17441,7 +17956,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Held with a workspace's key equivalent to borrow it into the current screen — then a direction key places it."
+            "value": "Held with a workspace's key equivalent to borrow it into the current screen. A direction key then places it."
           }
         }
       }
@@ -17718,36 +18233,36 @@
         }
       }
     },
-    "How far you must swipe to switch — higher sensitivity needs a shorter swipe.": {
+    "How far you must swipe before the bound action runs. Higher sensitivity needs a shorter swipe.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "전환에 필요한 스와이프 거리예요. 민감도가 높을수록 짧게 밀어도 전환돼요."
+            "value": "지정한 동작을 실행하는 데 필요한 스와이프 거리예요. 민감도가 높을수록 짧게 밀어도 실행돼요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "切り替えに必要なスワイプ距離です。感度を上げるほど、短いスワイプで切り替わります。"
+            "value": "割り当てた操作を実行するために必要なスワイプ距離です。感度を上げるほど、短いスワイプで実行できます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "切换所需的轻扫距离。灵敏度越高，轻扫越短也能切换。"
+            "value": "运行所绑定操作所需的轻扫距离。灵敏度越高，轻扫越短也能运行。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "切換所需的滑動距離。靈敏度越高，滑動越短也能切換。"
+            "value": "執行所綁定操作所需的滑動距離。靈敏度越高，滑動越短也能執行。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "How far you must swipe to switch — higher sensitivity needs a shorter swipe."
+            "value": "How far you must swipe before the bound action runs. Higher sensitivity needs a shorter swipe."
           }
         }
       }
@@ -17951,7 +18466,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Ignore"
+            "value": "Leave As Is"
           }
         }
       }
@@ -18432,7 +18947,7 @@
         }
       }
     },
-    "Keep exactly one app here—such as a terminal or notes window—then Borrow it only when needed.": {
+    "Keep exactly one app here, such as a terminal or notes window. Then Borrow it only when needed.": {
       "localizations": {
         "ko": {
           "stringUnit": {
@@ -18461,7 +18976,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keep exactly one app here—such as a terminal or notes window—then Borrow it only when needed."
+            "value": "Keep exactly one app here, such as a terminal or notes window. Then Borrow it only when needed."
           }
         }
       }
@@ -19384,36 +19899,36 @@
         }
       }
     },
-    "Live — edits re-tile your windows now.": {
+    "Live. Edits re-tile your windows now.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "실시간 — 편집하면 창이 바로 다시 배치돼요."
+            "value": "실시간으로 편집 내용을 창에 바로 반영해요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ライブ — 編集内容がすぐにウインドウへ反映されます。"
+            "value": "ライブです。編集内容がすぐにウインドウへ反映されます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "实时 — 编辑会立即重新平铺窗口。"
+            "value": "实时编辑会立即重新平铺窗口。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "即時 — 編輯會立即重新排列視窗。"
+            "value": "即時編輯會立即重新排列視窗。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Live — edits re-tile your windows now."
+            "value": "Live. Edits re-tile your windows now."
           }
         }
       }
@@ -20433,7 +20948,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Move focus to a remaining window in the workspace when the focused one closes — so closing a chat window hands focus back to your editor instead of stranding it."
+            "value": "Move focus to a remaining window in the workspace when the focused one closes, so closing a chat window hands focus back to your editor instead of stranding it."
           }
         }
       }
@@ -21351,7 +21866,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No conditions — activates on any configuration. Add a monitor condition below to narrow it."
+            "value": "No conditions. Activates on any configuration. Add a monitor condition below to narrow it."
           }
         }
       }
@@ -21929,7 +22444,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "No shared apps yet. Tap + to add one — it will tile into every workspace."
+            "value": "No shared apps yet. Tap + to add one. It will tile into every workspace."
           }
         }
       }
@@ -22251,25 +22766,25 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "未インストール — %@へシンボリックリンクを作成します"
+            "value": "未インストール。%@へシンボリックリンクを作成します"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "未安装 — 将创建符号链接到%@"
+            "value": "未安装。将创建符号链接到%@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "未安裝 — 將建立符號連結至%@"
+            "value": "未安裝。將建立符號連結至%@"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Not installed — will symlink to %@"
+            "value": "Not installed. Will symlink to %@"
           }
         }
       }
@@ -22575,7 +23090,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Nothing shared—recommended"
+            "value": "Nothing shared (recommended)"
           }
         }
       }
@@ -22881,7 +23396,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "One key for this workspace — hold it with the switch / assign / borrow modifier (Settings → Workspace Keys) to run each action."
+            "value": "One key for this workspace. Hold it with the switch / assign / borrow modifier (Settings → Workspace Keys) to run each action."
           }
         }
       }
@@ -23187,7 +23702,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Overlaps %@ — more specific, so it wins where both match."
+            "value": "Overlaps %@. It is more specific, so it wins where both match."
           }
         }
       }
@@ -23629,7 +24144,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pick the closest example. Notice that workspaces follow recurring activities—not broad app categories. Nothing here is applied to your draft."
+            "value": "Pick the closest example. Notice that workspaces follow recurring activities, not broad app categories. Nothing here is applied to your draft."
           }
         }
       }
@@ -24513,7 +25028,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Pull another workspace's apps and settings into this one — you'll review and pick each change. The display pin is included, so uncheck it to keep this workspace's own."
+            "value": "Pull another workspace's apps and settings into this one. You'll review and pick each change. The display pin is included, so uncheck it to keep this workspace's own."
           }
         }
       }
@@ -26694,7 +27209,7 @@
         }
       }
     },
-    "Saved layout — edits apply on next activation.": {
+    "Saved layout. Edits apply on next activation.": {
       "localizations": {
         "ko": {
           "stringUnit": {
@@ -26705,25 +27220,25 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "保存済みレイアウト — 次回の有効化時に編集内容を適用します。"
+            "value": "保存済みレイアウトです。次回の有効化時に編集内容を適用します。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "已保存布局 — 下次启用时应用编辑内容。"
+            "value": "已保存布局。下次启用时应用编辑内容。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "已儲存佈局 — 下次啟用時套用編輯內容。"
+            "value": "已儲存版面。下次啟用時套用編輯內容。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Saved layout — edits apply on next activation."
+            "value": "Saved layout. Edits apply on next activation."
           }
         }
       }
@@ -27521,25 +28036,25 @@
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "共有アプリ — すべてのワークスペースに表示"
+            "value": "共有アプリ。すべてのワークスペースに表示"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "共享应用 — 出现在每个工作区"
+            "value": "共享应用。出现在每个工作区"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "共用 App — 出現在每個工作空間"
+            "value": "共用 App。出現在每個工作空間"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Shared app — in every workspace"
+            "value": "Shared app in every workspace"
           }
         }
       }
@@ -28967,7 +29482,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Step through the visible Tatami workspace—not the global ⌘Tab list or one app's ⌘` list."
+            "value": "Step through the visible Tatami workspace, not the global ⌘Tab list or one app's ⌘` list."
           }
         }
       }
@@ -29001,7 +29516,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Still in Shared Apps — %@ removes it"
+            "value": "Still in Shared Apps. %@ removes it"
           }
         }
       }
@@ -29035,7 +29550,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Still in this workspace — %@ removes it"
+            "value": "Still in this workspace. %@ removes it"
           }
         }
       }
@@ -30157,7 +30672,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami prepares the prompt and validates the result. You choose ChatGPT, Claude, Gemini, or another AI — no account connection required."
+            "value": "Tatami prepares the prompt and validates the result. You choose ChatGPT, Claude, Gemini, or another AI. No account connection is required."
           }
         }
       }
@@ -30191,7 +30706,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami uses it only for per-window always-on-top mirrors. Ignore needs no capture permission."
+            "value": "Tatami uses it only for per-window always-on-top mirrors. Leave As Is needs no capture permission."
           }
         }
       }
@@ -30701,7 +31216,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The prompt contains only these answers, app metadata, and connected display names and sizes — never screen contents."
+            "value": "The prompt contains only these answers, app metadata, and connected display names and sizes, never screen contents."
           }
         }
       }
@@ -30740,70 +31255,70 @@
         }
       }
     },
-    "The shortcut arms Borrow first; finish with an arrow or H/J/K/L direction, just like the real command.%@": {
+    "The shortcut arms Borrow first; finish with an arrow or H/J/K/L direction, just like the real command. %@": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "단축키를 누르면 먼저 빌려오기 모드가 시작돼요. 실제 명령처럼 방향키나 H/J/K/L로 위치를 정하세요.%@"
+            "value": "단축키를 누르면 먼저 빌려오기 모드가 시작돼요. 실제 명령처럼 방향키나 H/J/K/L로 위치를 정하세요. %@"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ショートカットでまず「借りる」を開始します。実際のコマンドと同じように、矢印キーまたはH/J/K/Lで方向を決めてください。%@"
+            "value": "ショートカットでまず「借りる」を開始します。実際のコマンドと同じように、矢印キーまたはH/J/K/Lで方向を決めてください。 %@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "快捷键会先进入借用模式；再像真实命令一样，用方向键或 H/J/K/L 完成放置。%@"
+            "value": "快捷键会先进入借用模式；再像真实命令一样，用方向键或 H/J/K/L 完成放置。 %@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "快速鍵會先進入借用模式；再像實際指令一樣，用方向鍵或 H/J/K/L 完成放置。%@"
+            "value": "快速鍵會先進入借用模式；再像實際指令一樣，用方向鍵或 H/J/K/L 完成放置。 %@"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The shortcut arms Borrow first; finish with an arrow or H/J/K/L direction, just like the real command.%@"
+            "value": "The shortcut arms Borrow first; finish with an arrow or H/J/K/L direction, just like the real command. %@"
           }
         }
       }
     },
-    "The shortcut docks on the %@. Repeating it dismisses only when ‘Dismiss when summoned again’ is on.%@": {
+    "The shortcut docks on the %@. Repeating it dismisses only when ‘Dismiss when summoned again’ is on. %@": {
       "localizations": {
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "The shortcut docks on the %1$@. Repeating it returns the workspace only when ‘Return When Borrowed Again’ is on.%2$@"
+            "value": "The shortcut docks on the %1$@. Repeating it returns the workspace only when ‘Return When Borrowed Again’ is on. %2$@"
           }
         },
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "단축키를 누르면 %@에 바로 붙어요. ‘다시 빌려오면 돌려보내기’를 켠 경우에만 같은 단축키를 다시 눌러 돌려보낼 수 있어요.%@"
+            "value": "단축키를 누르면 %@에 바로 붙어요. ‘다시 빌려오면 돌려보내기’를 켠 경우에만 같은 단축키를 다시 눌러 돌려보낼 수 있어요. %@"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "ショートカットですぐに%@へ配置します。「もう一度呼ぶと元へ戻す」がオンの場合だけ、同じショートカットを繰り返すと元へ戻します。%@"
+            "value": "ショートカットですぐに%@へ配置します。「もう一度呼ぶと元へ戻す」がオンの場合だけ、同じショートカットを繰り返すと元へ戻します。 %@"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "快捷键会停靠到%@。只有开启“再次借用时归还”后，重复按下才会归还工作区。%@"
+            "value": "快捷键会停靠到%@。只有开启“再次借用时归还”后，重复按下才会归还工作区。 %@"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "快速鍵會停靠至%@。只有開啟「再次借用時歸還」後，重複按下才會歸還工作空間。%@"
+            "value": "快速鍵會停靠至%@。只有開啟「再次借用時歸還」後，重複按下才會歸還工作空間。 %@"
           }
         }
       }
@@ -33966,7 +34481,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Walk through this Tatami workspace—not the global ⌘Tab list or only one app like ⌘`"
+            "value": "Walk through this Tatami workspace, not the global ⌘Tab list or only one app like ⌘`"
           }
         }
       }
@@ -34136,7 +34651,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When on, auto-switch to this profile as the monitors match — all conditions apply together. Per monitor: Required = must be connected, Excluded = must be unplugged."
+            "value": "When on, auto-switch to this profile as the monitors match. All conditions apply together. Per monitor: Required = must be connected, Excluded = must be unplugged."
           }
         }
       }
@@ -34170,7 +34685,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When Tatami changes the focused managed window, the pointer follows it—even between the host and a borrowed block. Directional Focus and Window Switching move it to the new window. Swap keeps it with the same window in its new tile."
+            "value": "When Tatami changes the focused managed window, the pointer follows it, even between the host and a borrowed block. Directional Focus and Window Switching move it to the new window. Swap keeps it with the same window in its new tile."
           }
         }
       }
@@ -34238,7 +34753,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When the last window in the active workspace closes, switch to the recent workspace. Shared apps don't count — they join every workspace anyway."
+            "value": "When the last window in the active workspace closes, switch to the recent workspace. Shared apps don't count because they join every workspace anyway."
           }
         }
       }
@@ -34884,7 +35399,7 @@
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "When there’s a neighboring window, Swap exchanges their positions. At an outer edge, it changes the split direction—for example, from side by side to stacked."
+            "value": "When there’s a neighboring window, Swap exchanges their positions. At an outer edge, it changes the split direction, for example, from side by side to stacked."
           }
         }
       }
@@ -35875,308 +36390,240 @@
         }
       }
     },
-    "Tatami is now available in five interface languages, with clearer names and guidance written for each locale.": {
+    "Tatami 1.12 adds scriptable control and lifecycle hooks, plus safer, more selective profile and workspace duplication.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami를 다시 열면 각 디스플레이에서 마지막 프로필과 작업 공간으로 돌아가요. 앱 상태가 바뀌거나 잠자기 후에도 창을 더 빠르고 안정적으로 맞춰요."
+            "value": "Tatami 1.12에서는 CLI와 수명 주기 훅으로 작업을 자동화하고, 더 안전한 검토 화면에서 프로필과 작업 공간을 필요한 내용만 골라 복제할 수 있어요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami を開き直すと、各ディスプレイで最後に使ったプロファイルとワークスペースに戻ります。App の変化やスリープ後も、ウインドウをすばやく安定して整えます。"
+            "value": "Tatami 1.12 では、CLI とライフサイクルフックで作業を自動化し、より安全な確認画面で必要な内容だけを選んでプロファイルやワークスペースを複製できます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新打开 Tatami 后，每台显示器都会恢复上次使用的配置方案和工作区。应用状态变化或睡眠唤醒后，窗口也能更快、更稳定地归位。"
+            "value": "Tatami 1.12 新增了 CLI 自动化和生命周期钩子，并提供更安全、更灵活的配置方案与工作区复制流程。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "重新開啟 Tatami 時，每部顯示器都會回到上次使用的設定組合和工作空間。App 狀態變更或睡眠喚醒後，視窗也能更快、更穩定地回到正確位置。"
+            "value": "Tatami 1.12 新增 CLI 自動化與生命週期 Hook，並提供更安全、更彈性的設定組合與工作空間複製流程。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami now returns to the right profile and workspace on every display, while window tracking stays responsive and resilient through app changes and sleep."
+            "value": "Tatami 1.12 adds scriptable control and lifecycle hooks, plus safer, more selective profile and workspace duplication."
           }
         }
       }
     },
-    "Use Tatami in your language": {
+    "Control Tatami from the command line": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "마지막으로 사용한 구성으로 돌아가요"
+            "value": "명령줄에서 Tatami를 제어해요"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "前回の作業環境から再開"
+            "value": "コマンドラインから Tatami を操作"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "从上次的位置继续"
+            "value": "从命令行控制 Tatami"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "從上次的狀態繼續"
+            "value": "從命令列控制 Tatami"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Resume where you left off"
+            "value": "Control Tatami from the command line"
           }
         }
       }
     },
-    "Choose English, Korean, Japanese, Simplified Chinese, or Traditional Chinese. Tatami follows the language selected for the app in macOS.": {
+    "Use domain commands for profiles, workspaces, windows, displays, layouts, and apps, with stable JSON output and every action available to trackpad gestures.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "마지막으로 사용한 조건에 맞는 프로필과 디스플레이별 작업 공간을 복원해요. 디스플레이 조건이 달라졌다면 현재 구성에 맞는 프로필을 선택해요."
+            "value": "프로필, 작업 공간, 윈도우, 디스플레이, 레이아웃, 앱 명령을 기능별로 사용하고, 제스처에서 지원하는 모든 동작을 안정적인 JSON 출력과 함께 실행할 수 있어요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "最後に使った、現在の条件に合うプロファイルと、各ディスプレイのワークスペースを復元します。ディスプレイ条件が変わった場合は、今の構成に合うプロファイルを選びます。"
+            "value": "プロファイル、ワークスペース、ウインドウ、ディスプレイ、レイアウト、App のコマンドを機能別に使い、トラックパッドジェスチャで使えるすべての操作を安定した JSON 出力とともに実行できます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami 会恢复上次使用且仍符合条件的配置方案，以及每台显示器的工作区。显示器条件发生变化时，会选择适合当前设备组合的配置方案。"
+            "value": "按配置方案、工作区、窗口、显示器、布局和应用分类使用命令，并通过稳定的 JSON 输出执行触控板手势支持的全部操作。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami 會還原上次使用且仍符合條件的設定組合，以及每部顯示器的工作空間。顯示器條件變更時，會選擇符合目前組合的設定。"
+            "value": "依設定組合、工作空間、視窗、顯示器、版面與 App 分類使用指令，並透過穩定的 JSON 輸出執行觸控板手勢支援的所有操作。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Tatami restores the last eligible profile and each display's workspace. If a display rule no longer matches, it chooses the correct profile for the current setup."
+            "value": "Use domain commands for profiles, workspaces, windows, displays, layouts, and apps, with stable JSON output and every action available to trackpad gestures."
           }
         }
       }
     },
-    "Clearer names across the app": {
+    "Run programs on lifecycle events": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "잠자기 후에도 배치를 유지해요"
+            "value": "수명 주기 이벤트에서 프로그램을 실행해요"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "スリープ後もレイアウトを維持"
+            "value": "ライフサイクルイベントでプログラムを実行"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "睡眠唤醒后保留布局"
+            "value": "在生命周期事件中运行程序"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "睡眠喚醒後保留版面"
+            "value": "在生命週期事件中執行程式"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Keep layouts through sleep"
+            "value": "Run programs on lifecycle events"
           }
         }
       }
     },
-    "Always on Top, Leave As Is, Window Switching, and On-Screen Feedback now describe what each control does.": {
+    "Create and test hooks for Tatami launch, profile changes, and workspaces becoming visible on a display. Each event includes versioned JSON and useful environment variables.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "잠자기와 깨우기 후에도 BSP 배치를 유지해요. macOS가 창을 새로 만들면 새 배치로 인식하지 않고 저장된 위치에 다시 연결해요."
+            "value": "Tatami 실행, 프로필 변경, 작업 공간이 디스플레이에 표시될 때 실행할 훅을 만들고 테스트하세요. 각 이벤트에는 버전이 지정된 JSON과 유용한 환경 변수가 포함돼요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "スリープと復帰をまたいでも BSP レイアウトを維持します。macOS がウインドウを作り直しても、新しいレイアウトとして扱わず、保存済みの位置に戻します。"
+            "value": "Tatami の起動、プロファイルの変更、ワークスペースがディスプレイに表示されたときのフックを作成、テストできます。各イベントにはバージョン付き JSON と便利な環境変数が含まれます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "BSP 布局会在睡眠和唤醒后保留。即使 macOS 重新创建窗口，Tatami 也会将它放回已保存的位置，而不会当作新布局。"
+            "value": "为 Tatami 启动、配置方案变更和工作区显示在屏幕上创建并测试钩子。每个事件都包含带版本的 JSON 和实用的环境变量。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "BSP 版面會在睡眠與喚醒後保留。即使 macOS 重新建立視窗，Tatami 也會將它放回已儲存的位置，不會當成新的版面。"
+            "value": "為 Tatami 啟動、設定組合變更及工作空間顯示在螢幕上建立並測試 Hook。每個事件都包含有版本的 JSON 與實用的環境變數。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Your BSP layout survives sleep and wake. If macOS recreates a window, Tatami reconnects it to its saved place instead of treating it as a new layout."
+            "value": "Create and test hooks for Tatami launch, profile changes, and workspaces becoming visible on a display. Each event includes versioned JSON and useful environment variables."
           }
         }
       }
     },
-    "Your configuration stays compatible": {
+    "Choose what Duplicate keeps": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "기다림 없이 창 변화를 따라가요"
+            "value": "복제할 내용을 직접 골라요"
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "待たずにウインドウの変化を反映"
+            "value": "複製する内容を選択"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "更快跟上窗口变化"
+            "value": "选择要复制的内容"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "更快跟上視窗變化"
+            "value": "選擇要複製的內容"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Track windows without the wait"
+            "value": "Choose what Duplicate keeps"
           }
         }
       }
     },
-    "Your workspaces, profiles, shortcuts, and existing `config.toml` continue to work. Stable configuration keys have not changed.": {
+    "Right-click a profile or workspace, review its workspaces, apps, settings, and saved layouts, then include only what you want.": {
       "localizations": {
         "ko": {
           "stringUnit": {
             "state": "translated",
-            "value": "중복된 손쉬운 사용 조회를 줄였어요. 늦게 열리거나 숨었다 다시 나타난 창도 빌려오기 안을 포함해 알맞은 타일과 포커스로 더 안정적으로 돌아가요."
+            "value": "프로필이나 작업 공간을 우클릭하고 작업 공간, 앱, 설정, 저장된 레이아웃을 검토한 다음 필요한 항목만 포함하세요."
           }
         },
         "ja": {
           "stringUnit": {
             "state": "translated",
-            "value": "重複するアクセシビリティ処理を減らしました。遅れて開くウインドウや、非表示から戻ったウインドウも、借りている間を含めて正しいタイルとフォーカスへより安定して戻ります。"
+            "value": "プロファイルやワークスペースを右クリックし、ワークスペース、App、設定、保存済みレイアウトを確認して、必要な項目だけを含められます。"
           }
         },
         "zh-Hans": {
           "stringUnit": {
             "state": "translated",
-            "value": "减少了重复的辅助功能查询。延迟打开、隐藏后重新出现的窗口也能更稳定地回到正确的分区和焦点位置，包括借用中的窗口。"
+            "value": "右键点按配置方案或工作区，检查其中的工作区、应用、设置和已存布局，然后仅包含需要的项目。"
           }
         },
         "zh-Hant": {
           "stringUnit": {
             "state": "translated",
-            "value": "減少了重複的輔助使用查詢。較晚開啟、隱藏後再次出現的視窗，也能更穩定地回到正確的並排區域和焦點位置，包括借用中的視窗。"
+            "value": "在設定組合或工作空間上按右鍵，檢查其中的工作空間、App、設定與已儲存版面，然後只包含需要的項目。"
           }
         },
         "en": {
           "stringUnit": {
             "state": "translated",
-            "value": "Window discovery and updates now avoid redundant Accessibility work. Late-opening, hidden, and reappearing windows return to the right tile and focus more reliably, including inside Borrow."
-          }
-        }
-      }
-    },
-    "Written for each language": {
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "상태가 잘 보이는 창 전환과 예측 가능한 균형"
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "状態が見える切り替えと分かりやすい均等化"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "状态更清晰的窗口切换与可预测的均衡"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "狀態更清楚的視窗切換與可預期的均衡"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "A clearer switcher and predictable Balance"
-          }
-        }
-      }
-    },
-    "Instructions, empty states, errors, and confirmations are written around the task and next action instead of translated word for word.": {
-      "localizations": {
-        "ko": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "창 전환기에서 포커스, 빌려오기, 공용 앱, 항상 위, 전체 화면 상태를 확인하고 마우스로 정확한 창을 선택할 수 있어요. 균형 맞추기는 자동 균형 설정을 따르며, 끔에서는 기본 BSP 배치를 다시 구성해요."
-          }
-        },
-        "ja": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "切り替え画面で、フォーカス、借りる、共有アプリ、常に手前、フルスクリーンの状態を確認し、ポインタで目的のウインドウを正確に選べます。均等化は自動均等配置に従い、「オフ」では標準の BSP レイアウトに組み直します。"
-          }
-        },
-        "zh-Hans": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "窗口切换器会显示焦点、借用、共享应用、置顶和全屏状态，并可用指针准确选择窗口。均衡会遵循自动均衡设置；关闭时会重建标准 BSP 布局。"
-          }
-        },
-        "zh-Hant": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "視窗切換器會顯示焦點、借用、共用 App、置頂和全螢幕狀態，並可用游標準確選取視窗。均衡會遵循自動均衡設定；關閉時會重建標準 BSP 版面。"
-          }
-        },
-        "en": {
-          "stringUnit": {
-            "state": "translated",
-            "value": "The switcher shows focus, Borrow, Shared Apps, Always on Top, and fullscreen status, and hover selects the exact window. Balance follows Auto-balance; with it off, Balance rebuilds the canonical BSP layout."
+            "value": "Right-click a profile or workspace, review its workspaces, apps, settings, and saved layouts, then include only what you want."
           }
         }
       }

--- a/Tatami/Sources/Onboarding/OnboardingComponents.swift
+++ b/Tatami/Sources/Onboarding/OnboardingComponents.swift
@@ -1035,7 +1035,7 @@ struct OnboardingSwitchingDemo: View {
           .frame(width: 44, height: 44)
           .background(Color.accentColor.opacity(0.12), in: .rect(cornerRadius: 12))
         VStack(alignment: .leading, spacing: 3) {
-          Text(activeWorkspace?.name ?? "Workspace")
+          Text(activeWorkspace?.name ?? String(localized: "Workspace"))
             .font(.headline)
           Text(activeApps.isEmpty ? "No assigned apps yet" : "\(activeApps.count) apps arrive together")
             .font(.caption)
@@ -1738,7 +1738,7 @@ private struct OnboardingGestureConsole: View {
       }
 
       Label(
-        "3 fingers · cycle the focused window inside \(activeWorkspace?.name ?? "this workspace")",
+        "3 fingers · cycle the focused window inside \(activeWorkspace?.name ?? String(localized: "this workspace"))",
         systemImage: "macwindow",
       )
       .font(.caption.weight(.semibold))

--- a/Tatami/Sources/Onboarding/OnboardingComponents.swift
+++ b/Tatami/Sources/Onboarding/OnboardingComponents.swift
@@ -488,6 +488,7 @@ struct OnboardingShortcutPracticeRow: View {
       Spacer(minLength: 12)
       ShortcutRecorder(
         hotKey: hotKey,
+        accessibilityLabel: title,
         conflict: { config.shortcutConflict(for: $0, excluding: action) },
         onRecordingChanged: onRecordingChanged,
         onChange: onChange,

--- a/Tatami/Sources/Onboarding/OnboardingView.swift
+++ b/Tatami/Sources/Onboarding/OnboardingView.swift
@@ -1245,17 +1245,23 @@ private struct OnboardingBorrowStep: View {
         ) {
           HStack {
             VStack(alignment: .leading, spacing: 3) {
-              Text(store.scratchpads.first?.name ?? "No Scratchpad configured yet")
+              if let scratchpadName = store.scratchpads.first?.name {
+                Text(scratchpadName)
+              } else {
+                Text("No Scratchpad configured yet")
+              }
               let scratchpadAppCount = store.scratchpads.first.map {
                 store.state.apps(in: $0.id).count
               } ?? 0
-              Text(
-                scratchpadAppCount > 1
-                  ? "\(scratchpadAppCount) apps assigned — scratchpads work best with exactly one."
-                  : "Keep exactly one app here—such as a terminal or notes window—then Borrow it only when needed."
-              )
-              .font(.caption)
-              .foregroundStyle(scratchpadAppCount > 1 ? Color.orange : Color.secondary)
+              if scratchpadAppCount > 1 {
+                Text("\(scratchpadAppCount) apps assigned. Scratchpads work best with exactly one.")
+                  .font(.caption)
+                  .foregroundStyle(.orange)
+              } else {
+                Text("Keep exactly one app here, such as a terminal or notes window. Then Borrow it only when needed.")
+                  .font(.caption)
+                  .foregroundStyle(.secondary)
+              }
             }
             Spacer()
             if store.scratchpads.isEmpty {
@@ -1323,15 +1329,18 @@ private struct OnboardingBorrowStep: View {
     let scratchpadSwitchDetail =
       if workspace.kind == .scratchpad {
         store.state.shortcut(for: .activateWorkspace(workspace.id))
-          .map { " Its \($0.symbols) workspace shortcut takes this same Borrow path." }
-          ?? " Its workspace shortcut takes this same Borrow path."
+          .map {
+            String(localized: "Its \($0.symbols) workspace shortcut takes this same Borrow path.")
+          }
+          ?? String(localized: "Its workspace shortcut takes this same Borrow path.")
       } else {
         ""
       }
     if let edge = workspace.borrowEdge ?? store.draft.settings.switching.borrowDefaultEdge {
-      return "The shortcut docks on the \(edge.rawValue). Repeating it dismisses only when ‘Dismiss when summoned again’ is on.\(scratchpadSwitchDetail)"
+      let edgeName = String(localized: edge.displayName)
+      return "The shortcut docks on the \(edgeName). Repeating it dismisses only when ‘Dismiss when summoned again’ is on. \(scratchpadSwitchDetail)"
     }
-    return "The shortcut arms Borrow first; finish with an arrow or H/J/K/L direction, just like the real command.\(scratchpadSwitchDetail)"
+    return "The shortcut arms Borrow first; finish with an arrow or H/J/K/L direction, just like the real command. \(scratchpadSwitchDetail)"
   }
 
 }
@@ -1536,7 +1545,8 @@ private struct OnboardingFocusCyclingStep: View {
       ) {
         VStack(alignment: .leading, spacing: 13) {
           OnboardingWindowCyclingComparison(
-            tatamiShortcut: store.state.shortcut(for: .cycleNextWindow)?.symbols ?? "Not set"
+            tatamiShortcut: store.state.shortcut(for: .cycleNextWindow)?.symbols
+              ?? String(localized: "Not set")
           )
           Divider()
           OnboardingSettingToggle(
@@ -1844,15 +1854,25 @@ private struct OnboardingCumulativeLayoutStage: View {
     .frame(width: frame.width, height: frame.height)
     .position(x: frame.midX, y: frame.midY)
     .overlay(alignment: .topLeading) {
-      Text(isHost
-        ? (store.activeDemoWorkspace?.name ?? "Host")
-        : (store.demoBorrowWorkspace?.name ?? "Borrowed"))
-        .font(.caption2.weight(.bold))
-        .padding(.horizontal, 8)
-        .padding(.vertical, 5)
-        .background(.ultraThinMaterial, in: .capsule)
-        .padding(8)
-        .allowsHitTesting(false)
+      Group {
+        if isHost {
+          if let name = store.activeDemoWorkspace?.name {
+            Text(name)
+          } else {
+            Text("Host")
+          }
+        } else if let name = store.demoBorrowWorkspace?.name {
+          Text(name)
+        } else {
+          Text("Borrowed")
+        }
+      }
+      .font(.caption2.weight(.bold))
+      .padding(.horizontal, 8)
+      .padding(.vertical, 5)
+      .background(.ultraThinMaterial, in: .capsule)
+      .padding(8)
+      .allowsHitTesting(false)
     }
   }
 

--- a/Tatami/Sources/Onboarding/OnboardingView.swift
+++ b/Tatami/Sources/Onboarding/OnboardingView.swift
@@ -252,7 +252,7 @@ private struct OnboardingWelcomeStep: View {
         OnboardingPhilosophyCard(
           icon: "lock.shield",
           title: "Native and inspectable",
-          detail: "Keep SIP enabled, avoid shell scripts, and retain a readable TOML configuration.",
+          detail: "Keep SIP enabled, use native controls, and retain a readable TOML configuration.",
         )
       }
 
@@ -262,7 +262,7 @@ private struct OnboardingWelcomeStep: View {
             store.displays.count == 1
               ? "\(store.displays.count) display"
               : "\(store.displays.count) displays",
-            systemImage: "display"
+            systemImage: "display",
           )
           Label("\(store.runningApps.count) running apps", systemImage: "app.badge")
           Label("No screen contents captured", systemImage: "eye.slash")
@@ -1030,7 +1030,7 @@ private struct OnboardingTilingStep: View {
     step: LocalizedStringResource,
     title: LocalizedStringResource,
     detail: LocalizedStringResource,
-    completed: Bool
+    completed: Bool,
   ) {
     let lessons: [(OnboardingPractice, LocalizedStringResource, LocalizedStringResource)] = [
       (
@@ -1282,7 +1282,7 @@ private struct OnboardingBorrowStep: View {
     step: LocalizedStringResource,
     title: LocalizedStringResource,
     detail: LocalizedStringResource,
-    completed: Bool
+    completed: Bool,
   ) {
     if !store.demoBorrowed, !store.practices.contains(.borrowDismiss) {
       return (
@@ -1493,7 +1493,7 @@ private struct OnboardingFloatingStep: View {
     step: LocalizedStringResource,
     title: LocalizedStringResource,
     detail: LocalizedStringResource,
-    completed: Bool
+    completed: Bool,
   ) {
     if !store.practices.contains(.floating) {
       return (
@@ -1690,7 +1690,7 @@ private struct OnboardingFocusCyclingStep: View {
     let borrow = store.demoBorrowed
       ? String(
         localized:
-          "Borrowed \(store.demoBorrowWorkspace?.name ?? String(localized: "workspace"))"
+        "Borrowed \(store.demoBorrowWorkspace?.name ?? String(localized: "workspace"))"
       )
       : String(localized: store.demoLayoutMode.displayName)
     let mff = store.draft.settings.focus.mouseFollowsFocus
@@ -1706,7 +1706,7 @@ private struct OnboardingFocusCyclingStep: View {
     step: LocalizedStringResource,
     title: LocalizedStringResource,
     detail: LocalizedStringResource,
-    completed: Bool
+    completed: Bool,
   ) {
     if !store.practices.contains(.mouseFollowsFocus) {
       return (

--- a/Tatami/Sources/Settings/AboutView.swift
+++ b/Tatami/Sources/Settings/AboutView.swift
@@ -91,6 +91,7 @@ struct AboutView: View {
     ("swift-collections", "https://github.com/apple/swift-collections"),
     ("Magnet", "https://github.com/Clipy/Magnet"),
     ("swift-toml", "https://github.com/mattt/swift-toml"),
+    ("swift-subprocess", "https://github.com/swiftlang/swift-subprocess"),
     ("swift-yyjson", "https://github.com/mattt/swift-yyjson"),
     ("SFSafeSymbols", "https://github.com/SFSafeSymbols/SFSafeSymbols"),
     ("swift-argument-parser", "https://github.com/apple/swift-argument-parser"),

--- a/Tatami/Sources/Settings/CLIReferenceView.swift
+++ b/Tatami/Sources/Settings/CLIReferenceView.swift
@@ -1,0 +1,256 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import SwiftUI
+
+// MARK: - CLIReferenceView
+
+/// Renders the bundled `docs/CLI.md` so the app and website share one source.
+struct CLIReferenceView: View {
+
+  // MARK: Internal
+
+  var body: some View {
+    NavigationStack {
+      Group {
+        if let blocks {
+          ScrollView {
+            LazyVStack(alignment: .leading, spacing: 12) {
+              ForEach(blocks) { block in
+                blockView(block)
+              }
+            }
+            .padding(24)
+            .frame(maxWidth: .infinity, alignment: .leading)
+          }
+        } else if let loadErrorMessage {
+          ContentUnavailableView(
+            "Unable to Open Document",
+            systemImage: "doc.badge.exclamationmark",
+            description: Text(loadErrorMessage),
+          )
+        } else {
+          ProgressView("Loading document…")
+        }
+      }
+      .navigationTitle("CLI Guide")
+      .toolbar {
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Done") {
+            dismiss()
+          }
+        }
+      }
+    }
+    .frame(minWidth: 720, minHeight: 600)
+    .task {
+      do {
+        blocks = try await MarkdownBlock.loadCLIReference()
+      } catch {
+        loadErrorMessage = error.localizedDescription
+      }
+    }
+  }
+
+  // MARK: Private
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var blocks: [MarkdownBlock]?
+  @State private var loadErrorMessage: String?
+
+  @ViewBuilder
+  private func blockView(_ block: MarkdownBlock) -> some View {
+    switch block.content {
+    case .heading(let level, let text):
+      Text(inline(text))
+        .font(headingFont(level))
+        .padding(.top, level == 1 ? 0 : 10)
+        .textSelection(.enabled)
+
+    case .paragraph(let text):
+      Text(inline(text))
+        .fixedSize(horizontal: false, vertical: true)
+        .textSelection(.enabled)
+
+    case .bullet(let text):
+      HStack(alignment: .firstTextBaseline, spacing: 8) {
+        Text("•")
+          .foregroundStyle(.secondary)
+        Text(inline(text))
+          .fixedSize(horizontal: false, vertical: true)
+      }
+      .textSelection(.enabled)
+
+    case .code(let text):
+      ScrollView(.horizontal) {
+        Text(verbatim: text)
+          .font(.system(.body, design: .monospaced))
+          .textSelection(.enabled)
+          .padding(12)
+      }
+      .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+
+    case .table(let rows):
+      ScrollView(.horizontal) {
+        Grid(alignment: .leading, horizontalSpacing: 20, verticalSpacing: 8) {
+          ForEach(Array(rows.enumerated()), id: \.offset) { rowIndex, row in
+            GridRow {
+              ForEach(Array(row.enumerated()), id: \.offset) { _, cell in
+                Text(inline(cell))
+                  .fontWeight(rowIndex == 0 ? .semibold : .regular)
+                  .fixedSize(horizontal: true, vertical: false)
+              }
+            }
+          }
+        }
+        .textSelection(.enabled)
+        .padding(12)
+      }
+      .background(.quaternary, in: RoundedRectangle(cornerRadius: 8))
+    }
+  }
+
+  private func headingFont(_ level: Int) -> Font {
+    switch level {
+    case 1: .title2.weight(.semibold)
+    case 2: .title3.weight(.semibold)
+    default: .headline
+    }
+  }
+
+  private func inline(_ text: String) -> AttributedString {
+    let options = AttributedString.MarkdownParsingOptions(
+      interpretedSyntax: .inlineOnlyPreservingWhitespace
+    )
+    return (try? AttributedString(markdown: text, options: options)) ?? AttributedString(text)
+  }
+
+}
+
+// MARK: - MarkdownBlock
+
+private struct MarkdownBlock: Identifiable, Sendable {
+
+  // MARK: Internal
+
+  enum Content: Sendable {
+    case heading(level: Int, text: String)
+    case paragraph(String)
+    case bullet(String)
+    case code(String)
+    case table([[String]])
+  }
+
+  let id: Int
+  let content: Content
+
+  static func loadCLIReference() async throws -> [Self] {
+    guard let url = Bundle.main.url(forResource: "CLI", withExtension: "md") else {
+      throw CocoaError(.fileNoSuchFile)
+    }
+
+    return try await Task.detached(priority: .userInitiated) {
+      let source = try String(contentsOf: url, encoding: .utf8)
+      return parse(source)
+    }.value
+  }
+
+  // MARK: Private
+
+  private static func parse(_ source: String) -> [Self] {
+    let lines = source.components(separatedBy: .newlines)
+    var contents = [Content]()
+    var index = 0
+
+    while index < lines.count {
+      let line = lines[index]
+      let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+      if trimmed.isEmpty {
+        index += 1
+        continue
+      }
+
+      if trimmed.hasPrefix("```") {
+        index += 1
+        var codeLines = [String]()
+        while index < lines.count, !lines[index].trimmingCharacters(in: .whitespaces).hasPrefix("```") {
+          codeLines.append(lines[index])
+          index += 1
+        }
+        if index < lines.count {
+          index += 1
+        }
+        contents.append(.code(codeLines.joined(separator: "\n")))
+        continue
+      }
+
+      if let heading = heading(from: trimmed) {
+        contents.append(heading)
+        index += 1
+        continue
+      }
+
+      if trimmed.hasPrefix("|"), trimmed.hasSuffix("|") {
+        var rows = [[String]]()
+        while index < lines.count {
+          let candidate = lines[index].trimmingCharacters(in: .whitespaces)
+          guard candidate.hasPrefix("|"), candidate.hasSuffix("|") else { break }
+          let cells = candidate
+            .split(separator: "|", omittingEmptySubsequences: false)
+            .dropFirst()
+            .dropLast()
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+          if !cells.allSatisfy({ $0.allSatisfy { $0 == "-" || $0 == ":" } }) {
+            rows.append(cells)
+          }
+          index += 1
+        }
+        contents.append(.table(rows))
+        continue
+      }
+
+      if trimmed.hasPrefix("- ") {
+        var parts = [String(trimmed.dropFirst(2))]
+        index += 1
+        while index < lines.count, isContinuation(lines[index]) {
+          parts.append(lines[index].trimmingCharacters(in: .whitespaces))
+          index += 1
+        }
+        contents.append(.bullet(parts.joined(separator: " ")))
+        continue
+      }
+
+      var paragraphLines = [trimmed]
+      index += 1
+      while index < lines.count, isContinuation(lines[index]) {
+        paragraphLines.append(lines[index].trimmingCharacters(in: .whitespaces))
+        index += 1
+      }
+      contents.append(.paragraph(paragraphLines.joined(separator: " ")))
+    }
+
+    return contents.enumerated().map { Self(id: $0.offset, content: $0.element) }
+  }
+
+  private static func heading(from line: String) -> Content? {
+    let markerCount = line.prefix { $0 == "#" }.count
+    guard (1...3).contains(markerCount), line.dropFirst(markerCount).hasPrefix(" ") else {
+      return nil
+    }
+    return .heading(
+      level: markerCount,
+      text: String(line.dropFirst(markerCount + 1)),
+    )
+  }
+
+  private static func isContinuation(_ line: String) -> Bool {
+    let trimmed = line.trimmingCharacters(in: .whitespaces)
+    return !trimmed.isEmpty
+      && !trimmed.hasPrefix("#")
+      && !trimmed.hasPrefix("```")
+      && !trimmed.hasPrefix("- ")
+      && !(trimmed.hasPrefix("|") && trimmed.hasSuffix("|"))
+  }
+
+}

--- a/Tatami/Sources/Settings/HooksSettingsPane.swift
+++ b/Tatami/Sources/Settings/HooksSettingsPane.swift
@@ -139,8 +139,14 @@ private struct HookSummaryRow: View {
             .truncationMode(.middle)
           let argumentCount = max(0, row.definition.command.count - 1)
           if argumentCount > 0 {
-            Text("· \(argumentCount) arguments")
-              .foregroundStyle(.secondary)
+            Group {
+              if argumentCount == 1 {
+                Text("· 1 argument")
+              } else {
+                Text("· \(argumentCount) arguments")
+              }
+            }
+            .foregroundStyle(.secondary)
           }
         }
         .font(.caption.monospaced())
@@ -525,10 +531,20 @@ private struct HookProgramEditorSection: View {
     } footer: {
       VStack(alignment: .leading, spacing: 4) {
         Text(
-          "Enter the path to a program, an executable script, or a command-line shell such as `/bin/zsh` or `/opt/homebrew/bin/fish`. Shell locations vary, so use the full path returned by `which fish`. For a script without execute permission, choose its command-line shell and add the script path as the first argument."
+          """
+          Enter the path to a program, an executable script, or a command-line shell such as `/bin/zsh` or \
+          `/opt/homebrew/bin/fish`. Shell locations vary, so use the full path returned by `which fish`. For a \
+          script without execute permission, choose its command-line shell and add the script path as the first \
+          argument.
+          """
         )
         Text(
-          "Each argument is passed exactly as one argv value. To use shell syntax, choose a shell executable and add its flags explicitly. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments."
+          """
+          Each argument is passed exactly as one argv value. To use shell syntax, choose a command-line shell and \
+          add its flags explicitly. For fish, use `/opt/homebrew/bin/fish` and add `-c` and `command ls` as separate \
+          arguments. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as \
+          separate arguments.
+          """
         )
       }
     }
@@ -582,7 +598,11 @@ private struct HookExecutionEditorSection: View {
       Text("Execution")
     } footer: {
       Text(
-        "Working Directory is the hook process's current directory. Relative paths used by the program are resolved from it. Leave it empty to use Tatami's configuration directory. Timeout stops the process after the specified number of milliseconds."
+        """
+        Working Directory is the hook process's current directory. Relative paths used by the program are resolved \
+        from it. Leave it empty to use Tatami's configuration directory. Timeout stops the process after the \
+        specified number of milliseconds.
+        """
       )
     }
   }
@@ -646,7 +666,12 @@ private struct HookEnvironmentEditorSection: View {
     } header: {
       Text("Environment")
     } footer: {
-      Text("These values are added to Tatami's inherited environment for this hook.")
+      Text(
+        """
+        These values are added to Tatami's inherited environment for this hook. Tatami event variables take \
+        precedence when names match.
+        """
+      )
     }
   }
 }
@@ -848,22 +873,8 @@ extension HookEditorFeature.Mode {
 extension HookEditorFeature.ValidationIssue.Code {
   fileprivate var localizedMessage: LocalizedStringResource {
     switch self {
-    case .definition(.emptyID):
-      "Enter an identifier."
-    case .definition(.invalidID):
-      "Use only ASCII letters, numbers, period, underscore, or hyphen in the identifier."
-    case .definition(.duplicateID):
-      "Choose a unique identifier."
-    case .definition(.emptyCommand):
-      "Choose an executable."
-    case .definition(.nulCommand):
-      "Executable and arguments cannot contain NUL."
-    case .definition(.timeoutOutOfRange):
-      "Timeout must be between 100 and 300000 milliseconds."
-    case .definition(.invalidWorkingDirectory):
-      "Working directory must be absolute or start with ~/."
-    case .definition(.invalidEnvironment):
-      "Environment variable names must be valid and values cannot contain NUL."
+    case .definition(let code):
+      code.localizedMessage
     case .duplicateEnvironmentKey:
       "Environment variable names must be unique"
     case .noActiveProfile:

--- a/Tatami/Sources/Settings/HooksSettingsPane.swift
+++ b/Tatami/Sources/Settings/HooksSettingsPane.swift
@@ -1,0 +1,877 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import SwiftUI
+import TatamiKit
+import UniformTypeIdentifiers
+
+// MARK: - HooksSettingsPane
+
+struct HooksSettingsPane: View {
+  @Bindable var store: StoreOf<HookSettingsFeature>
+
+  var body: some View {
+    HooksIntroductionSection(
+      isDisabled: store.mutationInFlight != nil,
+      showsAddButton: !store.rows.isEmpty,
+      addHook: { store.send(.addButtonTapped) },
+    )
+
+    HooksListSection(
+      rows: store.rows,
+      mutationInFlight: store.mutationInFlight,
+      addHook: { store.send(.addButtonTapped) },
+      editHook: { store.send(.editButtonTapped($0)) },
+      deleteHook: { store.send(.deleteButtonTapped($0)) },
+      setEnabled: { store.send(.enabledChanged($0, $1)) },
+    )
+    .task { await store.send(.task).finish() }
+    .sheet(item: $store.scope(state: \.editor, action: \.editor)) { editorStore in
+      HookEditorView(store: editorStore)
+    }
+    .alert($store.scope(state: \.alert, action: \.alert))
+  }
+}
+
+// MARK: - HooksIntroductionSection
+
+private struct HooksIntroductionSection: View {
+  let isDisabled: Bool
+  let showsAddButton: Bool
+  let addHook: () -> Void
+
+  var body: some View {
+    Section {
+      HStack(alignment: .center, spacing: 16) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text("Run a program when Tatami launches, changes profile, or activates a workspace.")
+          Text("Commands run directly with the arguments and environment shown below. A shell is never added automatically.")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        Spacer(minLength: 12)
+        if showsAddButton {
+          Button(action: addHook) {
+            Label("Add Hook", systemImage: "plus")
+          }
+          .disabled(isDisabled)
+        }
+      }
+    } header: {
+      Text("Event Hooks")
+    }
+  }
+}
+
+// MARK: - HooksListSection
+
+private struct HooksListSection: View {
+  let rows: [HookSettingsFeature.Row]
+  let mutationInFlight: HookSettingsFeature.Mutation?
+  let addHook: () -> Void
+  let editHook: (HookLocator) -> Void
+  let deleteHook: (HookLocator) -> Void
+  let setEnabled: (HookLocator, Bool) -> Void
+
+  var body: some View {
+    Section {
+      if rows.isEmpty {
+        ContentUnavailableView {
+          Label("No Hooks", systemImage: "bolt.slash")
+        } description: {
+          Text("Add a hook to automate work outside Tatami.")
+        } actions: {
+          Button("Add Hook", action: addHook)
+            .disabled(mutationInFlight != nil)
+        }
+        .frame(maxWidth: .infinity, minHeight: 180)
+      } else {
+        ForEach(rows) { row in
+          HookSummaryRow(
+            row: row,
+            isDisabled: mutationInFlight != nil,
+            editHook: { editHook(row.locator) },
+            deleteHook: { deleteHook(row.locator) },
+            setEnabled: { setEnabled(row.locator, $0) },
+          )
+        }
+      }
+    } header: {
+      Text("Configured Hooks")
+    } footer: {
+      Text("Hooks receive a JSON event on standard input. Disabled or invalid hooks do not run.")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+// MARK: - HookSummaryRow
+
+private struct HookSummaryRow: View {
+
+  // MARK: Internal
+
+  let row: HookSettingsFeature.Row
+  let isDisabled: Bool
+  let editHook: () -> Void
+  let deleteHook: () -> Void
+  let setEnabled: (Bool) -> Void
+
+  var body: some View {
+    HStack(spacing: 12) {
+      Image(systemName: row.definition.event.symbolName)
+        .foregroundStyle(row.isValid ? AnyShapeStyle(.tint) : AnyShapeStyle(.orange))
+        .frame(width: 24)
+
+      VStack(alignment: .leading, spacing: 3) {
+        HStack(spacing: 7) {
+          Text(row.definition.id.isEmpty ? String(localized: "Unnamed Hook") : row.definition.id)
+            .fontWeight(.medium)
+          Text(row.definition.event.localizedTitle)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        HStack(spacing: 6) {
+          Text(executableDescription)
+            .lineLimit(1)
+            .truncationMode(.middle)
+          let argumentCount = max(0, row.definition.command.count - 1)
+          if argumentCount > 0 {
+            Text("· \(argumentCount) arguments")
+              .foregroundStyle(.secondary)
+          }
+        }
+        .font(.caption.monospaced())
+        if !row.isValid {
+          Label("Needs attention", systemImage: "exclamationmark.triangle.fill")
+            .font(.caption)
+            .foregroundStyle(.orange)
+        }
+      }
+
+      Spacer(minLength: 8)
+
+      Toggle("Enabled", isOn: Binding(
+        get: { row.definition.enabled },
+        set: { enabled in setEnabled(enabled) },
+      ))
+      .labelsHidden()
+      .disabled(isDisabled)
+      .help(row.definition.enabled ? "Disable this hook" : "Enable this hook")
+
+      Button("Edit", action: editHook)
+        .disabled(isDisabled)
+
+      Menu {
+        Button("Delete", role: .destructive, action: deleteHook)
+      } label: {
+        Image(systemName: "ellipsis.circle")
+      }
+      .menuStyle(.borderlessButton)
+      .fixedSize()
+      .disabled(isDisabled)
+      .accessibilityLabel("More actions for \(row.definition.id)")
+    }
+    .padding(.vertical, 3)
+  }
+
+  // MARK: Private
+
+  private var executableDescription: String {
+    guard let executable = row.definition.command.first, !executable.isEmpty else {
+      return String(localized: "Executable not set")
+    }
+    return executable
+  }
+
+}
+
+// MARK: - HookEditorView
+
+private struct HookEditorView: View {
+
+  // MARK: Internal
+
+  @Bindable var store: StoreOf<HookEditorFeature>
+
+  var body: some View {
+    NavigationStack {
+      VStack(spacing: 0) {
+        Form {
+          HookGeneralEditorSection(store: store)
+          HookProgramEditorSection(
+            store: store,
+            chooseExecutable: { isChoosingExecutable = true },
+          )
+          HookExecutionEditorSection(
+            store: store,
+            chooseWorkingDirectory: { isChoosingWorkingDirectory = true },
+          )
+          HookEnvironmentEditorSection(store: store)
+          HookTestSection(store: store)
+        }
+        .formStyle(.grouped)
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
+
+        Divider()
+
+        HookEditorBottomBar(
+          saveError: store.saveError,
+          validationIssues: visibleValidationIssues,
+          cancel: { store.send(.cancelButtonTapped) },
+          save: { store.send(.saveButtonTapped) },
+        )
+      }
+      .navigationTitle(store.mode.navigationTitle)
+    }
+    .frame(minWidth: 660, idealWidth: 720, minHeight: 620, idealHeight: 720)
+    .fileImporter(
+      isPresented: $isChoosingExecutable,
+      allowedContentTypes: [.unixExecutable],
+      allowsMultipleSelection: false,
+    ) { result in
+      guard let url = try? result.get().first else { return }
+      store.send(.executableChanged(url.path(percentEncoded: false)))
+    }
+    .fileImporter(
+      isPresented: $isChoosingWorkingDirectory,
+      allowedContentTypes: [.folder],
+      allowsMultipleSelection: false,
+    ) { result in
+      guard let url = try? result.get().first else { return }
+      store.send(.workingDirectoryChanged(url.path(percentEncoded: false)))
+    }
+  }
+
+  // MARK: Private
+
+  @State private var isChoosingExecutable = false
+  @State private var isChoosingWorkingDirectory = false
+
+  private var visibleValidationIssues: [HookEditorFeature.ValidationIssue] {
+    guard store.showsValidation || store.showsTestValidation else { return [] }
+    return store.showsTestValidation
+      ? store.testValidationIssues
+      : store.validationIssues
+  }
+
+}
+
+// MARK: - HookEditorBottomBar
+
+private struct HookEditorBottomBar: View {
+
+  let saveError: String?
+  let validationIssues: [HookEditorFeature.ValidationIssue]
+  let cancel: () -> Void
+  let save: () -> Void
+
+  var body: some View {
+    HStack(spacing: 12) {
+      HookEditorBottomBarStatus(
+        saveError: saveError,
+        validationIssues: validationIssues,
+      )
+      .layoutPriority(1)
+
+      Spacer(minLength: 0)
+
+      HStack(spacing: 8) {
+        Button("Cancel", role: .cancel, action: cancel)
+          .buttonStyle(.bordered)
+          .keyboardShortcut(.cancelAction)
+
+        Button("Save", action: save)
+          .buttonStyle(.borderedProminent)
+          .keyboardShortcut(.defaultAction)
+      }
+      .fixedSize()
+    }
+    .controlSize(.regular)
+    .padding(.horizontal, 16)
+    .padding(.vertical, 12)
+    .frame(maxWidth: .infinity)
+    .background(.regularMaterial)
+  }
+
+}
+
+// MARK: - HookEditorBottomBarStatus
+
+private struct HookEditorBottomBarStatus: View {
+
+  // MARK: Internal
+
+  let saveError: String?
+  let validationIssues: [HookEditorFeature.ValidationIssue]
+
+  var body: some View {
+    if saveError != nil || !validationIssues.isEmpty {
+      Button {
+        isShowingDetails.toggle()
+      } label: {
+        Label {
+          Text(summary)
+        } icon: {
+          Image(systemName: "exclamationmark.triangle.fill")
+        }
+        .lineLimit(1)
+      }
+      .buttonStyle(.plain)
+      .foregroundStyle(saveError == nil ? Color.orange : Color.red)
+      .help("Show error details")
+      .popover(isPresented: $isShowingDetails, arrowEdge: .bottom) {
+        details
+      }
+    }
+  }
+
+  // MARK: Private
+
+  @State private var isShowingDetails = false
+
+  private var summary: LocalizedStringResource {
+    if saveError != nil { return "Hook could not be saved" }
+    if validationIssues.count == 1, let issue = validationIssues.first {
+      return issue.code.localizedMessage
+    }
+    return "Check These Fields"
+  }
+
+  private var details: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Label {
+        Text(detailsTitle)
+      } icon: {
+        Image(systemName: "exclamationmark.triangle.fill")
+      }
+      .font(.headline)
+      .foregroundStyle(saveError == nil ? Color.orange : Color.red)
+
+      Divider()
+
+      if let saveError {
+        Text(saveError)
+          .textSelection(.enabled)
+      } else {
+        ForEach(validationIssues, id: \.self) { issue in
+          Text(issue.code.localizedMessage)
+        }
+      }
+    }
+    .frame(width: 340, alignment: .leading)
+    .padding()
+  }
+
+  private var detailsTitle: LocalizedStringResource {
+    saveError == nil ? "Check These Fields" : "Save Error"
+  }
+
+}
+
+// MARK: - HookGeneralEditorSection
+
+private struct HookGeneralEditorSection: View {
+  let store: StoreOf<HookEditorFeature>
+
+  var body: some View {
+    Section {
+      LabeledContent("Identifier") {
+        TextField(
+          "Hook identifier",
+          text: Binding(
+            get: { store.draft.id },
+            set: { store.send(.idChanged($0)) },
+          ),
+          prompt: Text(verbatim: "notify-team"),
+        )
+        .labelsHidden()
+        .textFieldStyle(.roundedBorder)
+        .frame(maxWidth: 360)
+        .accessibilityLabel("Hook identifier")
+      }
+
+      Picker("Event", selection: Binding(
+        get: { store.draft.event },
+        set: { store.send(.eventChanged($0)) },
+      )) {
+        ForEach(HookEvent.allCases, id: \.self) { event in
+          Text(event.localizedTitle).tag(event)
+        }
+      }
+      .pickerStyle(.menu)
+
+      HookEventDataSummary(event: store.draft.event)
+
+      Toggle("Enabled", isOn: Binding(
+        get: { store.draft.enabled },
+        set: { store.send(.enabledChanged($0)) },
+      ))
+    } header: {
+      Text("Hook")
+    } footer: {
+      Text("Choose a unique name for this hook, such as notify-team. Tatami also sends it as TATAMI_HOOK_ID.")
+    }
+  }
+}
+
+// MARK: - HookEventDataSummary
+
+private struct HookEventDataSummary: View {
+
+  // MARK: Internal
+
+  let event: HookEvent
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Label {
+        Text(event.localizedPayloadDescription)
+      } icon: {
+        Image(systemName: "info.circle")
+          .foregroundStyle(.tint)
+      }
+
+      dataRow("JSON Standard Input", value: event.jsonFields)
+      dataRow("Tatami Environment Variables", value: event.environmentVariables)
+
+      if event.hasOptionalPayload {
+        Text("A question mark means the value is included only when available.")
+          .font(.caption)
+          .foregroundStyle(.tertiary)
+      }
+    }
+    .font(.caption)
+    .padding(.vertical, 4)
+  }
+
+  // MARK: Private
+
+  private func dataRow(_ title: LocalizedStringResource, value: String) -> some View {
+    VStack(alignment: .leading, spacing: 3) {
+      Text(title)
+        .fontWeight(.semibold)
+        .foregroundStyle(.secondary)
+      Text(verbatim: value)
+        .font(.caption.monospaced())
+        .foregroundStyle(.secondary)
+        .textSelection(.enabled)
+    }
+  }
+
+}
+
+// MARK: - HookProgramEditorSection
+
+private struct HookProgramEditorSection: View {
+  let store: StoreOf<HookEditorFeature>
+  let chooseExecutable: () -> Void
+
+  var body: some View {
+    Section {
+      LabeledContent("Executable") {
+        HStack(spacing: 8) {
+          TextField(
+            "Executable",
+            text: Binding(
+              get: { store.draft.executable },
+              set: { store.send(.executableChanged($0)) },
+            ),
+            prompt: Text(verbatim: "/usr/local/bin/my-hook"),
+          )
+          .labelsHidden()
+          .textFieldStyle(.roundedBorder)
+          Button("Choose...", action: chooseExecutable)
+        }
+        .frame(maxWidth: 480)
+      }
+
+      ForEach(store.draft.arguments) { argument in
+        HStack(spacing: 8) {
+          TextField(
+            "Argument",
+            text: Binding(
+              get: {
+                store.draft.arguments.first(where: { $0.id == argument.id })?.value
+                  ?? argument.value
+              },
+              set: { store.send(.argumentValueChanged(argument.id, $0)) },
+            ),
+            prompt: Text("Argument"),
+          )
+          .labelsHidden()
+          .textFieldStyle(.roundedBorder)
+          .font(.body.monospaced())
+
+          Button(role: .destructive) {
+            store.send(.argumentDeleteButtonTapped(argument.id))
+          } label: {
+            Image(systemName: "minus.circle.fill")
+          }
+          .buttonStyle(.borderless)
+          .accessibilityLabel("Remove argument")
+        }
+      }
+
+      Button {
+        store.send(.argumentAddButtonTapped)
+      } label: {
+        Label("Add Argument", systemImage: "plus")
+      }
+    } header: {
+      Text("Program")
+    } footer: {
+      VStack(alignment: .leading, spacing: 4) {
+        Text(
+          "Enter the path to a program, an executable script, or a command-line shell such as `/bin/zsh` or `/opt/homebrew/bin/fish`. Shell locations vary, so use the full path returned by `which fish`. For a script without execute permission, choose its command-line shell and add the script path as the first argument."
+        )
+        Text(
+          "Each argument is passed exactly as one argv value. To use shell syntax, choose a shell executable and add its flags explicitly. To open a macOS app, use `/usr/bin/open` as the executable and add `-a` and the app name as separate arguments."
+        )
+      }
+    }
+  }
+}
+
+// MARK: - HookExecutionEditorSection
+
+private struct HookExecutionEditorSection: View {
+  let store: StoreOf<HookEditorFeature>
+  let chooseWorkingDirectory: () -> Void
+
+  var body: some View {
+    Section {
+      LabeledContent("Working Directory") {
+        HStack(spacing: 8) {
+          TextField(
+            "Working Directory",
+            text: Binding(
+              get: { store.draft.workingDirectory },
+              set: { store.send(.workingDirectoryChanged($0)) },
+            ),
+            prompt: Text("Tatami configuration directory (default)"),
+          )
+          .labelsHidden()
+          .textFieldStyle(.roundedBorder)
+          Button("Choose...", action: chooseWorkingDirectory)
+        }
+        .frame(maxWidth: 480)
+      }
+
+      LabeledContent("Timeout") {
+        HStack(spacing: 6) {
+          TextField(
+            "Timeout",
+            value: Binding(
+              get: { store.draft.timeoutMs },
+              set: { store.send(.timeoutChanged($0)) },
+            ),
+            format: .number,
+            prompt: Text(verbatim: "5000"),
+          )
+          .labelsHidden()
+          .textFieldStyle(.roundedBorder)
+          .frame(width: 100)
+          Text("ms")
+            .foregroundStyle(.secondary)
+        }
+      }
+    } header: {
+      Text("Execution")
+    } footer: {
+      Text(
+        "Working Directory is the hook process's current directory. Relative paths used by the program are resolved from it. Leave it empty to use Tatami's configuration directory. Timeout stops the process after the specified number of milliseconds."
+      )
+    }
+  }
+}
+
+// MARK: - HookEnvironmentEditorSection
+
+private struct HookEnvironmentEditorSection: View {
+  let store: StoreOf<HookEditorFeature>
+
+  var body: some View {
+    Section {
+      ForEach(store.draft.environment) { variable in
+        HStack(spacing: 8) {
+          TextField(
+            "Name",
+            text: Binding(
+              get: {
+                store.draft.environment.first(where: { $0.id == variable.id })?.key
+                  ?? variable.key
+              },
+              set: { store.send(.environmentKeyChanged(variable.id, $0)) },
+            ),
+            prompt: Text("Name"),
+          )
+          .labelsHidden()
+          .textFieldStyle(.roundedBorder)
+          .frame(maxWidth: 180)
+          .font(.body.monospaced())
+
+          TextField(
+            "Value",
+            text: Binding(
+              get: {
+                store.draft.environment.first(where: { $0.id == variable.id })?.value
+                  ?? variable.value
+              },
+              set: { store.send(.environmentValueChanged(variable.id, $0)) },
+            ),
+            prompt: Text("Value"),
+          )
+          .labelsHidden()
+          .textFieldStyle(.roundedBorder)
+          .font(.body.monospaced())
+
+          Button(role: .destructive) {
+            store.send(.environmentDeleteButtonTapped(variable.id))
+          } label: {
+            Image(systemName: "minus.circle.fill")
+          }
+          .buttonStyle(.borderless)
+          .accessibilityLabel("Remove environment variable")
+        }
+      }
+
+      Button {
+        store.send(.environmentAddButtonTapped)
+      } label: {
+        Label("Add Environment Variable", systemImage: "plus")
+      }
+    } header: {
+      Text("Environment")
+    } footer: {
+      Text("These values are added to Tatami's inherited environment for this hook.")
+    }
+  }
+}
+
+// MARK: - HookTestSection
+
+private struct HookTestSection: View {
+  let store: StoreOf<HookEditorFeature>
+
+  var body: some View {
+    Section {
+      if store.draft.event == .workspaceActivated {
+        Picker("Workspace", selection: Binding(
+          get: { store.testWorkspaceID },
+          set: { store.send(.testWorkspaceChanged($0)) },
+        )) {
+          if store.testWorkspaces.isEmpty {
+            Text("No normal workspaces").tag(Workspace.ID?.none)
+          } else {
+            ForEach(store.testWorkspaces) { workspace in
+              Text(workspace.name).tag(Workspace.ID?.some(workspace.id))
+            }
+          }
+        }
+        .pickerStyle(.menu)
+      }
+
+      HStack {
+        switch store.testStatus {
+        case .running:
+          ProgressView()
+            .controlSize(.small)
+          Text("Running test...")
+            .foregroundStyle(.secondary)
+          Spacer()
+          Button("Cancel Test") { store.send(.cancelTestButtonTapped) }
+
+        default:
+          Button {
+            store.send(.testButtonTapped)
+          } label: {
+            Label("Run Test", systemImage: "play.fill")
+          }
+        }
+      }
+
+      HookTestResultView(status: store.testStatus)
+    } header: {
+      Text("Test")
+    } footer: {
+      Text("Runs the current draft once with a sample event. Testing does not save the hook.")
+    }
+  }
+}
+
+// MARK: - HookTestResultView
+
+private struct HookTestResultView: View {
+  let status: HookEditorFeature.TestStatus
+
+  var body: some View {
+    switch status {
+    case .idle,
+         .running:
+      EmptyView()
+
+    case .succeeded(let stdout, let stderr):
+      Label("Test succeeded", systemImage: "checkmark.circle.fill")
+        .foregroundStyle(.green)
+      HookProcessOutput(stdout: stdout, stderr: stderr)
+
+    case .failed(let message, let stdout, let stderr):
+      Label(message, systemImage: "xmark.circle.fill")
+        .foregroundStyle(.red)
+        .textSelection(.enabled)
+      HookProcessOutput(stdout: stdout, stderr: stderr)
+
+    case .cancelled:
+      Label("Test cancelled", systemImage: "stop.circle")
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+// MARK: - HookProcessOutput
+
+private struct HookProcessOutput: View {
+
+  // MARK: Internal
+
+  let stdout: String
+  let stderr: String
+
+  var body: some View {
+    if !stdout.isEmpty {
+      output("Standard Output", value: stdout)
+    }
+    if !stderr.isEmpty {
+      output("Standard Error", value: stderr)
+    }
+  }
+
+  // MARK: Private
+
+  private func output(_ title: LocalizedStringResource, value: String) -> some View {
+    VStack(alignment: .leading, spacing: 5) {
+      Text(title)
+        .font(.caption.weight(.semibold))
+        .foregroundStyle(.secondary)
+      ScrollView {
+        Text(value)
+          .font(.caption.monospaced())
+          .textSelection(.enabled)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(8)
+      }
+      .frame(maxHeight: 120)
+      .background(.quaternary, in: RoundedRectangle(cornerRadius: 6))
+    }
+  }
+
+}
+
+extension HookEvent {
+  fileprivate var localizedTitle: LocalizedStringResource {
+    switch self {
+    case .profileChanged:
+      "Profile Changed"
+    case .tatamiLaunched:
+      "Tatami Launched"
+    case .workspaceActivated:
+      "Workspace Activated"
+    }
+  }
+
+  fileprivate var symbolName: String {
+    switch self {
+    case .profileChanged:
+      "rectangle.stack.badge.person.crop"
+    case .tatamiLaunched:
+      "power"
+    case .workspaceActivated:
+      "square.stack.3d.up"
+    }
+  }
+
+  fileprivate var localizedPayloadDescription: LocalizedStringResource {
+    switch self {
+    case .profileChanged:
+      "Provides the new profile and, when available, the previous profile."
+    case .tatamiLaunched:
+      "Provides the current profile when Tatami finishes launching."
+    case .workspaceActivated:
+      "Provides the profile, workspace, and, when available, the display."
+    }
+  }
+
+  fileprivate var jsonFields: String {
+    let base = "schemaVersion, event, occurredAt, profile { id, name }"
+    switch self {
+    case .profileChanged:
+      return base + ", previousProfile? { id, name }"
+    case .tatamiLaunched:
+      return base
+    case .workspaceActivated:
+      return base + ", workspace { id, name, kind }, display? { uuid?, name }"
+    }
+  }
+
+  fileprivate var environmentVariables: String {
+    let base = "TATAMI_HOOK_ID, TATAMI_HOOK_EVENT, TATAMI_PROFILE_ID, TATAMI_PROFILE_NAME"
+    switch self {
+    case .profileChanged,
+         .tatamiLaunched:
+      return base
+    case .workspaceActivated:
+      return base
+        + ", TATAMI_WORKSPACE_ID, TATAMI_WORKSPACE_NAME, TATAMI_WORKSPACE_KIND"
+        + ", TATAMI_DISPLAY_NAME?, TATAMI_DISPLAY_UUID?"
+    }
+  }
+
+  fileprivate var hasOptionalPayload: Bool {
+    self != .tatamiLaunched
+  }
+}
+
+extension HookEditorFeature.Mode {
+  fileprivate var navigationTitle: LocalizedStringResource {
+    switch self {
+    case .add:
+      "Add Hook"
+    case .edit:
+      "Edit Hook"
+    }
+  }
+}
+
+extension HookEditorFeature.ValidationIssue.Code {
+  fileprivate var localizedMessage: LocalizedStringResource {
+    switch self {
+    case .definition(.emptyID):
+      "Enter an identifier."
+    case .definition(.invalidID):
+      "Use only ASCII letters, numbers, period, underscore, or hyphen in the identifier."
+    case .definition(.duplicateID):
+      "Choose a unique identifier."
+    case .definition(.emptyCommand):
+      "Choose an executable."
+    case .definition(.nulCommand):
+      "Executable and arguments cannot contain NUL."
+    case .definition(.timeoutOutOfRange):
+      "Timeout must be between 100 and 300000 milliseconds."
+    case .definition(.invalidWorkingDirectory):
+      "Working directory must be absolute or start with ~/."
+    case .definition(.invalidEnvironment):
+      "Environment variable names must be valid and values cannot contain NUL."
+    case .duplicateEnvironmentKey:
+      "Environment variable names must be unique"
+    case .noActiveProfile:
+      "A profile is required to run this hook"
+    case .noWorkspace:
+      "Choose a workspace for the test event"
+    case .staleDefinition:
+      "The hook changed while it was being edited"
+    }
+  }
+}

--- a/Tatami/Sources/Settings/SettingsView+Panes.swift
+++ b/Tatami/Sources/Settings/SettingsView+Panes.swift
@@ -527,7 +527,7 @@ extension SettingsView {
         step: 0.0125,
         minLabel: "Low",
         maxLabel: "High",
-        detail: "How far you must swipe to switch — higher sensitivity needs a shorter swipe.",
+        detail: "How far you must swipe before the bound action runs. Higher sensitivity needs a shorter swipe.",
         readout: { "\(Int(($0 * 100).rounded()))%" },
         commit: { setting(\.gestures.sensitivity).wrappedValue = $0 },
       )

--- a/Tatami/Sources/Settings/SettingsView+Panes.swift
+++ b/Tatami/Sources/Settings/SettingsView+Panes.swift
@@ -121,10 +121,16 @@ extension SettingsView {
         }
       }
       Text(
-        "Symlinks `tatami` into /usr/local/bin so you can script Tatami from the terminal — e.g. `tatami activate <workspace>`, `tatami list-workspaces`."
+        "Symlinks `tatami` into /usr/local/bin for terminal scripting. For example: `tatami workspace list`, `tatami workspace activate <workspace>`."
       )
       .font(.caption)
       .foregroundStyle(.secondary)
+      Button {
+        isCLIReferencePresented = true
+      } label: {
+        Label("View CLI Guide…", systemImage: "book.pages")
+      }
+      .buttonStyle(.link)
     }
 
     Section("Debug") {
@@ -723,13 +729,24 @@ extension SettingsView {
         KeyEquivalentRecorder(
           key: shortcuts[keyPath: keyKP],
           modifierSymbols: "",
-          conflict: { keyEquivalentConflict($0, switch: switchAction, assign: assignAction, borrow: borrowAction) },
+          accessibilityLabel: "Key equivalent: \(String(localized: title))",
+          conflict: {
+            keyEquivalentConflict(
+              $0,
+              switch: switchAction,
+              switchOverride: shortcuts[keyPath: switchOverride],
+              assign: assignAction,
+              assignOverride: shortcuts[keyPath: assignOverride],
+              borrow: borrowAction,
+              borrowOverride: shortcuts[keyPath: borrowOverride],
+            )
+          },
           onRecordingChanged: { store.send(.shortcutRecordingChanged($0)) },
         ) { newKey in $config.withLock { $0.settings.shortcuts[keyPath: keyKP] = newKey } }
       }
-      navDerivedRow("Switch", \.keyEquivalentModifiers, keyKP, switchOverride, switchAction)
-      navDerivedRow("Assign", \.assignModifiers, keyKP, assignOverride, assignAction)
-      navDerivedRow("Borrow", \.borrowModifiers, keyKP, borrowOverride, borrowAction)
+      navDerivedRow("Switch", context: title, \.keyEquivalentModifiers, keyKP, switchOverride, switchAction)
+      navDerivedRow("Assign", context: title, \.assignModifiers, keyKP, assignOverride, assignAction)
+      navDerivedRow("Borrow", context: title, \.borrowModifiers, keyKP, borrowOverride, borrowAction)
     }
   }
 
@@ -738,6 +755,7 @@ extension SettingsView {
   @ViewBuilder
   func navDerivedRow(
     _ label: LocalizedStringResource,
+    context: LocalizedStringResource,
     _ modifiersKP: WritableKeyPath<AppSettings.Shortcuts, [String]>,
     _ keyKP: WritableKeyPath<AppSettings.Shortcuts, String?>,
     _ overrideKP: WritableKeyPath<AppSettings.Shortcuts, HotKey?>,
@@ -757,6 +775,7 @@ extension SettingsView {
       Text("or").font(.caption).foregroundStyle(.tertiary)
       ShortcutRecorder(
         hotKey: shortcuts[keyPath: overrideKP],
+        accessibilityLabel: "\(String(localized: label)): \(String(localized: context))",
         conflict: { config.shortcutConflict(for: $0, excluding: action) },
         onRecordingChanged: { store.send(.shortcutRecordingChanged($0)) },
       ) { hotKey in $config.withLock { $0.settings.shortcuts[keyPath: overrideKP] = hotKey } }
@@ -772,22 +791,21 @@ extension SettingsView {
   func keyEquivalentConflict(
     _ char: String,
     switch switchAction: HotKeyAction,
+    switchOverride: HotKey?,
     assign assignAction: HotKeyAction,
+    assignOverride: HotKey?,
     borrow borrowAction: HotKeyAction,
+    borrowOverride: HotKey?,
   ) -> String? {
-    guard let code = HotKey.keyCode(forName: char) else { return nil }
-    let s = config.settings.shortcuts
-    func check(_ tokens: [String], _ exclude: HotKeyAction) -> String? {
-      let mods = HotKey.carbonModifiers(from: tokens)
-      guard mods != 0 else { return nil }
-      return config.shortcutConflict(
-        for: HotKey(carbonKeyCode: code, carbonModifiers: mods),
-        excluding: exclude,
-      )
-    }
-    return check(s.keyEquivalentModifiers, switchAction)
-      ?? check(s.assignModifiers, assignAction)
-      ?? check(s.borrowModifiers, borrowAction)
+    config.navigationKeyEquivalentConflict(
+      for: char,
+      switchAction: switchAction,
+      switchOverride: switchOverride,
+      assignAction: assignAction,
+      assignOverride: assignOverride,
+      borrowAction: borrowAction,
+      borrowOverride: borrowOverride,
+    )
   }
 
   /// A labeled row of modifier toggle buttons (⌃⌥⇧⌘) editing one modifier
@@ -848,6 +866,7 @@ extension SettingsView {
       Spacer(minLength: 16)
       ShortcutRecorder(
         hotKey: config.settings.shortcuts[keyPath: keyPath],
+        accessibilityLabel: title,
         conflict: { config.shortcutConflict(for: $0, excluding: action) },
         onRecordingChanged: { store.send(.shortcutRecordingChanged($0)) },
       ) { hotKey in

--- a/Tatami/Sources/Settings/SettingsView.swift
+++ b/Tatami/Sources/Settings/SettingsView.swift
@@ -23,8 +23,8 @@ struct SettingsView: View {
     case workspaceKeys
     case focusMouse
     case gestures
-    case hooks
     case appearance
+    case hooks
 
     // MARK: Internal
 
@@ -80,8 +80,15 @@ struct SettingsView: View {
     NavigationSplitView {
       // `id: \.self` so the ForEach id type matches the selection type —
       // macOS only wires the selection gesture when they line up.
-      List(Pane.allCases, id: \.self, selection: $pane) { pane in
-        Label(pane.title, systemImage: pane.icon)
+      List(selection: $pane) {
+        ForEach(Pane.allCases.filter { $0 != .hooks }, id: \.self) { pane in
+          Label(pane.title, systemImage: pane.icon)
+            .tag(pane)
+        }
+        Section("Advanced") {
+          Label(Pane.hooks.title, systemImage: Pane.hooks.icon)
+            .tag(Pane.hooks)
+        }
       }
       .listStyle(.sidebar)
       .navigationSplitViewColumnWidth(min: 180, ideal: 200)

--- a/Tatami/Sources/Settings/SettingsView.swift
+++ b/Tatami/Sources/Settings/SettingsView.swift
@@ -13,20 +13,8 @@ import TatamiKit
 /// System-Settings-style layout: a sidebar of panes on the left, one
 /// grouped form per pane on the right.
 struct SettingsView: View {
-  /// A deep-link from elsewhere in the app (e.g. a workspace's derived
-  /// shortcut) requesting a specific pane. Routed into `pane`, then cleared
-  /// via `onSectionConsumed`.
-  var pendingSection: SettingsSection? = nil
-  var onSectionConsumed: () -> Void = {}
-  var onStartOnboarding: () -> Void = {}
 
-  @Shared(.tatamiConfig) var config = AppConfig()
-  // Not `private`: the pane bodies live in SettingsView+Panes.swift, a
-  // cross-file extension of this view.
-  @State var store = Store(initialState: SettingsFeature.State()) {
-    SettingsFeature()
-  }
-  @State private var pane: Pane? = .general
+  // MARK: Internal
 
   enum Pane: String, CaseIterable, Identifiable {
     case general
@@ -35,9 +23,14 @@ struct SettingsView: View {
     case workspaceKeys
     case focusMouse
     case gestures
+    case hooks
     case appearance
 
-    var id: String { rawValue }
+    // MARK: Internal
+
+    var id: String {
+      rawValue
+    }
 
     var title: LocalizedStringResource {
       switch self {
@@ -47,6 +40,7 @@ struct SettingsView: View {
       case .workspaceKeys: "Workspace Keys"
       case .focusMouse: "Focus & Mouse"
       case .gestures: "Gestures"
+      case .hooks: "Hooks"
       case .appearance: "Appearance"
       }
     }
@@ -59,10 +53,28 @@ struct SettingsView: View {
       case .workspaceKeys: "keyboard"
       case .focusMouse: "cursorarrow.motionlines"
       case .gestures: "hand.draw"
+      case .hooks: "bolt.circle"
       case .appearance: "paintbrush"
       }
     }
   }
+
+  /// A deep-link from elsewhere in the app (e.g. a workspace's derived
+  /// shortcut) requesting a specific pane. Routed into `pane`, then cleared
+  /// via `onSectionConsumed`.
+  var pendingSection: SettingsSection? = nil
+  var onSectionConsumed: () -> Void = { }
+  var onStartOnboarding: () -> Void = { }
+
+  @Shared(.tatamiConfig) var config
+
+  /// Not `private`: the pane bodies live in SettingsView+Panes.swift, a
+  /// cross-file extension of this view.
+  @State var store = Store(initialState: SettingsFeature.State()) {
+    SettingsFeature()
+  }
+
+  @State var isCLIReferencePresented = false
 
   var body: some View {
     NavigationSplitView {
@@ -77,11 +89,22 @@ struct SettingsView: View {
       Form {
         switch pane ?? .general {
         case .general: generalPane
+
         case .tiling: tilingPane
+
         case .workspaces: workspacesPane
+
         case .workspaceKeys: workspaceKeysPane
+
         case .focusMouse: focusMousePane
+
         case .gestures: gesturesPane
+
+        case .hooks:
+          HooksSettingsPane(
+            store: store.scope(state: \.hooks, action: \.hooks)
+          )
+
         case .appearance: appearancePane
         }
       }
@@ -89,6 +112,9 @@ struct SettingsView: View {
       .navigationTitle((pane ?? .general).title)
     }
     .alert($store.scope(state: \.alert, action: \.alert))
+    .sheet(isPresented: $isCLIReferencePresented) {
+      CLIReferenceView()
+    }
     .frame(minWidth: 680, minHeight: 540)
     // All side effects (status reads, permission/CLI/update streams, the AX
     // change subscription) live in the reducer — the view just starts it.
@@ -102,8 +128,6 @@ struct SettingsView: View {
     }
   }
 
-  // MARK: - Helpers
-
   /// SwiftUI `Color` binding backed by a hex-string field in settings.
   func borderColorBinding(
     _ keyPath: WritableKeyPath<AppSettings, String>
@@ -113,7 +137,7 @@ struct SettingsView: View {
       set: { newColor in
         guard let hex = newColor.toHex() else { return }
         $config.withLock { $0.settings[keyPath: keyPath] = hex }
-      }
+      },
     )
   }
 
@@ -126,7 +150,12 @@ struct SettingsView: View {
       get: { config.settings[keyPath: keyPath] },
       set: { newValue in
         $config.withLock { $0.settings[keyPath: keyPath] = newValue }
-      }
+      },
     )
   }
+
+  // MARK: Private
+
+  @State private var pane: Pane? = .general
+
 }

--- a/Tatami/Sources/Settings/ShortcutRecorder.swift
+++ b/Tatami/Sources/Settings/ShortcutRecorder.swift
@@ -15,6 +15,8 @@ import TatamiKit
 /// recording down whenever the Settings window wasn't key.
 struct ShortcutRecorder: View {
   let hotKey: HotKey?
+  /// Action-specific VoiceOver label supplied by the row that owns this field.
+  let accessibilityLabel: LocalizedStringResource
   /// Returns the name of another action already bound to a candidate combo,
   /// or nil if it's free (the recorder's own current key reads as free).
   var conflict: (HotKey) -> String? = { _ in nil }
@@ -24,10 +26,13 @@ struct ShortcutRecorder: View {
   var onRecordingChanged: (Bool) -> Void = { _ in }
   let onChange: (HotKey?) -> Void
 
+  @State private var presentedConflict: ShortcutConflictPresentation?
+
   var body: some View {
     HStack(spacing: 4) {
       field
         .frame(width: 150, height: 24)
+        .shortcutConflictPopover(item: $presentedConflict)
 
       Button {
         onChange(nil)
@@ -49,7 +54,12 @@ struct ShortcutRecorder: View {
   private var field: some View {
     let representable = RecorderRepresentable(
       hotKey: hotKey,
+      accessibilityLabel: String(localized: accessibilityLabel),
       conflict: conflict,
+      isConflictPresented: presentedConflict != nil,
+      onConflictPresentationChanged: { owner in
+        presentedConflict = owner.map { ShortcutConflictPresentation(owner: $0) }
+      },
       onRecordingChanged: onRecordingChanged,
       onChange: onChange
     )
@@ -74,7 +84,7 @@ struct ComboCapsule: View {
   var dimmed = false
 
   var body: some View {
-    Text(text.isEmpty ? "—" : text)
+    Text(text.isEmpty ? String(localized: "None") : text)
       .font(.system(size: 12, weight: .medium))
       .foregroundStyle(.secondary)
       .frame(width: 96, height: 24)
@@ -92,15 +102,20 @@ struct KeyEquivalentRecorder: View {
   let key: String?
   /// The switch-modifier glyphs shown before the key (e.g. `⌃⌥`).
   let modifierSymbols: String
+  /// Target-specific VoiceOver label supplied by the row that owns this field.
+  let accessibilityLabel: LocalizedStringResource
   /// Conflict title for a candidate key char, or nil if free.
   var conflict: (String) -> String? = { _ in nil }
   var onRecordingChanged: (Bool) -> Void = { _ in }
   let onChange: (String?) -> Void
 
+  @State private var presentedConflict: ShortcutConflictPresentation?
+
   var body: some View {
     HStack(spacing: 4) {
       field
         .frame(width: 96, height: 24)
+        .shortcutConflictPopover(item: $presentedConflict)
 
       Button {
         onChange(nil)
@@ -121,7 +136,12 @@ struct KeyEquivalentRecorder: View {
     let representable = KeyCapRepresentable(
       key: key,
       modifierSymbols: modifierSymbols,
+      accessibilityLabel: String(localized: accessibilityLabel),
       conflict: conflict,
+      isConflictPresented: presentedConflict != nil,
+      onConflictPresentationChanged: { owner in
+        presentedConflict = owner.map { ShortcutConflictPresentation(owner: $0) }
+      },
       onRecordingChanged: onRecordingChanged,
       onChange: onChange
     )
@@ -136,25 +156,38 @@ struct KeyEquivalentRecorder: View {
 private struct KeyCapRepresentable: NSViewRepresentable {
   let key: String?
   let modifierSymbols: String
+  let accessibilityLabel: String
   let conflict: (String) -> String?
+  let isConflictPresented: Bool
+  let onConflictPresentationChanged: (String?) -> Void
   let onRecordingChanged: (Bool) -> Void
   let onChange: (String?) -> Void
 
   func makeNSView(context _: Context) -> KeyCapField {
     let field = KeyCapField()
+    field.setAccessibilityElement(true)
+    field.setAccessibilityRole(.button)
+    field.setAccessibilityLabel(accessibilityLabel)
     field.onChange = onChange
     field.conflict = conflict
+    field.setConflictPresentationHandler(onConflictPresentationChanged)
     field.onRecordingChanged = onRecordingChanged
     field.modifierSymbols = modifierSymbols
     field.key = key
+    field.updateAccessibilityValue(announce: false)
     return field
   }
 
   func updateNSView(_ field: KeyCapField, context _: Context) {
     field.onChange = onChange
     field.conflict = conflict
+    field.setConflictPresentationHandler(onConflictPresentationChanged)
     field.onRecordingChanged = onRecordingChanged
+    field.setAccessibilityLabel(accessibilityLabel)
     field.modifierSymbols = modifierSymbols
+    if !isConflictPresented {
+      field.clearConflictFeedback()
+    }
     if !field.isRecording {
       field.key = key
     }
@@ -165,20 +198,34 @@ final class KeyCapField: NSView {
   var onChange: ((String?) -> Void)?
   var conflict: ((String) -> String?)?
   var onRecordingChanged: ((Bool) -> Void)?
-  var modifierSymbols = "" { didSet { needsDisplay = true } }
+  var modifierSymbols = "" {
+    didSet {
+      guard modifierSymbols != oldValue else { return }
+      needsDisplay = true
+      updateAccessibilityValue()
+    }
+  }
 
-  var key: String? { didSet { needsDisplay = true } }
+  var key: String? {
+    didSet {
+      guard key != oldValue else { return }
+      needsDisplay = true
+      updateAccessibilityValue()
+    }
+  }
 
   /// Local keyDown monitor active only while recording. A bare special key
   /// (Delete, arrows…) inside a SwiftUI Form/List is otherwise eaten by the
   /// responder chain before reaching `keyDown`; the monitor intercepts every
   /// keyDown app-wide and consumes the captured one.
   private var monitor: Any?
+  private lazy var conflictPresenter = ShortcutConflictPresenter(view: self)
 
   private(set) var isRecording = false {
     didSet {
       guard isRecording != oldValue else { return }
       needsDisplay = true
+      updateAccessibilityValue()
       onRecordingChanged?(isRecording)
     }
   }
@@ -188,13 +235,22 @@ final class KeyCapField: NSView {
   override func acceptsFirstMouse(for _: NSEvent?) -> Bool { true }
   override func becomeFirstResponder() -> Bool { true }
 
+  override func accessibilityPerformPress() -> Bool {
+    window?.makeFirstResponder(self)
+    startRecording()
+    return true
+  }
+
   override func resignFirstResponder() -> Bool {
     stopRecording()
     return true
   }
 
   override func viewWillMove(toWindow newWindow: NSWindow?) {
-    if newWindow == nil { stopRecording() }
+    if newWindow == nil {
+      stopRecording()
+      conflictPresenter.clear()
+    }
     super.viewWillMove(toWindow: newWindow)
   }
 
@@ -205,10 +261,23 @@ final class KeyCapField: NSView {
 
   private func startRecording() {
     guard monitor == nil else { return }
+    conflictPresenter.clear()
     isRecording = true
     monitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
       guard let self, self.isRecording else { return event }
       return self.record(event) ? nil : event
+    }
+  }
+
+  fileprivate func updateAccessibilityValue(announce: Bool = true) {
+    let value = if isRecording {
+      String(localized: "Recording")
+    } else {
+      key.map { modifierSymbols + HotKey.keySymbol(forName: $0) } ?? String(localized: "None")
+    }
+    setAccessibilityValue(value)
+    if announce, window != nil {
+      NSAccessibility.post(element: self, notification: .valueChanged)
     }
   }
 
@@ -240,17 +309,16 @@ final class KeyCapField: NSView {
     return true
   }
 
-  private var conflictResetTask: Task<Void, Never>?
-  private var conflictText: String? { didSet { needsDisplay = true } }
-
   private func showConflict(_ owner: String) {
-    conflictText = "In use: \(owner)"
-    conflictResetTask?.cancel()
-    conflictResetTask = Task { @MainActor [weak self] in
-      try? await Task.sleep(for: .seconds(1.8))
-      guard !Task.isCancelled, let self else { return }
-      conflictText = nil
-    }
+    conflictPresenter.show(owner: owner)
+  }
+
+  fileprivate func setConflictPresentationHandler(_ handler: @escaping (String?) -> Void) {
+    conflictPresenter.onPresentationChanged = handler
+  }
+
+  fileprivate func clearConflictFeedback() {
+    conflictPresenter.clear()
   }
 
   override func draw(_: NSRect) {
@@ -268,37 +336,36 @@ final class KeyCapField: NSView {
     let text: String
     let color: NSColor
     let bold: Bool
-    if let conflictText {
-      text = conflictText
+    let leadingSymbol: String?
+    if conflictPresenter.isPresenting {
+      text = String(localized: "In use")
       color = .systemOrange
       bold = true
+      leadingSymbol = "exclamationmark.triangle.fill"
     } else if isRecording {
       text = "Press a key\u{2026}"
       color = .secondaryLabelColor
       bold = false
+      leadingSymbol = nil
     } else if let key {
       text = modifierSymbols + HotKey.keySymbol(forName: key)
       color = .labelColor
       bold = true
+      leadingSymbol = nil
     } else {
       text = "Set key"
       color = .secondaryLabelColor
       bold = false
+      leadingSymbol = nil
     }
 
-    let style = NSMutableParagraphStyle()
-    style.alignment = .center
-    style.lineBreakMode = .byTruncatingTail
-    let attributes: [NSAttributedString.Key: Any] = [
-      .font: NSFont.systemFont(ofSize: 12, weight: bold ? .semibold : .regular),
-      .foregroundColor: color,
-      .paragraphStyle: style,
-    ]
-    let nsText = text as NSString
-    let height = nsText.size(withAttributes: attributes).height
-    nsText.draw(
-      in: NSRect(x: 6, y: (bounds.height - height) / 2, width: bounds.width - 12, height: height),
-      withAttributes: attributes
+    drawRecorderStatus(
+      in: bounds,
+      text: text,
+      color: color,
+      bold: bold,
+      leadingSymbol: leadingSymbol,
+      horizontalInset: 6
     )
   }
 }
@@ -307,23 +374,36 @@ final class KeyCapField: NSView {
 
 private struct RecorderRepresentable: NSViewRepresentable {
   let hotKey: HotKey?
+  let accessibilityLabel: String
   let conflict: (HotKey) -> String?
+  let isConflictPresented: Bool
+  let onConflictPresentationChanged: (String?) -> Void
   let onRecordingChanged: (Bool) -> Void
   let onChange: (HotKey?) -> Void
 
   func makeNSView(context _: Context) -> RecorderField {
     let field = RecorderField()
+    field.setAccessibilityElement(true)
+    field.setAccessibilityRole(.button)
+    field.setAccessibilityLabel(accessibilityLabel)
     field.onChange = onChange
     field.conflict = conflict
+    field.setConflictPresentationHandler(onConflictPresentationChanged)
     field.onRecordingChanged = onRecordingChanged
     field.hotKey = hotKey
+    field.updateAccessibilityValue(announce: false)
     return field
   }
 
   func updateNSView(_ field: RecorderField, context _: Context) {
     field.onChange = onChange
     field.conflict = conflict
+    field.setConflictPresentationHandler(onConflictPresentationChanged)
     field.onRecordingChanged = onRecordingChanged
+    field.setAccessibilityLabel(accessibilityLabel)
+    if !isConflictPresented {
+      field.clearConflictFeedback()
+    }
     // Don't clobber an in-progress recording with the bound value.
     if !field.isRecording {
       field.hotKey = hotKey
@@ -342,7 +422,14 @@ final class RecorderField: NSView {
   var onRecordingChanged: ((Bool) -> Void)?
 
   var hotKey: HotKey? {
-    didSet { needsDisplay = true }
+    didSet {
+      guard hotKey != oldValue else { return }
+      needsDisplay = true
+      setAccessibilityValue(hotKey?.symbols ?? String(localized: "None"))
+      if window != nil {
+        NSAccessibility.post(element: self, notification: .valueChanged)
+      }
+    }
   }
 
   /// Local keyDown monitor active only while recording. Capturing through a
@@ -350,11 +437,13 @@ final class RecorderField: NSView {
   /// (Backspace, arrows, Return…) the SwiftUI responder chain would otherwise
   /// swallow still reach the recorder.
   private var monitor: Any?
+  private lazy var conflictPresenter = ShortcutConflictPresenter(view: self)
 
   private(set) var isRecording = false {
     didSet {
       guard isRecording != oldValue else { return }
       needsDisplay = true
+      updateAccessibilityValue()
       onRecordingChanged?(isRecording)
     }
   }
@@ -373,23 +462,47 @@ final class RecorderField: NSView {
     true
   }
 
+  override func accessibilityPerformPress() -> Bool {
+    window?.makeFirstResponder(self)
+    startRecording()
+    return true
+  }
+
   override func resignFirstResponder() -> Bool {
     stopRecording()
     return true
   }
 
   override func viewWillMove(toWindow newWindow: NSWindow?) {
-    if newWindow == nil { stopRecording() }
+    if newWindow == nil {
+      stopRecording()
+      conflictPresenter.clear()
+    }
     super.viewWillMove(toWindow: newWindow)
   }
 
   override func mouseDown(with _: NSEvent) {
     window?.makeFirstResponder(self)
+    startRecording()
+  }
+
+  private func startRecording() {
     guard monitor == nil else { return }
+    conflictPresenter.clear()
     isRecording = true
     monitor = NSEvent.addLocalMonitorForEvents(matching: [.keyDown]) { [weak self] event in
       guard let self, self.isRecording else { return event }
       return self.record(event) ? nil : event
+    }
+  }
+
+  fileprivate func updateAccessibilityValue(announce: Bool = true) {
+    let value = isRecording
+      ? String(localized: "Recording")
+      : hotKey?.symbols ?? String(localized: "None")
+    setAccessibilityValue(value)
+    if announce, window != nil {
+      NSAccessibility.post(element: self, notification: .valueChanged)
     }
   }
 
@@ -415,47 +528,40 @@ final class RecorderField: NSView {
     let text: String
     let color: NSColor
     let bold: Bool
-    if let conflictText {
-      text = conflictText
+    let leadingSymbol: String?
+    if conflictPresenter.isPresenting {
+      text = String(localized: "In use")
       color = .systemOrange
       bold = true
+      leadingSymbol = "exclamationmark.triangle.fill"
     } else if isRecording {
       text = "Press shortcut\u{2026}"
       color = .secondaryLabelColor
       bold = false
+      leadingSymbol = nil
     } else if let hotKey {
       text = hotKey.symbols
       color = .labelColor
       bold = true
+      leadingSymbol = nil
     } else {
       text = "Set shortcut"
       color = .secondaryLabelColor
       bold = false
+      leadingSymbol = nil
     }
 
-    let style = NSMutableParagraphStyle()
-    style.alignment = .center
-    style.lineBreakMode = .byTruncatingTail
-    let attributes: [NSAttributedString.Key: Any] = [
-      .font: NSFont.systemFont(ofSize: 12, weight: bold ? .semibold : .regular),
-      .foregroundColor: color,
-      .paragraphStyle: style,
-    ]
-    let nsText = text as NSString
-    let height = nsText.size(withAttributes: attributes).height
-    nsText.draw(
-      in: NSRect(x: 8, y: (bounds.height - height) / 2, width: bounds.width - 16, height: height),
-      withAttributes: attributes
+    drawRecorderStatus(
+      in: bounds,
+      text: text,
+      color: color,
+      bold: bold,
+      leadingSymbol: leadingSymbol,
+      horizontalInset: 8
     )
   }
 
   // MARK: Private
-
-  private var conflictResetTask: Task<Void, Never>?
-
-  private var conflictText: String? {
-    didSet { needsDisplay = true }
-  }
 
   /// Carbon modifier masks (cmd 256, shift 512, option 2048, control 4096).
   private func carbonModifiers(_ flags: NSEvent.ModifierFlags) -> Int {
@@ -497,12 +603,179 @@ final class RecorderField: NSView {
   }
 
   private func showConflict(_ owner: String) {
-    conflictText = "In use: \(owner)"
-    conflictResetTask?.cancel()
-    conflictResetTask = Task { @MainActor [weak self] in
-      try? await Task.sleep(for: .seconds(1.8))
-      guard !Task.isCancelled, let self else { return }
-      conflictText = nil
+    conflictPresenter.show(owner: owner)
+  }
+
+  fileprivate func setConflictPresentationHandler(_ handler: @escaping (String?) -> Void) {
+    conflictPresenter.onPresentationChanged = handler
+  }
+
+  fileprivate func clearConflictFeedback() {
+    conflictPresenter.clear()
+  }
+}
+
+// MARK: - ShortcutConflictPresenter
+
+/// Keeps conflict feedback compact at every width while making the complete
+/// owner immediately readable. The recorder itself always shows the same short
+/// warning; the popover and hover/VoiceOver help carry the untruncated detail.
+@MainActor
+private final class ShortcutConflictPresenter {
+  init(view: NSView) {
+    self.view = view
+  }
+
+  private(set) var isPresenting = false
+  var onPresentationChanged: ((String?) -> Void)?
+
+  func show(owner: String) {
+    clear()
+    guard let view else { return }
+
+    let message = String(localized: "This shortcut is already used by \(owner).")
+    isPresenting = true
+    previousAccessibilityValue = view.accessibilityValue()
+    view.toolTip = message
+    view.setAccessibilityHelp(message)
+    view.setAccessibilityValue(message)
+    view.needsDisplay = true
+    NSAccessibility.post(
+      element: NSApp as Any,
+      notification: .announcementRequested,
+      userInfo: [
+        .announcement: message,
+        .priority: NSAccessibilityPriorityLevel.high.rawValue,
+      ]
+    )
+    onPresentationChanged?(owner)
+
+    resetTask = Task { @MainActor [weak self] in
+      try? await Task.sleep(for: .seconds(4))
+      guard !Task.isCancelled else { return }
+      self?.clear()
     }
   }
+
+  func clear() {
+    let wasPresenting = isPresenting
+    resetTask?.cancel()
+    resetTask = nil
+    isPresenting = false
+    view?.toolTip = nil
+    view?.setAccessibilityHelp(nil)
+    if wasPresenting {
+      view?.setAccessibilityValue(previousAccessibilityValue)
+    }
+    previousAccessibilityValue = nil
+    view?.needsDisplay = true
+    if wasPresenting {
+      onPresentationChanged?(nil)
+    }
+  }
+
+  private weak var view: NSView?
+  private var previousAccessibilityValue: Any?
+  private var resetTask: Task<Void, Never>?
+}
+
+// MARK: - ShortcutConflictPopover
+
+private struct ShortcutConflictPresentation: Identifiable {
+  let id = UUID()
+  let owner: String
+}
+
+private extension View {
+  func shortcutConflictPopover(
+    item: Binding<ShortcutConflictPresentation?>
+  ) -> some View {
+    popover(
+      item: item,
+      attachmentAnchor: .rect(.bounds),
+      arrowEdge: .trailing,
+    ) { presentation in
+      ShortcutConflictPopover(owner: presentation.owner)
+    }
+  }
+}
+
+private struct ShortcutConflictPopover: View {
+  let owner: String
+
+  var body: some View {
+    Label {
+      Text(
+        "This shortcut is already used by \(owner).",
+        comment: "Shortcut recorder conflict. The variable is the action already using the shortcut."
+      )
+      .fixedSize(horizontal: false, vertical: true)
+    } icon: {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .foregroundStyle(.orange)
+    }
+    .padding(12)
+    .frame(width: 280, alignment: .leading)
+  }
+}
+
+@MainActor
+private func drawRecorderStatus(
+  in bounds: NSRect,
+  text: String,
+  color: NSColor,
+  bold: Bool,
+  leadingSymbol: String?,
+  horizontalInset: CGFloat
+) {
+  let style = NSMutableParagraphStyle()
+  style.alignment = .center
+  style.lineBreakMode = .byTruncatingTail
+  let attributes: [NSAttributedString.Key: Any] = [
+    .font: NSFont.systemFont(ofSize: 12, weight: bold ? .semibold : .regular),
+    .foregroundColor: color,
+    .paragraphStyle: style,
+  ]
+  let nsText = text as NSString
+  let textSize = nsText.size(withAttributes: attributes)
+  let iconSize: CGFloat = leadingSymbol == nil ? 0 : 12
+  let spacing: CGFloat = leadingSymbol == nil ? 0 : 4
+  let availableWidth = max(0, bounds.width - horizontalInset * 2)
+  let textWidth = min(textSize.width, max(0, availableWidth - iconSize - spacing))
+  let totalWidth = iconSize + spacing + textWidth
+  let originX = max(horizontalInset, (bounds.width - totalWidth) / 2)
+
+  if
+    let leadingSymbol,
+    let image = NSImage(systemSymbolName: leadingSymbol, accessibilityDescription: nil)?
+      .withSymbolConfiguration(
+        NSImage.SymbolConfiguration(pointSize: 11, weight: .semibold)
+          .applying(.init(hierarchicalColor: color))
+      )
+  {
+    image.draw(
+      in: NSRect(
+        x: originX,
+        y: (bounds.height - iconSize) / 2,
+        width: iconSize,
+        height: iconSize
+      ),
+      from: .zero,
+      operation: .sourceOver,
+      fraction: 1,
+      respectFlipped: true,
+      hints: nil
+    )
+  }
+
+  let textX = originX + iconSize + spacing
+  nsText.draw(
+    in: NSRect(
+      x: textX,
+      y: (bounds.height - textSize.height) / 2,
+      width: textWidth,
+      height: textSize.height
+    ),
+    withAttributes: attributes
+  )
 }

--- a/Tatami/Sources/TatamiApp.swift
+++ b/Tatami/Sources/TatamiApp.swift
@@ -2,20 +2,26 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import ComposableArchitecture
+import Darwin
 import SwiftUI
 import TatamiKit
 
+// MARK: - TatamiApp
+
 @main
 struct TatamiApp: App {
+
+  // MARK: Lifecycle
+
   init() {
+    Self.applyProcessPathOverrides()
     try? ConfigLocation.ensureDirectoryExists()
+    _appStore = State(initialValue: Store(initialState: AppFeature.State()) {
+      AppFeature()
+    })
   }
 
-  @State private var appStore = Store(initialState: AppFeature.State()) {
-    AppFeature()
-  }
-
-  @State private var windowActivation = WindowActivationCoordinator()
+  // MARK: Internal
 
   var body: some Scene {
     Window("Tatami", id: "main") {
@@ -47,16 +53,45 @@ struct TatamiApp: App {
     }
     .menuBarExtraStyle(.menu)
   }
+
+  // MARK: Private
+
+  @State private var appStore: StoreOf<AppFeature>
+
+  @State private var windowActivation = WindowActivationCoordinator()
+
+  /// Development-only launch isolation used by side-by-side builds. Applying
+  /// these before `AppFeature.State` is constructed keeps both the config and
+  /// CLI socket away from an installed Tatami instance.
+  private static func applyProcessPathOverrides() {
+    let arguments = CommandLine.arguments
+    for (flag, environmentKey) in [
+      ("--tatami-config-home", "XDG_CONFIG_HOME"),
+      ("--tatami-socket-path", "TATAMI_SOCKET_PATH"),
+    ] {
+      guard
+        let index = arguments.firstIndex(of: flag),
+        arguments.indices.contains(index + 1),
+        arguments[index + 1].hasPrefix("/")
+      else { continue }
+      setenv(environmentKey, arguments[index + 1], 1)
+    }
+  }
+
 }
+
+// MARK: - WindowActivationCoordinator
 
 @MainActor
 private final class WindowActivationCoordinator {
-  private var visibleWindowIDs = Set<String>()
-  private var menuBarActivity: NSObjectProtocol?
+
+  // MARK: Lifecycle
 
   init() {
     beginMenuBarActivity()
   }
+
+  // MARK: Internal
 
   func appeared(_ id: String) {
     visibleWindowIDs.insert(id)
@@ -73,6 +108,11 @@ private final class WindowActivationCoordinator {
     }
   }
 
+  // MARK: Private
+
+  private var visibleWindowIDs = Set<String>()
+  private var menuBarActivity: NSObjectProtocol?
+
   /// An LSUIElement app with no visible window is otherwise a strong App Nap
   /// candidate. Tatami is still an interactive window manager in that state:
   /// global hotkeys and gestures are user-requested work that must begin
@@ -82,7 +122,7 @@ private final class WindowActivationCoordinator {
     guard menuBarActivity == nil else { return }
     menuBarActivity = ProcessInfo.processInfo.beginActivity(
       options: .userInitiatedAllowingIdleSystemSleep,
-      reason: "Tatami is waiting for interactive window-management commands"
+      reason: "Tatami is waiting for interactive window-management commands",
     )
   }
 
@@ -91,7 +131,10 @@ private final class WindowActivationCoordinator {
     ProcessInfo.processInfo.endActivity(menuBarActivity)
     self.menuBarActivity = nil
   }
+
 }
+
+// MARK: - RegularWhileOpen
 
 private struct RegularWhileOpen: ViewModifier {
   let id: String
@@ -107,17 +150,17 @@ private struct RegularWhileOpen: ViewModifier {
 extension View {
   fileprivate func regularWhileOpen(
     id: String,
-    coordinator: WindowActivationCoordinator
+    coordinator: WindowActivationCoordinator,
   ) -> some View {
     modifier(RegularWhileOpen(id: id, coordinator: coordinator))
   }
 }
 
+// MARK: - OpenSettingsButton
+
 /// Opens the main window. A dedicated view so it can read the `openWindow`
 /// environment action from inside `.commands`.
 private struct OpenSettingsButton: View {
-  @Environment(\.openWindow) private var openWindow
-
   var body: some View {
     Button("Settings…") {
       openWindow(id: "main")
@@ -125,4 +168,6 @@ private struct OpenSettingsButton: View {
     }
     .keyboardShortcut(",", modifiers: .command)
   }
+
+  @Environment(\.openWindow) private var openWindow
 }

--- a/Tatami/Sources/WorkspaceDetail/ProfileDetailView.swift
+++ b/Tatami/Sources/WorkspaceDetail/ProfileDetailView.swift
@@ -14,7 +14,7 @@ private enum DisplayReq: Hashable { case any, required, excluded }
 struct ProfileDetailView: View {
   @Bindable var store: StoreOf<ProfileDetailFeature>
   @State private var symbolPickerPresented = false
-  @State private var syncSource: Profile?
+  @State private var syncReview: ProfileSyncReview?
 
   var body: some View {
     if let profile = store.profile {
@@ -43,15 +43,23 @@ struct ProfileDetailView: View {
             }
           }
 
-          TextField("Name", text: Binding(
-            get: { profile.name },
-            set: { store.send(.nameChanged($0)) }
-          ))
+          HStack {
+            Text("Name")
+            Spacer(minLength: 16)
+            TextField("", text: Binding(
+              get: { profile.name },
+              set: { store.send(.nameChanged($0)) },
+            ))
+            .textFieldStyle(.roundedBorder)
+            .frame(maxWidth: 360)
+            .accessibilityLabel("Name")
+          }
         }
 
         Section {
           ShortcutRecorder(
             hotKey: profile.shortcut,
+            accessibilityLabel: "Switch Shortcut",
             conflict: { store.state.shortcutConflict(for: $0) },
             onRecordingChanged: { store.send(.shortcutRecordingChanged($0)) },
             onChange: { store.send(.shortcutChanged($0)) }
@@ -88,15 +96,19 @@ struct ProfileDetailView: View {
       // pane view is reused, just re-scoped to a fresh state). Mirrors
       // WorkspaceDetailView.
       .task(id: store.profileId) { store.send(.onAppear) }
-      .sheet(item: $syncSource) { source in
+      .sheet(item: $syncReview) { review in
         SyncPreviewSheet(
-          title: "Copy from “\(source.name)”",
-          message: "Copy each change from “\(source.name)” into this profile's matching workspaces (by name). Uncheck anything you'd rather keep.",
+          title: "Copy from “\(review.source.name)”",
+          message: "Copy each change from “\(review.source.name)” into this profile's matching workspaces (by name). Uncheck anything you'd rather keep.",
           applyTitle: "Copy",
-          groups: profileSyncGroups(from: source),
-          onApply: { excluded in applyProfileSync(from: source, excluding: excluded) }
+          groups: profileSyncGroups(review),
+          validateSelection: { excluded in
+            profileSyncConflicts(review, excluding: excluded)
+          },
+          onApply: { excluded in applyProfileSync(review, excluding: excluded) }
         )
       }
+      .alert($store.scope(state: \.alert, action: \.alert))
     } else {
       ContentUnavailableView(
         "Profile Unavailable",
@@ -108,9 +120,9 @@ struct ProfileDetailView: View {
 
   // MARK: - Sync apps from another profile
 
-  /// Profiles keep independent workspaces, so app assignments can drift between
-  /// them. This copies another profile's apps into the same-named workspaces
-  /// here, leaving each workspace's display / key / layout untouched.
+  /// Profiles keep independent workspaces, so assignments and settings can
+  /// drift. This previews another profile's apps and workspace settings for
+  /// same-named workspaces, then copies only the changes the user selects.
   @ViewBuilder
   private var syncSection: some View {
     let others = store.config.profiles.filter { $0.id != store.profileId }
@@ -143,7 +155,16 @@ struct ProfileDetailView: View {
           .foregroundStyle(diverged.isEmpty ? Color.secondary : Color.orange)
       }
       Spacer()
-      Button("Copy from…") { syncSource = source }
+      Button("Copy from…") {
+        let baseline = store.config
+        guard let snapshot = baseline.profiles.first(where: { $0.id == source.id })
+        else { return }
+        syncReview = ProfileSyncReview(
+          baseline: baseline,
+          source: snapshot,
+          targetProfileId: store.profileId
+        )
+      }
         .disabled(diverged.isEmpty)
     }
   }
@@ -151,11 +172,12 @@ struct ProfileDetailView: View {
   /// One group per this-profile workspace that has changes vs the same-named
   /// source workspace; items are namespaced by workspace id so `onApply` can
   /// map excluded ids back per workspace.
-  private func profileSyncGroups(from source: Profile) -> [SyncChangeGroup] {
-    guard let target = store.config.profiles.first(where: { $0.id == store.profileId }) else { return [] }
+  private func profileSyncGroups(_ review: ProfileSyncReview) -> [SyncChangeGroup] {
+    guard let target = review.baseline.profiles.first(where: { $0.id == review.targetProfileId })
+    else { return [] }
     var groups: [SyncChangeGroup] = []
     for ws in target.workspaces {
-      guard let match = source.workspaces.first(where: { $0.name == ws.name }) else { continue }
+      guard let match = review.source.workspaces.first(where: { $0.name == ws.name }) else { continue }
       let appChanges = WorkspaceSync.appChanges(from: match.apps, to: ws.apps)
       let fieldChanges = WorkspaceSync.fieldChanges(from: match, to: ws)
       guard !appChanges.isEmpty || !fieldChanges.isEmpty else { continue }
@@ -170,7 +192,43 @@ struct ProfileDetailView: View {
     return groups
   }
 
-  private func applyProfileSync(from source: Profile, excluding excluded: Set<String>) {
+  private func applyProfileSync(
+    _ review: ProfileSyncReview,
+    excluding excluded: Set<String>
+  ) {
+    let exclusions = profileSyncExclusions(excluded)
+    store.send(.applyProfileSync(
+      target: review.targetProfileId,
+      source: review.source.id,
+      baseline: review.baseline,
+      excludedApps: exclusions.apps,
+      excludedFields: exclusions.fields
+    ))
+  }
+
+  /// Validate exactly the options currently effective in the sheet by applying
+  /// them to a temporary config. Grouping by the chooser's namespaced field id
+  /// lets a conflict involving two selected workspaces highlight both rows.
+  private func profileSyncConflicts(
+    _ review: ProfileSyncReview,
+    excluding excluded: Set<String>
+  ) -> [String: [WorkspaceShortcutConflict]] {
+    let exclusions = profileSyncExclusions(excluded)
+    guard let projection = review.baseline.profileSyncProjection(
+      into: review.targetProfileId,
+      from: review.source.id,
+      excludedAppsByWorkspace: exclusions.apps,
+      excludedFieldsByWorkspace: exclusions.fields
+    ) else { return [:] }
+    return Dictionary(grouping: projection.conflicts) { conflict in
+      let prefix = "\(conflict.selection.workspaceId.uuidString):"
+      return SyncChangeItem.fieldId(prefix, conflict.selection.field.rawValue)
+    }
+  }
+
+  private func profileSyncExclusions(
+    _ excluded: Set<String>
+  ) -> (apps: [Workspace.ID: Set<String>], fields: [Workspace.ID: Set<String>]) {
     var excApps: [Workspace.ID: Set<String>] = [:]
     var excFields: [Workspace.ID: Set<String>] = [:]
     for id in excluded {
@@ -181,7 +239,17 @@ struct ProfileDetailView: View {
       if parts[1] == "app" { excApps[wsId, default: []].insert(key) }
       else if parts[1] == "field" { excFields[wsId, default: []].insert(key) }
     }
-    store.send(.applyProfileSync(source: source.id, excludedApps: excApps, excludedFields: excFields))
+    return (excApps, excFields)
+  }
+
+  private struct ProfileSyncReview: Identifiable {
+    let baseline: AppConfig
+    let source: Profile
+    let targetProfileId: Profile.ID
+
+    var id: String {
+      "\(targetProfileId.uuidString):\(source.id.uuidString)"
+    }
   }
 
   // MARK: - Auto-activation editor

--- a/Tatami/Sources/WorkspaceDetail/SyncPreviewSheet.swift
+++ b/Tatami/Sources/WorkspaceDetail/SyncPreviewSheet.swift
@@ -8,6 +8,10 @@ import TatamiKit
 /// caller so it can map an excluded id back to a workspace + app/field.
 struct SyncChangeItem: Identifiable {
   let id: String
+  /// Optional parent toggle. When it is off this item stays remembered but is
+  /// disabled and treated as excluded, so re-enabling the parent restores the
+  /// user's per-item choices.
+  let parentId: String?
   let title: String
   let detail: String
   /// Colors the detail line — conveys add (green) / remove (red) / change.
@@ -18,6 +22,28 @@ struct SyncChangeItem: Identifiable {
   /// When set, the leading glyph is the app's real icon instead of a symbol.
   let appBundleId: String?
   let appIconPath: String?
+
+  init(
+    id: String,
+    parentId: String? = nil,
+    title: String,
+    detail: String,
+    detailTint: Color,
+    symbol: String?,
+    symbolTint: Color,
+    appBundleId: String?,
+    appIconPath: String?
+  ) {
+    self.id = id
+    self.parentId = parentId
+    self.title = title
+    self.detail = detail
+    self.detailTint = detailTint
+    self.symbol = symbol
+    self.symbolTint = symbolTint
+    self.appBundleId = appBundleId
+    self.appIconPath = appIconPath
+  }
 }
 
 /// A titled group of changes (a workspace, or "Apps" / "Settings"). `symbol`
@@ -35,7 +61,7 @@ extension SyncChangeItem {
   /// Field-id key (namespaced): `"<prefix>field:<fieldId>"`.
   static func fieldId(_ prefix: String, _ fieldId: String) -> String { "\(prefix)field:\(fieldId)" }
 
-  init(_ change: AppChange, prefix: String) {
+  init(_ change: AppChange, prefix: String, parentId: String? = nil) {
     let title: String, detail: String, tint: Color, app: AppAssignment
     switch change.kind {
     case .add(let a):
@@ -67,13 +93,14 @@ extension SyncChangeItem {
       (title, detail, tint, app) = (after.name, parts.joined(separator: " · "), .orange, after)
     }
     self.init(
-      id: Self.appId(prefix, change.bundleId), title: title, detail: detail, detailTint: tint,
+      id: Self.appId(prefix, change.bundleId), parentId: parentId,
+      title: title, detail: detail, detailTint: tint,
       symbol: nil, symbolTint: .secondary,
       appBundleId: app.bundleIdentifier, appIconPath: app.iconPath
     )
   }
 
-  init(_ change: WorkspaceFieldChange, prefix: String) {
+  init(_ change: WorkspaceFieldChange, prefix: String, parentId: String? = nil) {
     var symbol = "pencil"
     var symbolTint: Color = .secondary
     var appBundleId: String?
@@ -92,7 +119,8 @@ extension SyncChangeItem {
     case .activateShortcut, .assignAppShortcut, .borrowShortcut: symbol = "command"
     }
     self.init(
-      id: Self.fieldId(prefix, change.id), title: String(localized: change.label),
+      id: Self.fieldId(prefix, change.id), parentId: parentId,
+      title: String(localized: change.label),
       detail: "\(change.beforeText) → \(change.afterText)", detailTint: .secondary,
       symbol: appBundleId == nil ? symbol : nil, symbolTint: symbolTint,
       appBundleId: appBundleId, appIconPath: nil
@@ -107,6 +135,13 @@ struct SyncPreviewSheet: View {
   let message: LocalizedStringResource
   let applyTitle: LocalizedStringResource
   let groups: [SyncChangeGroup]
+  /// Duplicate can intentionally create an empty shell after every content
+  /// option is unchecked. Existing Copy flows still require one selection.
+  let allowsEmptySelection: Bool
+  /// Validates the complete effective selection after projecting it into the
+  /// destination config. Keys are chooser item ids so each contributing field
+  /// can explain why Apply is unavailable.
+  let validateSelection: (_ excludedItemIds: Set<String>) -> [String: [WorkspaceShortcutConflict]]
   let onApply: (_ excludedItemIds: Set<String>) -> Void
 
   @Environment(\.dismiss) private var dismiss
@@ -117,38 +152,64 @@ struct SyncPreviewSheet: View {
     message: LocalizedStringResource,
     applyTitle: LocalizedStringResource = "Apply",
     groups: [SyncChangeGroup],
+    allowsEmptySelection: Bool = false,
+    validateSelection: @escaping (Set<String>) -> [String: [WorkspaceShortcutConflict]] = { _ in [:] },
     onApply: @escaping (Set<String>) -> Void
   ) {
     self.title = title
     self.message = message
     self.applyTitle = applyTitle
     self.groups = groups
+    self.allowsEmptySelection = allowsEmptySelection
+    self.validateSelection = validateSelection
     self.onApply = onApply
     _selected = State(initialValue: Set(groups.flatMap { $0.items.map(\.id) }))
   }
 
   private var allIds: Set<String> { Set(groups.flatMap { $0.items.map(\.id) }) }
 
+  private var effectiveSelection: Set<String> {
+    let parentByItemID = Dictionary(
+      uniqueKeysWithValues: groups.flatMap(\.items).compactMap { item in
+        item.parentId.map { (item.id, $0) }
+      }
+    )
+    return WorkspaceSync.effectiveSelection(
+      selected: selected,
+      validIDs: allIds,
+      parentByItemID: parentByItemID
+    )
+  }
+
   var body: some View {
+    let selection = effectiveSelection
+    let excluded = allIds.subtracting(selection)
+    let conflictsByItem = validateSelection(excluded)
+    let hasShortcutConflicts = !conflictsByItem.values.allSatisfy(\.isEmpty)
+
     NavigationStack {
       Form {
         Section {
           Text(message).font(.callout).foregroundStyle(.secondary)
+          if hasShortcutConflicts {
+            Label {
+              Text("Deselect the highlighted shortcut changes to continue.")
+            } icon: {
+              Image(systemName: "exclamationmark.triangle.fill")
+            }
+            .font(.callout)
+            .foregroundStyle(.orange)
+          }
         }
         ForEach(groups) { group in
           Section {
             ForEach(group.items) { item in
-              Toggle(isOn: binding(for: item.id)) {
-                HStack(spacing: 8) {
-                  leading(item).frame(width: 20, height: 20)
-                  VStack(alignment: .leading, spacing: 2) {
-                    Text(item.title)
-                    if !item.detail.isEmpty {
-                      Text(item.detail).font(.caption).foregroundStyle(item.detailTint)
-                    }
-                  }
-                }
-              }
+              SyncChangeRow(
+                item: item,
+                conflicts: conflictsByItem[item.id] ?? [],
+                isSelected: $selected[contains: item.id],
+                isParentSelected: item.parentId.map(selected.contains) ?? true,
+              )
             }
           } header: {
             if let symbol = group.symbol {
@@ -167,18 +228,67 @@ struct SyncPreviewSheet: View {
         }
         ToolbarItem(placement: .confirmationAction) {
           Button(applyTitle) {
-            onApply(allIds.subtracting(selected))
+            onApply(excluded)
             dismiss()
           }
-          .disabled(selected.isEmpty)
+          .disabled((!allowsEmptySelection && selection.isEmpty) || hasShortcutConflicts)
+          .help(
+            hasShortcutConflicts
+              ? "Deselect the conflicting shortcut changes before applying."
+              : ""
+          )
         }
       }
     }
     .frame(width: 480, height: 560)
   }
+}
+
+private struct SyncChangeRow: View {
+  let item: SyncChangeItem
+  let conflicts: [WorkspaceShortcutConflict]
+  @Binding var isSelected: Bool
+  let isParentSelected: Bool
+
+  var body: some View {
+    Toggle(isOn: $isSelected) {
+      HStack(spacing: 8) {
+        leading.frame(width: 20, height: 20)
+        VStack(alignment: .leading, spacing: 2) {
+          Text(item.title)
+          if !item.detail.isEmpty {
+            Text(item.detail)
+              .font(.caption)
+              .foregroundStyle(item.detailTint)
+          }
+          if !conflicts.isEmpty {
+            Label {
+              Text("Conflicts with \(conflictDescriptions)")
+            } icon: {
+              Image(systemName: "exclamationmark.triangle.fill")
+            }
+            .font(.caption)
+            .foregroundStyle(.orange)
+          }
+        }
+      }
+    }
+    .disabled(!isParentSelected)
+    .accessibilityHint(
+      conflicts.isEmpty
+        ? ""
+        : "Deselect this change to resolve the shortcut conflict."
+    )
+  }
+
+  private var conflictDescriptions: String {
+    Set(conflicts.map { "\($0.hotKey.symbols): \($0.owner)" })
+      .sorted()
+      .formatted()
+  }
 
   @ViewBuilder
-  private func leading(_ item: SyncChangeItem) -> some View {
+  private var leading: some View {
     if let bundleId = item.appBundleId {
       AppIcon(bundleIdentifier: bundleId, iconPath: item.appIconPath)
     } else if let symbol = item.symbol {
@@ -187,11 +297,17 @@ struct SyncPreviewSheet: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
   }
+}
 
-  private func binding(for id: String) -> Binding<Bool> {
-    Binding(
-      get: { selected.contains(id) },
-      set: { on in if on { selected.insert(id) } else { selected.remove(id) } }
-    )
+private extension Set {
+  subscript(contains element: Element) -> Bool {
+    get { contains(element) }
+    set {
+      if newValue {
+        insert(element)
+      } else {
+        remove(element)
+      }
+    }
   }
 }

--- a/Tatami/Sources/WorkspaceDetail/WorkspaceDetailView.swift
+++ b/Tatami/Sources/WorkspaceDetail/WorkspaceDetailView.swift
@@ -224,7 +224,8 @@ struct WorkspaceDetailView: View {
 
           Section("Borrow Placement") {
             let globalEdge = store.config.settings.switching.borrowDefaultEdge
-            let globalEdgeLabel = globalEdge?.rawValue.capitalized ?? "Ask"
+            let globalEdgeLabel = globalEdge.map { String(localized: $0.displayName) }
+              ?? String(localized: "Ask")
             let globalFraction = store.config.settings.switching.borrowFraction
             Picker(
               selection: Binding(

--- a/Tatami/Sources/WorkspaceDetail/WorkspaceDetailView.swift
+++ b/Tatami/Sources/WorkspaceDetail/WorkspaceDetailView.swift
@@ -86,6 +86,7 @@ struct WorkspaceDetailView: View {
                 KeyEquivalentRecorder(
                   key: workspace.keyEquivalent,
                   modifierSymbols: "",
+                  accessibilityLabel: "Key equivalent",
                   conflict: { keyEquivalentConflict($0) },
                   onRecordingChanged: { store.send(.shortcutRecordingChanged($0)) },
                 ) { store.send(.keyEquivalentChanged($0)) }
@@ -314,16 +315,23 @@ struct WorkspaceDetailView: View {
             onCancel: { store.send(.appPickerDismissed) },
           )
         }
-        .sheet(item: $importSource) { source in
+        .sheet(item: $importReview) { review in
           SyncPreviewSheet(
-            title: "Copy from “\(source.workspaceName)”",
-            message: "Copy each change from “\(source.workspaceName)” (\(source.profileName)) into this workspace. Uncheck anything you'd rather keep.",
+            title: "Copy from “\(review.workspaceName)”",
+            message: "Copy each change from “\(review.workspaceName)” (\(review.profileName)) into this workspace. Uncheck anything you'd rather keep.",
             applyTitle: "Copy",
-            groups: importGroups(source),
-            onApply: { excluded in applyImport(source, excluding: excluded) },
+            groups: importGroups(review),
+            validateSelection: { excluded in
+              importConflicts(review, excluding: excluded)
+            },
+            onApply: { excluded in applyImport(review, excluding: excluded) },
           )
         }
         .onChange(of: workspace.id, initial: true) { _, _ in nameDraft = workspace.name }
+        // A sidebar inline rename keeps the workspace identity. Refresh only
+        // this draft instead of rebuilding the whole detail view (which would
+        // discard its scroll position, sheets, and transient highlighting).
+        .onChange(of: workspace.name) { _, name in nameDraft = name }
         // Keyed on the workspace so re-running per selection re-fetches the
         // display list (a plain `.task` only fires on first appearance, which
         // left later workspaces' pickers showing just their own pinned display).
@@ -367,10 +375,12 @@ struct WorkspaceDetailView: View {
   // MARK: Private
 
   /// A chosen source workspace for the "copy from" review sheet.
-  private struct ImportSource: Identifiable {
+  private struct WorkspaceImportReview: Identifiable {
+    let baseline: AppConfig
     let profileId: Profile.ID
-    let workspaceId: Workspace.ID
     let profileName: String
+    let targetWorkspaceId: Workspace.ID
+    let workspaceId: Workspace.ID
     let workspaceName: String
 
     var id: String {
@@ -384,7 +394,7 @@ struct WorkspaceDetailView: View {
   /// lands on the right row.
   @State private var highlightedApp: String?
   /// The workspace picked to copy from — drives the review sheet.
-  @State private var importSource: ImportSource?
+  @State private var importReview: WorkspaceImportReview?
   @FocusState private var nameFieldFocused: Bool
 
   private let highlightFlash = Duration.seconds(1.6)
@@ -408,28 +418,16 @@ struct WorkspaceDetailView: View {
   /// — so each is checked against every other binding (excluding this
   /// workspace's matching action). Nil when all three are free / unbound.
   private func keyEquivalentConflict(_ char: String) -> String? {
-    guard let code = HotKey.keyCode(forName: char) else { return nil }
-    let s = store.config.settings.shortcuts
-    func combo(_ tokens: [String]) -> HotKey? {
-      let mods = HotKey.carbonModifiers(from: tokens)
-      return mods == 0 ? nil : HotKey(carbonKeyCode: code, carbonModifiers: mods)
-    }
-    if
-      let hk = combo(s.keyEquivalentModifiers),
-      let owner = store.state.activateShortcutConflict(for: hk) { return owner }
-    if
-      let hk = combo(s.assignModifiers),
-      let owner = store.state.assignShortcutConflict(for: hk) { return owner }
-    if
-      let hk = combo(s.borrowModifiers),
-      let owner = store.state.borrowShortcutConflict(for: hk) { return owner }
-    return nil
+    store.config.workspaceKeyEquivalentConflict(
+      for: char,
+      workspaceId: store.state.workspaceId,
+    )
   }
 
   /// A shortcut row whose default is "modifier + the workspace key equivalent"
   /// (shown read-only in a capsule) with an explicit-shortcut override beside.
   private func derivedShortcutRow(
-    _ title: String,
+    _ title: LocalizedStringResource,
     modifiers: [String],
     key: String?,
     override: HotKey?,
@@ -447,6 +445,7 @@ struct WorkspaceDetailView: View {
         .foregroundStyle(.tertiary)
       ShortcutRecorder(
         hotKey: override,
+        accessibilityLabel: title,
         conflict: conflict,
         onRecordingChanged: { store.send(.shortcutRecordingChanged($0)) },
       ) { onOverride($0) }
@@ -466,11 +465,18 @@ struct WorkspaceDetailView: View {
               Menu(profile.name) {
                 ForEach(sources, id: \.id) { ws in
                   Button(ws.name) {
-                    importSource = ImportSource(
-                      profileId: profile.id,
-                      workspaceId: ws.id,
-                      profileName: profile.name,
-                      workspaceName: ws.name,
+                    let baseline = store.config
+                    guard
+                      let profileSnapshot = baseline.profiles.first(where: { $0.id == profile.id }),
+                      let workspaceSnapshot = profileSnapshot.workspaces[id: ws.id]
+                    else { return }
+                    importReview = WorkspaceImportReview(
+                      baseline: baseline,
+                      profileId: profileSnapshot.id,
+                      profileName: profileSnapshot.name,
+                      targetWorkspaceId: store.workspaceId,
+                      workspaceId: workspaceSnapshot.id,
+                      workspaceName: workspaceSnapshot.name,
                     )
                   }
                 }
@@ -491,45 +497,76 @@ struct WorkspaceDetailView: View {
     }
   }
 
-  private func importGroups(_ source: ImportSource) -> [SyncChangeGroup] {
+  private func importGroups(_ review: WorkspaceImportReview) -> [SyncChangeGroup] {
     guard
-      let sourceWs = store.config.profiles.first(where: { $0.id == source.profileId })?
-        .workspaces[id: source.workspaceId],
-      let target = store.workspace
+      let sourceWorkspace = review.baseline.profiles.first(where: { $0.id == review.profileId })?
+        .workspaces[id: review.workspaceId],
+      let target = review.baseline.workspace(id: review.targetWorkspaceId)
     else { return [] }
     var groups = [SyncChangeGroup]()
-    let appChanges = WorkspaceSync.appChanges(from: sourceWs.apps, to: target.apps)
+    let appChanges = WorkspaceSync.appChanges(from: sourceWorkspace.apps, to: target.apps)
     if !appChanges.isEmpty {
       groups.append(SyncChangeGroup(
         id: "apps",
-        title: "Apps",
+        title: String(localized: "Apps"),
         items: appChanges.map { SyncChangeItem($0, prefix: "") },
       ))
     }
-    let fieldChanges = WorkspaceSync.fieldChanges(from: sourceWs, to: target)
+    let fieldChanges = WorkspaceSync.fieldChanges(from: sourceWorkspace, to: target)
     if !fieldChanges.isEmpty {
       groups.append(SyncChangeGroup(
         id: "settings",
-        title: "Settings",
+        title: String(localized: "Settings"),
         items: fieldChanges.map { SyncChangeItem($0, prefix: "") },
       ))
     }
     return groups
   }
 
-  private func applyImport(_ source: ImportSource, excluding excluded: Set<String>) {
+  private func applyImport(
+    _ review: WorkspaceImportReview,
+    excluding excluded: Set<String>,
+  ) {
+    let exclusions = importExclusions(excluded)
+    store.send(.importWorkspace(
+      targetWorkspace: review.targetWorkspaceId,
+      sourceProfile: review.profileId,
+      sourceWorkspace: review.workspaceId,
+      baseline: review.baseline,
+      excludingApps: exclusions.apps,
+      excludingFields: exclusions.fields,
+    ))
+  }
+
+  private func importConflicts(
+    _ review: WorkspaceImportReview,
+    excluding excluded: Set<String>,
+  ) -> [String: [WorkspaceShortcutConflict]] {
+    let exclusions = importExclusions(excluded)
+    guard
+      let projection = review.baseline.workspaceImportProjection(
+        into: review.targetWorkspaceId,
+        from: review.profileId,
+        sourceWorkspace: review.workspaceId,
+        excludingApps: exclusions.apps,
+        excludingFields: exclusions.fields,
+      )
+    else { return [:] }
+    return Dictionary(grouping: projection.conflicts) { conflict in
+      SyncChangeItem.fieldId("", conflict.selection.field.rawValue)
+    }
+  }
+
+  private func importExclusions(
+    _ excluded: Set<String>
+  ) -> (apps: Set<String>, fields: Set<String>) {
     var excApps = Set<String>()
     var excFields = Set<String>()
     for id in excluded {
       if id.hasPrefix("app:") { excApps.insert(String(id.dropFirst(4))) }
       else if id.hasPrefix("field:") { excFields.insert(String(id.dropFirst(6))) }
     }
-    store.send(.importWorkspace(
-      sourceProfile: source.profileId,
-      sourceWorkspace: source.workspaceId,
-      excludingApps: excApps,
-      excludingFields: excFields,
-    ))
+    return (excApps, excFields)
   }
 
 }

--- a/Tatami/Sources/WorkspaceDetail/WorkspaceLayoutPreview.swift
+++ b/Tatami/Sources/WorkspaceDetail/WorkspaceLayoutPreview.swift
@@ -131,7 +131,7 @@ struct WorkspaceLayoutPreview: View {
     .padding(.horizontal, 8)
     .padding(.vertical, 5)
     .background(Capsule().fill(Color.secondary.opacity(0.12)))
-    .help(nonTiledHelp(app))
+    .help(String(localized: nonTiledHelp(app)))
     .contextMenu {
       Button {
         store.send(.revealApp(bundleId: app.bundleId, isShared: app.isShared))
@@ -144,9 +144,17 @@ struct WorkspaceLayoutPreview: View {
     }
   }
 
-  private func nonTiledHelp(_ app: NonTiledApp) -> String {
-    let mode = app.mode == .floating ? "Floating — kept above the tiles" : "Ignored — left where it is"
-    return app.isShared ? "\(mode) · Shared (in every workspace)" : mode
+  private func nonTiledHelp(_ app: NonTiledApp) -> LocalizedStringResource {
+    switch (app.mode, app.isShared) {
+    case (.floating, true):
+      "Always on Top. Kept above the tiles and shared with every workspace."
+    case (.floating, false):
+      "Always on Top. Kept above the tiles in this workspace."
+    case (_, true):
+      "Leave As Is. Kept in place and shared with every workspace."
+    case (_, false):
+      "Leave As Is. Kept in place in this workspace."
+    }
   }
 
   private func isShared(_ bundleId: String) -> Bool {
@@ -177,7 +185,7 @@ struct WorkspaceLayoutPreview: View {
       toolButton("arrow.up.and.down.righttriangle.up.righttriangle.down", help: "Flip top ↔ bottom") {
         store.send(.mirror(axis: .horizontal))
       }
-      toolButton("square.grid.2x2", help: "Balance — equalize splits") { store.send(.balance) }
+      toolButton("square.grid.2x2", help: "Balance all splits equally") { store.send(.balance) }
 
       Divider().frame(height: 16)
 
@@ -204,7 +212,7 @@ struct WorkspaceLayoutPreview: View {
 
   private func toolButton(
     _ symbol: String,
-    help: String,
+    help: LocalizedStringResource,
     enabled: Bool = true,
     action: @escaping () -> Void
   ) -> some View {
@@ -213,7 +221,7 @@ struct WorkspaceLayoutPreview: View {
     }
     .buttonStyle(.borderless)
     .disabled(!enabled)
-    .help(help)
+    .help(String(localized: help))
   }
 
   // MARK: Canvas (fullscreen band + tile area share one coordinate space)
@@ -302,10 +310,13 @@ struct WorkspaceLayoutPreview: View {
     HStack(spacing: 6) {
       Image(systemName: (resolved?.isLive == true) ? "dot.radiowaves.left.and.right" : "clock.arrow.circlepath")
         .font(.caption2)
-      Text((resolved?.isLive == true)
-        ? "Live — edits re-tile your windows now."
-        : "Saved layout — edits apply on next activation.")
-        .font(.caption)
+      if resolved?.isLive == true {
+        Text("Live. Edits re-tile your windows now.")
+          .font(.caption)
+      } else {
+        Text("Saved layout. Edits apply on next activation.")
+          .font(.caption)
+      }
     }
     .foregroundStyle(.secondary)
   }

--- a/Tatami/Sources/WorkspaceList/WorkspaceListView.swift
+++ b/Tatami/Sources/WorkspaceList/WorkspaceListView.swift
@@ -182,7 +182,7 @@ struct WorkspaceListView: View {
     }
     .listStyle(.sidebar)
     .navigationSplitViewColumnWidth(min: 220, ideal: 240, max: 300)
-    .navigationTitle(store.selectedProfile?.name ?? "Workspaces")
+    .navigationTitle(store.selectedProfile?.name ?? String(localized: "Workspaces"))
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
         Button {
@@ -615,7 +615,7 @@ private struct WorkspaceRuntimeStatusView: View {
       where composition.borrowed.contains(where: { $0.workspace == workspaceID })
     {
       return activationStore.config.activeProfile?.workspaces[id: composition.host]?.name
-        ?? "another workspace"
+        ?? String(localized: "another workspace")
     }
     return nil
   }

--- a/Tatami/Sources/WorkspaceList/WorkspaceListView.swift
+++ b/Tatami/Sources/WorkspaceList/WorkspaceListView.swift
@@ -5,9 +5,11 @@ import ComposableArchitecture
 import SwiftUI
 import TatamiKit
 
+// MARK: - WorkspaceListView
+
 struct WorkspaceListView: View {
-  @Bindable var store: StoreOf<WorkspaceListFeature>
-  let activationStore: StoreOf<WorkspaceActivationFeature>
+
+  // MARK: Internal
 
   /// Where the in-flight drag would land: a row + which edge (below when
   /// `after`). Drives the insertion line the row overlays draw. Set/cleared by
@@ -19,7 +21,9 @@ struct WorkspaceListView: View {
     let after: Bool
   }
 
-  @State private var dropIndicator: DropIndicator?
+  @Bindable var store: StoreOf<WorkspaceListFeature>
+
+  let activationStore: StoreOf<WorkspaceActivationFeature>
 
   var body: some View {
     NavigationSplitView {
@@ -32,11 +36,27 @@ struct WorkspaceListView: View {
     .sheet(isPresented: $store.isAddSheetPresented) {
       AddWorkspaceForm(store: store)
     }
+    .sheet(item: $store.duplicationReview) { review in
+      DuplicationReviewSheet(review: review) { excluded in
+        store.send(.duplicationReviewConfirmed(excluding: excluded))
+      }
+    }
     .alert($store.scope(state: \.alert, action: \.alert))
     .task { store.send(.sidebarAppeared) }
+    .onChange(of: focusedRenameTarget) { oldTarget, newTarget in
+      guard
+        let oldTarget,
+        newTarget != oldTarget,
+        store.renameSession?.target == oldTarget
+      else { return }
+      store.send(.renameSubmitted)
+    }
   }
 
-  // MARK: - Column 1: Profiles
+  // MARK: Private
+
+  @State private var dropIndicator: DropIndicator?
+  @FocusState private var focusedRenameTarget: WorkspaceListFeature.NameTarget?
 
   /// The profile whose contents col 2 lists. Its green dot in col 1 marks the
   /// *active* (running) profile, which need not be the selected one.
@@ -44,7 +64,6 @@ struct WorkspaceListView: View {
     store.config.activeProfileId ?? store.config.profiles.first?.id
   }
 
-  @ViewBuilder
   private var profilesColumn: some View {
     List(selection: $store.topSelection.sending(\.topSelected)) {
       Section("Profiles") {
@@ -55,6 +74,7 @@ struct WorkspaceListView: View {
           profileRow(profile)
             .tag(profile.sidebarTop as WorkspaceListFeature.SidebarTop?)
             .contextMenu {
+              RenameButton()
               Button("Duplicate") { store.send(.duplicateProfileTapped(profile.id)) }
               if store.config.profiles.count > 1 {
                 Divider()
@@ -62,6 +82,9 @@ struct WorkspaceListView: View {
                   store.send(.deleteProfileRequested(profile.id))
                 }
               }
+            }
+            .renameAction {
+              store.send(.renameRequested(.profile(profile.id)))
             }
         }
         .onMove { source, destination in
@@ -89,30 +112,6 @@ struct WorkspaceListView: View {
     .navigationTitle("Tatami")
   }
 
-  /// A profile row: icon + name, an overlap-conflict badge, and a green dot on
-  /// the *active* profile (distinct from the selected/highlighted one).
-  @ViewBuilder
-  private func profileRow(_ profile: Profile) -> some View {
-    HStack {
-      Label(profile.name, systemImage: profile.symbolIconName ?? "rectangle.stack")
-      Spacer()
-      if store.config.autoActivationDiagnostic(for: profile.id).hasConflict {
-        Image(systemName: "exclamationmark.triangle.fill")
-          .foregroundStyle(.orange)
-          .imageScale(.small)
-          .help("Auto-activation overlaps another profile at the same priority — order decides which one activates.")
-      }
-      if profile.id == activeProfileId {
-        Image(systemName: "circle.fill")
-          .foregroundStyle(.green)
-          .imageScale(.small)
-          .help("Active profile")
-      }
-    }
-  }
-
-  // MARK: - Column 2: the selected profile's contents
-
   @ViewBuilder
   private var contentColumn: some View {
     if store.isViewingShared {
@@ -121,7 +120,7 @@ struct WorkspaceListView: View {
       ContentUnavailableView(
         "Shared Apps",
         systemImage: "square.on.square",
-        description: Text("These apps join every workspace in every profile. Edit them in the detail pane.")
+        description: Text("These apps join every workspace in every profile. Edit them in the detail pane."),
       )
       .navigationSplitViewColumnWidth(min: 220, ideal: 240, max: 300)
       .navigationTitle("Everywhere")
@@ -130,7 +129,6 @@ struct WorkspaceListView: View {
     }
   }
 
-  @ViewBuilder
   private var profileContentList: some View {
     List(selection: $store.selection.sending(\.sidebarSelected)) {
       // The profile's own settings (name, icon, auto-activation, copy) — the
@@ -198,8 +196,6 @@ struct WorkspaceListView: View {
     }
   }
 
-  // MARK: - Column 3: detail
-
   @ViewBuilder
   private var detailColumn: some View {
     if let detailStore = store.scope(state: \.detail, action: \.detail) {
@@ -212,12 +208,10 @@ struct WorkspaceListView: View {
       ContentUnavailableView(
         "Nothing Selected",
         systemImage: "square.stack.3d.up",
-        description: Text("Pick a profile's settings or a workspace from the sidebar, or add one with ⌘N.")
+        description: Text("Pick a profile's settings or a workspace from the sidebar, or add one with ⌘N."),
       )
     }
   }
-
-  // MARK: - Workspace rows
 
   /// Whether col 2 is showing the *active* profile — gates the Activate / Borrow
   /// row actions, which only make sense for workspaces of the running profile.
@@ -225,10 +219,38 @@ struct WorkspaceListView: View {
     store.selectedProfileResolvedId == activeProfileId
   }
 
-  @ViewBuilder
+  /// A profile row: icon + name, an overlap-conflict badge, and a green dot on
+  /// the *active* profile (distinct from the selected/highlighted one).
+  private func profileRow(_ profile: Profile) -> some View {
+    HStack {
+      Label {
+        editableName(profile.name, target: .profile(profile.id))
+      } icon: {
+        Image(systemName: profile.symbolIconName ?? "rectangle.stack")
+      }
+      Spacer()
+      if store.config.autoActivationDiagnostic(for: profile.id).hasConflict {
+        Image(systemName: "exclamationmark.triangle.fill")
+          .foregroundStyle(.orange)
+          .imageScale(.small)
+          .help("Auto-activation overlaps another profile at the same priority. Order decides which one activates.")
+      }
+      if profile.id == activeProfileId {
+        Image(systemName: "circle.fill")
+          .foregroundStyle(.green)
+          .imageScale(.small)
+          .help("Active profile")
+      }
+    }
+  }
+
   private func row(for workspace: Workspace) -> some View {
     HStack(spacing: 6) {
-      Label(workspace.name, systemImage: workspace.symbolIconName ?? "square.stack.3d.up")
+      Label {
+        editableName(workspace.name, target: .workspace(workspace.id))
+      } icon: {
+        Image(systemName: workspace.symbolIconName ?? "square.stack.3d.up")
+      }
       Spacer()
       WorkspaceRuntimeStatusView(
         workspaceID: workspace.id,
@@ -254,9 +276,46 @@ struct WorkspaceListView: View {
         }
         Divider()
       }
+      RenameButton()
+      Button("Duplicate") {
+        store.send(.duplicateWorkspaceTapped(workspace.id))
+      }
+      Divider()
       Button("Delete", role: .destructive) {
         store.send(.workspaceDeleteRequested(workspace.id))
       }
+    }
+    .renameAction {
+      store.send(.renameRequested(.workspace(workspace.id)))
+    }
+  }
+
+  @ViewBuilder
+  private func editableName(
+    _ name: String,
+    target: WorkspaceListFeature.NameTarget,
+  ) -> some View {
+    if store.renameSession?.target == target {
+      TextField(
+        "Name",
+        text: Binding(
+          get: { store.renameSession?.draft ?? name },
+          set: { store.send(.renameDraftChanged($0)) },
+        ),
+      )
+      .textFieldStyle(.plain)
+      .focused($focusedRenameTarget, equals: target)
+      .onAppear { focusedRenameTarget = target }
+      .onSubmit {
+        store.send(.renameSubmitted)
+        focusedRenameTarget = nil
+      }
+      .onExitCommand {
+        store.send(.renameCancelled)
+        focusedRenameTarget = nil
+      }
+    } else {
+      Text(name)
     }
   }
 
@@ -265,7 +324,6 @@ struct WorkspaceListView: View {
   /// id, and two stacked half-height drop zones split it into an above/below
   /// target so the insertion line follows the cursor and the drop lands there
   /// (`workspace.kind` picks the destination section).
-  @ViewBuilder
   private func draggableRow(_ workspace: Workspace) -> some View {
     row(for: workspace)
       .draggable(workspace.id.uuidString) {
@@ -328,7 +386,7 @@ struct WorkspaceListView: View {
     _ ids: [String],
     kind: WorkspaceKind,
     relativeTo targetId: Workspace.ID?,
-    after: Bool
+    after: Bool,
   ) -> Bool {
     guard let first = ids.first, let draggedId = UUID(uuidString: first) else { return false }
     dropIndicator = nil
@@ -338,9 +396,186 @@ struct WorkspaceListView: View {
 
 }
 
+// MARK: - DuplicationReviewSheet
+
+/// Adapts a reducer-owned duplicate snapshot into the same grouped, toggleable
+/// review surface used by Profile/Workspace "Copy from…". Keeping this out of
+/// `WorkspaceListView` prevents option construction from widening the sidebar's
+/// normal invalidation boundary.
+private struct DuplicationReviewSheet: View {
+  let review: WorkspaceListFeature.DuplicationReview
+  let onConfirm: (Set<String>) -> Void
+
+  var body: some View {
+    switch review.source {
+    case .profile(let profile):
+      SyncPreviewSheet(
+        title: "Duplicate “\(profile.name)”",
+        message: "Choose which workspaces and content to include. The profile switch shortcut and auto-activation are left off; workspace shortcuts can be copied because the new profile is independently scoped.",
+        applyTitle: "Duplicate",
+        groups: profileGroups(profile),
+        allowsEmptySelection: true,
+        validateSelection: { excluded in
+          WorkspaceListFeature.duplicationShortcutConflicts(
+            review: review,
+            excluding: excluded
+          )
+        },
+        onApply: onConfirm,
+      )
+
+    case .workspace(let workspace):
+      SyncPreviewSheet(
+        title: "Duplicate “\(workspace.name)”",
+        message: "Choose the apps, settings, and saved layout to include. Workspace keys and explicit shortcuts are always left blank to avoid conflicts.",
+        applyTitle: "Duplicate",
+        groups: workspaceGroups(workspace),
+        allowsEmptySelection: true,
+        validateSelection: { excluded in
+          WorkspaceListFeature.duplicationShortcutConflicts(
+            review: review,
+            excluding: excluded
+          )
+        },
+        onApply: onConfirm,
+      )
+    }
+  }
+
+  /// A profile chooser keeps each workspace in one group. Its first toggle is
+  /// the parent of that workspace's content and layout rows, so excluding a
+  /// workspace also excludes every subordinate option without losing the
+  /// user's individual choices if it is turned back on.
+  private func profileGroups(_ profile: Profile) -> [SyncChangeGroup] {
+    var groups = [SyncChangeGroup]()
+    if let symbol = profile.symbolIconName {
+      groups.append(SyncChangeGroup(
+        id: "profile",
+        title: String(localized: "Profile"),
+        symbol: symbol,
+        items: [SyncChangeItem(
+          id: WorkspaceListFeature.DuplicationOptionID.profileIcon,
+          title: String(localized: "Profile icon"),
+          detail: String(localized: "Copy the profile's appearance."),
+          detailTint: .secondary,
+          symbol: symbol,
+          symbolTint: .accentColor,
+          appBundleId: nil,
+          appIconPath: nil,
+        )],
+      ))
+    }
+
+    for workspace in profile.workspaces {
+      let parentId = WorkspaceListFeature.DuplicationOptionID.includeWorkspace(workspace.id)
+      var items = [SyncChangeItem(
+        id: parentId,
+        title: String(localized: "Include workspace"),
+        detail: workspace.apps.isEmpty
+          ? String(localized: "Copy its settings and saved layout.")
+          : String(localized: "Copy its apps, settings, and saved layout."),
+        detailTint: .secondary,
+        symbol: "checkmark.circle",
+        symbolTint: .accentColor,
+        appBundleId: nil,
+        appIconPath: nil,
+      )]
+      items.append(contentsOf: appItems(workspace, parentId: parentId))
+      items.append(contentsOf: settingItems(
+        workspace,
+        parentId: parentId,
+        includeShortcuts: true,
+      ))
+      items.append(layoutItem(workspace, parentId: parentId))
+      groups.append(SyncChangeGroup(
+        id: workspace.id.uuidString,
+        title: workspace.name,
+        symbol: workspace.symbolIconName ?? "square.stack.3d.up",
+        items: items,
+      ))
+    }
+    return groups
+  }
+
+  private func workspaceGroups(_ workspace: Workspace) -> [SyncChangeGroup] {
+    var groups = [SyncChangeGroup]()
+    let apps = appItems(workspace)
+    if !apps.isEmpty {
+      groups.append(SyncChangeGroup(id: "apps", title: String(localized: "Apps"), items: apps))
+    }
+    let settings = settingItems(workspace)
+    if !settings.isEmpty {
+      groups.append(SyncChangeGroup(
+        id: "settings",
+        title: String(localized: "Settings"),
+        items: settings,
+      ))
+    }
+    groups.append(SyncChangeGroup(
+      id: "layout",
+      title: String(localized: "Layout"),
+      items: [layoutItem(workspace)],
+    ))
+    return groups
+  }
+
+  private func appItems(
+    _ workspace: Workspace,
+    parentId: String? = nil
+  ) -> [SyncChangeItem] {
+    let prefix = "\(workspace.id.uuidString):"
+    return WorkspaceSync.appChanges(from: workspace.apps, to: []).map {
+      SyncChangeItem($0, prefix: prefix, parentId: parentId)
+    }
+  }
+
+  private func settingItems(
+    _ workspace: Workspace,
+    parentId: String? = nil,
+    includeShortcuts: Bool = false
+  ) -> [SyncChangeItem] {
+    let empty = Workspace(name: workspace.name)
+    let prefix = "\(workspace.id.uuidString):"
+    return WorkspaceSync.fieldChanges(from: workspace, to: empty)
+      .filter { includeShortcuts || !isShortcutIdentity($0) }
+      .map { SyncChangeItem($0, prefix: prefix, parentId: parentId) }
+  }
+
+  private func layoutItem(
+    _ workspace: Workspace,
+    parentId: String? = nil
+  ) -> SyncChangeItem {
+    SyncChangeItem(
+      id: WorkspaceListFeature.DuplicationOptionID.layout(workspace.id),
+      parentId: parentId,
+      title: String(localized: "Saved layout"),
+      detail: String(localized: "Copy the saved tiling tree, if one exists."),
+      detailTint: .secondary,
+      symbol: "rectangle.split.2x1",
+      symbolTint: .accentColor,
+      appBundleId: nil,
+      appIconPath: nil,
+    )
+  }
+
+  private func isShortcutIdentity(_ change: WorkspaceFieldChange) -> Bool {
+    switch change {
+    case .keyEquivalent, .activateShortcut, .assignAppShortcut, .borrowShortcut:
+      true
+    case .icon, .kind, .appToFocus, .displayHint, .borrowEdge, .borrowFraction:
+      false
+    }
+  }
+}
+
+// MARK: - WorkspaceRuntimeStatusView
+
 /// Keeps fast-changing runtime badges in their own observation boundary so a
 /// Borrow toggle does not invalidate the entire three-column settings view.
 private struct WorkspaceRuntimeStatusView: View {
+
+  // MARK: Internal
+
   let workspaceID: Workspace.ID
   let activationStore: StoreOf<WorkspaceActivationFeature>
 
@@ -366,6 +601,8 @@ private struct WorkspaceRuntimeStatusView: View {
     }
   }
 
+  // MARK: Private
+
   /// The display this workspace is currently active on, if any.
   private var activeDisplay: DisplayName? {
     activationStore.activeWorkspacesByDisplay.first { $0.value == workspaceID }?.key
@@ -375,7 +612,8 @@ private struct WorkspaceRuntimeStatusView: View {
   /// a live composition, else nil.
   private var borrowedHostName: String? {
     for (_, composition) in activationStore.compositionsByDisplay
-    where composition.borrowed.contains(where: { $0.workspace == workspaceID }) {
+      where composition.borrowed.contains(where: { $0.workspace == workspaceID })
+    {
       return activationStore.config.activeProfile?.workspaces[id: composition.host]?.name
         ?? "another workspace"
     }
@@ -391,23 +629,32 @@ private struct WorkspaceRuntimeStatusView: View {
     let palette: [Color] = [.green, .blue, .orange, .purple, .pink, .teal]
     return palette[index % palette.count]
   }
+
 }
 
-private extension Workspace {
+extension Workspace {
   /// Sidebar row identity — must be the List's selection type for macOS to make
   /// the row selectable (see the ForEach above).
-  var sidebarItem: WorkspaceListFeature.SidebarItem { .workspace(id) }
+  fileprivate var sidebarItem: WorkspaceListFeature.SidebarItem {
+    .workspace(id)
+  }
 }
 
-private extension Profile {
+extension Profile {
   /// Col 1 row identity — must match the sidebar List's selection type
   /// (SidebarTop) for macOS to wire the row's selection gesture.
-  var sidebarTop: WorkspaceListFeature.SidebarTop { .profile(id) }
+  fileprivate var sidebarTop: WorkspaceListFeature.SidebarTop {
+    .profile(id)
+  }
 }
 
+// MARK: - AddWorkspaceForm
+
 private struct AddWorkspaceForm: View {
+
+  // MARK: Internal
+
   @Bindable var store: StoreOf<WorkspaceListFeature>
-  @FocusState private var nameFieldFocused: Bool
 
   var body: some View {
     Form {
@@ -435,4 +682,9 @@ private struct AddWorkspaceForm: View {
     .padding()
     .onAppear { nameFieldFocused = true }
   }
+
+  // MARK: Private
+
+  @FocusState private var nameFieldFocused: Bool
+
 }

--- a/TatamiCLI/Sources/TatamiCLI.swift
+++ b/TatamiCLI/Sources/TatamiCLI.swift
@@ -5,11 +5,13 @@ import ArgumentParser
 import Foundation
 import TatamiCLIProtocol
 
+// MARK: - TatamiCLI
+
 @main
 struct TatamiCLI: ParsableCommand {
   static let configuration = CommandConfiguration(
     commandName: "tatami",
-    abstract: "Tatami CLI — interact with the Tatami workspace manager.",
+    abstract: "Tatami CLI for controlling the Tatami workspace manager.",
     // Read from the Info.plist section embedded in the binary (see Project.swift),
     // so `--version` tracks the app's marketing version without a hardcoded string.
     version: (Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String) ?? "dev",
@@ -18,8 +20,63 @@ struct TatamiCLI: ParsableCommand {
       ListWorkspaces.self,
       ListApps.self,
       Activate.self,
-    ]
+      ProfileCommand.self,
+      WorkspaceCommand.self,
+      WindowCommand.self,
+      DisplayCommand.self,
+      LayoutCommand.self,
+      AppCommand.self,
+      HookCommand.self,
+    ],
   )
+}
+
+// MARK: - OutputOptions
+
+struct OutputOptions: ParsableArguments {
+  @Flag(name: .long, help: "Print stable JSON output.")
+  var json = false
+
+  var format: CLIMessage.OutputFormat {
+    json ? .json : .plain
+  }
+}
+
+// MARK: - FixedDomainCommand
+
+private protocol FixedDomainCommand: ParsableCommand {
+  static var domainCommand: CLIMessage.DomainCommand { get }
+
+  var output: OutputOptions { get }
+}
+
+extension FixedDomainCommand {
+  func run() throws {
+    try dispatchDomainCommand(Self.domainCommand, output: output)
+  }
+}
+
+// MARK: - AdjacentDirection
+
+enum AdjacentDirection: String, ExpressibleByArgument {
+  case next
+  case previous
+}
+
+// MARK: - CardinalDirection
+
+enum CardinalDirection: String, ExpressibleByArgument {
+  case left
+  case right
+  case up
+  case down
+}
+
+// MARK: - ResizeDirection
+
+enum ResizeDirection: String, ExpressibleByArgument {
+  case grow
+  case shrink
 }
 
 extension TatamiCLI {
@@ -28,48 +85,763 @@ extension TatamiCLI {
       abstract: "Print Tatami app version (queries the running app)."
     )
 
+    @OptionGroup var output: OutputOptions
+
     func run() throws {
-      try dispatch(CLIMessage.Request(command: .version))
+      try dispatch(CLIMessage.Request(command: .version, outputFormat: output.format))
     }
   }
 
   struct ListWorkspaces: ParsableCommand {
     static let configuration = CommandConfiguration(
       commandName: "list-workspaces",
-      abstract: "List workspace names in the active profile."
+      abstract: "List workspace names in the active profile.",
+      shouldDisplay: false,
     )
 
+    @OptionGroup var output: OutputOptions
+
     func run() throws {
-      try dispatch(CLIMessage.Request(command: .listWorkspaces))
+      try dispatch(CLIMessage.Request(command: .listWorkspaces, outputFormat: output.format))
     }
   }
 
   struct ListApps: ParsableCommand {
     static let configuration = CommandConfiguration(
       commandName: "list-apps",
-      abstract: "List bundle IDs assigned to a workspace."
+      abstract: "List bundle IDs assigned to a workspace.",
+      shouldDisplay: false,
     )
 
     @Argument(help: "Workspace name or UUID.")
     var workspace: String
 
+    @OptionGroup var output: OutputOptions
+
     func run() throws {
-      try dispatch(CLIMessage.Request(command: .listApps, arguments: [workspace]))
+      try dispatch(CLIMessage.Request(
+        command: .listApps,
+        arguments: [workspace],
+        outputFormat: output.format,
+      ))
     }
   }
 
   struct Activate: ParsableCommand {
     static let configuration = CommandConfiguration(
-      abstract: "Activate a workspace (show its apps, hide others)."
+      abstract: "Activate a workspace (show its apps, hide others).",
+      shouldDisplay: false,
     )
 
     @Argument(help: "Workspace name or UUID.")
     var workspace: String
 
+    @OptionGroup var output: OutputOptions
+
     func run() throws {
-      try dispatch(CLIMessage.Request(command: .activate, arguments: [workspace]))
+      try dispatch(CLIMessage.Request(
+        command: .activate,
+        arguments: [workspace],
+        outputFormat: output.format,
+      ))
     }
   }
+
+  struct ProfileCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "profile",
+      abstract: "Inspect and manage profiles.",
+      subcommands: [
+        ProfileList.self,
+        ProfileActivate.self,
+        ProfileRename.self,
+        ProfileDuplicate.self,
+      ],
+    )
+  }
+
+  struct ProfileList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "list",
+      abstract: "List profiles.",
+    )
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(command: .listProfiles, outputFormat: output.format))
+    }
+  }
+
+  struct ProfileActivate: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "activate",
+      abstract: "Activate a profile.",
+    )
+
+    @Argument(help: "Profile name or UUID.")
+    var profile: String
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatchDomainCommand(.profileActivate, target: profile, output: output)
+    }
+  }
+
+  struct ProfileRename: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "rename",
+      abstract: "Rename a profile.",
+    )
+
+    @Argument(help: "Profile name or UUID.")
+    var profile: String
+
+    @Argument(help: "New profile name.")
+    var newName: String
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(
+        command: .renameProfile,
+        arguments: [profile, newName],
+        outputFormat: output.format,
+      ))
+    }
+  }
+
+  struct ProfileDuplicate: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "duplicate",
+      abstract: "Duplicate a profile with fresh identifiers.",
+    )
+
+    @Argument(help: "Profile name or UUID.")
+    var profile: String
+
+    @Option(name: .long, help: "Name for the duplicate.")
+    var name: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(
+        command: .duplicateProfile,
+        arguments: [profile],
+        options: optionValues(name: name),
+        outputFormat: output.format,
+      ))
+    }
+  }
+
+  struct WorkspaceCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "workspace",
+      abstract: "Inspect and manage workspaces.",
+      subcommands: [
+        WorkspaceList.self,
+        WorkspaceApps.self,
+        WorkspaceActivate.self,
+        WorkspaceRename.self,
+        WorkspaceDuplicate.self,
+        WorkspaceNext.self,
+        WorkspacePrevious.self,
+        WorkspaceRecent.self,
+        WorkspaceMoveApp.self,
+        WorkspaceAssignApp.self,
+        WorkspaceBorrow.self,
+        WorkspaceDismissBorrow.self,
+      ],
+    )
+  }
+
+  struct WorkspaceList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "list",
+      abstract: "List workspaces in a profile.",
+    )
+
+    @Option(name: .long, help: "Profile name or UUID (defaults to active).")
+    var profile: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(
+        command: .listWorkspaces,
+        options: optionValues(profile: profile),
+        outputFormat: output.format,
+      ))
+    }
+  }
+
+  struct WorkspaceApps: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "apps",
+      abstract: "List apps assigned to a workspace.",
+    )
+
+    @Argument(help: "Workspace name or UUID.")
+    var workspace: String
+
+    @Option(name: .long, help: "Profile name or UUID (defaults to active).")
+    var profile: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(
+        command: .listApps,
+        arguments: [workspace],
+        options: optionValues(profile: profile),
+        outputFormat: output.format,
+      ))
+    }
+  }
+
+  struct WorkspaceActivate: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "activate",
+      abstract: "Activate a workspace.",
+    )
+
+    @Argument(help: "Workspace name or UUID.")
+    var workspace: String
+
+    @Option(name: .long, help: "Profile name or UUID (defaults to active).")
+    var profile: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatchDomainCommand(
+        .workspaceActivate,
+        target: workspace,
+        profile: profile,
+        output: output,
+      )
+    }
+  }
+
+  struct WorkspaceRename: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "rename",
+      abstract: "Rename a workspace.",
+    )
+
+    @Argument(help: "Workspace name or UUID.")
+    var workspace: String
+
+    @Argument(help: "New workspace name.")
+    var newName: String
+
+    @Option(name: .long, help: "Profile name or UUID (defaults to active).")
+    var profile: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(
+        command: .renameWorkspace,
+        arguments: [workspace, newName],
+        options: optionValues(profile: profile),
+        outputFormat: output.format,
+      ))
+    }
+  }
+
+  struct WorkspaceDuplicate: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "duplicate",
+      abstract: "Duplicate a workspace with a fresh identifier.",
+    )
+
+    @Argument(help: "Workspace name or UUID.")
+    var workspace: String
+
+    @Option(name: .long, help: "Profile name or UUID (defaults to active).")
+    var profile: String?
+
+    @Option(name: .long, help: "Name for the duplicate.")
+    var name: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(
+        command: .duplicateWorkspace,
+        arguments: [workspace],
+        options: optionValues(profile: profile, name: name),
+        outputFormat: output.format,
+      ))
+    }
+  }
+
+  struct WorkspaceNext: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "next",
+      abstract: "Switch to the next workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceNext
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspacePrevious: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "previous",
+      abstract: "Switch to the previous workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspacePrevious
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceRecent: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "recent",
+      abstract: "Switch to the most recent workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceRecent
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceMoveApp: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "move-app",
+      abstract: "Move the focused app to an adjacent workspace and switch.",
+    )
+
+    @Argument(help: "Direction: next or previous.")
+    var direction: AdjacentDirection
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      let command: CLIMessage.DomainCommand =
+        switch direction {
+        case .next: .workspaceMoveAppNext
+        case .previous: .workspaceMoveAppPrevious
+        }
+      try dispatchDomainCommand(command, output: output)
+    }
+  }
+
+  struct WorkspaceAssignApp: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "assign-app",
+      abstract: "Assign the focused app to a workspace and switch.",
+      subcommands: [
+        WorkspaceAssignAppTo.self,
+        WorkspaceAssignAppNext.self,
+        WorkspaceAssignAppPrevious.self,
+        WorkspaceAssignAppRecent.self,
+      ],
+    )
+  }
+
+  struct WorkspaceAssignAppTo: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "to",
+      abstract: "Assign to a named workspace.",
+    )
+
+    @Argument(help: "Workspace name or UUID.")
+    var workspace: String
+
+    @Option(name: .long, help: "Profile name or UUID (defaults to active).")
+    var profile: String?
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatchDomainCommand(
+        .workspaceAssignAppTo,
+        target: workspace,
+        profile: profile,
+        output: output,
+      )
+    }
+  }
+
+  struct WorkspaceAssignAppNext: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "next",
+      abstract: "Assign to the next workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceAssignAppNext
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceAssignAppPrevious: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "previous",
+      abstract: "Assign to the previous workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceAssignAppPrevious
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceAssignAppRecent: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "recent",
+      abstract: "Assign to the most recent workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceAssignAppRecent
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceBorrow: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "borrow",
+      abstract: "Borrow a workspace from the active profile.",
+      subcommands: [
+        WorkspaceBorrowFrom.self,
+        WorkspaceBorrowNext.self,
+        WorkspaceBorrowPrevious.self,
+        WorkspaceBorrowRecent.self,
+      ],
+    )
+  }
+
+  struct WorkspaceBorrowFrom: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "from",
+      abstract: "Borrow a named workspace from the active profile.",
+    )
+
+    @Argument(help: "Workspace name or UUID in the active profile.")
+    var workspace: String
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatchDomainCommand(.workspaceBorrowFrom, target: workspace, output: output)
+    }
+  }
+
+  struct WorkspaceBorrowNext: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "next",
+      abstract: "Borrow the next workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceBorrowNext
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceBorrowPrevious: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "previous",
+      abstract: "Borrow the previous workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceBorrowPrevious
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceBorrowRecent: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "recent",
+      abstract: "Borrow the most recent workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceBorrowRecent
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WorkspaceDismissBorrow: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "dismiss-borrow",
+      abstract: "Dismiss Borrow on the pointer display.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.workspaceDismissBorrow
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WindowCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "window",
+      abstract: "Focus, cycle, resize, swap, and change window layout.",
+      subcommands: [
+        WindowFocus.self,
+        WindowCycle.self,
+        WindowResize.self,
+        WindowSwap.self,
+        WindowToggleFullscreen.self,
+        WindowToggleFloating.self,
+        WindowToggleSharedFloating.self,
+      ],
+    )
+  }
+
+  struct WindowFocus: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "focus",
+      abstract: "Focus a neighboring tiled window.",
+    )
+
+    @Argument(help: "Direction: left, right, up, or down.")
+    var direction: CardinalDirection
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      let command: CLIMessage.DomainCommand =
+        switch direction {
+        case .left: .windowFocusLeft
+        case .right: .windowFocusRight
+        case .up: .windowFocusUp
+        case .down: .windowFocusDown
+        }
+      try dispatchDomainCommand(command, output: output)
+    }
+  }
+
+  struct WindowCycle: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "cycle",
+      abstract: "Cycle through visible windows.",
+    )
+
+    @Argument(help: "Direction: next or previous.")
+    var direction: AdjacentDirection
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      let command: CLIMessage.DomainCommand =
+        switch direction {
+        case .next: .windowCycleNext
+        case .previous: .windowCyclePrevious
+        }
+      try dispatchDomainCommand(command, output: output)
+    }
+  }
+
+  struct WindowResize: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "resize",
+      abstract: "Grow or shrink the focused window.",
+    )
+
+    @Argument(help: "Direction: grow or shrink.")
+    var direction: ResizeDirection
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      let command: CLIMessage.DomainCommand =
+        switch direction {
+        case .grow: .windowResizeGrow
+        case .shrink: .windowResizeShrink
+        }
+      try dispatchDomainCommand(command, output: output)
+    }
+  }
+
+  struct WindowSwap: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "swap",
+      abstract: "Swap the focused window directionally.",
+    )
+
+    @Argument(help: "Direction: left, right, up, or down.")
+    var direction: CardinalDirection
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      let command: CLIMessage.DomainCommand =
+        switch direction {
+        case .left: .windowSwapLeft
+        case .right: .windowSwapRight
+        case .up: .windowSwapUp
+        case .down: .windowSwapDown
+        }
+      try dispatchDomainCommand(command, output: output)
+    }
+  }
+
+  struct WindowToggleFullscreen: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "toggle-fullscreen",
+      abstract: "Toggle Tatami layout fullscreen for the focused window.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.windowToggleFullscreen
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WindowToggleFloating: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "toggle-floating",
+      abstract: "Toggle floating layout for the focused app.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.windowToggleFloating
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct WindowToggleSharedFloating: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "toggle-shared-floating",
+      abstract: "Toggle Shared Apps floating layout for the focused app.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.windowToggleSharedFloating
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct DisplayCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "display",
+      abstract: "Move focus between displays.",
+      subcommands: [DisplayFocus.self],
+    )
+  }
+
+  struct DisplayFocus: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "focus",
+      abstract: "Focus the workspace on an adjacent display.",
+    )
+
+    @Argument(help: "Direction: next or previous.")
+    var direction: AdjacentDirection
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      let command: CLIMessage.DomainCommand =
+        switch direction {
+        case .next: .displayFocusNext
+        case .previous: .displayFocusPrevious
+        }
+      try dispatchDomainCommand(command, output: output)
+    }
+  }
+
+  struct LayoutCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "layout",
+      abstract: "Edit the active BSP layout and global tiling state.",
+      subcommands: [
+        LayoutToggleOrientation.self,
+        LayoutBalance.self,
+        LayoutToggleTiling.self,
+      ],
+    )
+  }
+
+  struct LayoutToggleOrientation: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "toggle-orientation",
+      abstract: "Toggle the focused split orientation.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.layoutToggleOrientation
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct LayoutBalance: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "balance",
+      abstract: "Rebalance the active layout.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.layoutBalance
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct LayoutToggleTiling: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "toggle-tiling",
+      abstract: "Pause or resume Tatami tiling globally.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.layoutToggleTiling
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct AppCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "app",
+      abstract: "Change membership for the focused app.",
+      subcommands: [AppToggleWorkspace.self, AppToggleShared.self],
+    )
+  }
+
+  struct AppToggleWorkspace: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "toggle-workspace",
+      abstract: "Add or remove the focused app in the active workspace.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.appToggleWorkspace
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct AppToggleShared: FixedDomainCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "toggle-shared",
+      abstract: "Add or remove the focused app in Shared Apps.",
+    )
+    static let domainCommand = CLIMessage.DomainCommand.appToggleShared
+
+    @OptionGroup var output: OutputOptions
+  }
+
+  struct HookCommand: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "hook",
+      abstract: "Inspect configured hooks.",
+      subcommands: [HookList.self],
+    )
+  }
+
+  struct HookList: ParsableCommand {
+    static let configuration = CommandConfiguration(
+      commandName: "list",
+      abstract: "List hooks and their validation status.",
+    )
+
+    @OptionGroup var output: OutputOptions
+
+    func run() throws {
+      try dispatch(CLIMessage.Request(command: .listHooks, outputFormat: output.format))
+    }
+  }
+}
+
+private func optionValues(profile: String? = nil, name: String? = nil) -> [String: String] {
+  var options = [String: String]()
+  if let profile { options[CLIMessage.Option.profile.rawValue] = profile }
+  if let name { options[CLIMessage.Option.name.rawValue] = name }
+  return options
+}
+
+private func dispatchDomainCommand(
+  _ command: CLIMessage.DomainCommand,
+  target: String? = nil,
+  profile: String? = nil,
+  output: OutputOptions,
+) throws {
+  var arguments = [command.rawValue]
+  if let target { arguments.append(target) }
+  try dispatch(CLIMessage.Request(
+    command: .dispatchDomainCommand,
+    arguments: arguments,
+    options: optionValues(profile: profile),
+    outputFormat: output.format,
+  ))
 }
 
 private func dispatch(_ request: CLIMessage.Request) throws {
@@ -77,19 +849,49 @@ private func dispatch(_ request: CLIMessage.Request) throws {
   do {
     response = try SocketClient.send(request)
   } catch {
-    FileHandle.standardError.write(Data("\(error)\n".utf8))
+    writeError(String(describing: error), format: request.outputFormat)
     throw ExitCode.failure
   }
 
-  if let output = response.output, !output.isEmpty {
-    print(output)
-  }
   if response.success {
-    return
-  } else {
-    if let error = response.error {
-      FileHandle.standardError.write(Data("\(error)\n".utf8))
+    if request.outputFormat == .json {
+      guard
+        response.outputFormat == .json,
+        let output = response.output,
+        let data = output.data(using: .utf8),
+        (try? JSONSerialization.jsonObject(with: data, options: .fragmentsAllowed)) != nil
+      else {
+        writeError(
+          "The running Tatami app does not support JSON output; update and relaunch Tatami",
+          format: .json,
+        )
+        throw ExitCode.failure
+      }
+      print(output)
+    } else if let output = response.output, !output.isEmpty {
+      print(output)
     }
-    throw ExitCode.failure
+    return
   }
+  writeError(response.error ?? "Unknown Tatami CLI error", format: request.outputFormat)
+  throw ExitCode.failure
+}
+
+// MARK: - CLIErrorOutput
+
+private struct CLIErrorOutput: Encodable {
+  var error: String
+}
+
+private func writeError(_ message: String, format: CLIMessage.OutputFormat) {
+  let text: String =
+    if
+      format == .json,
+      let data = try? JSONEncoder().encode(CLIErrorOutput(error: message))
+    {
+      String(decoding: data, as: UTF8.self)
+    } else {
+      message
+    }
+  FileHandle.standardError.write(Data("\(text)\n".utf8))
 }

--- a/TatamiCLIProtocol/Sources/CLIMessage.swift
+++ b/TatamiCLIProtocol/Sources/CLIMessage.swift
@@ -6,50 +6,301 @@ import Foundation
 /// Wire format shared between the Tatami app (server) and the `tatami` CLI binary.
 /// Serialized over a Unix domain socket; encoded as one JSON document per line.
 public enum CLIMessage {
-  /// Unix-domain socket in the per-user temp directory
-  /// (`DARWIN_USER_TEMP_DIR`, mode 0700). A fixed path in world-writable
-  /// `/tmp` let any local user pre-create the file — the sticky bit then
-  /// makes the server's `unlink` fail and `bind` error out (a CLI-server
-  /// DoS). The per-user dir is stable across processes of the same user,
-  /// so the app and the CLI resolve the same path, and it's short enough
-  /// for `sun_path`'s 104-byte limit.
-  public static let socketPath: String =
-    FileManager.default.temporaryDirectory.path + "/tatami.socket"
-
   public enum Command: String, Codable, Sendable, Equatable {
     case version
     case listWorkspaces = "list-workspaces"
     case listApps = "list-apps"
     case activate
+    case dispatchDomainCommand = "dispatch-domain-command"
+    case listProfiles = "list-profiles"
+    case renameProfile = "rename-profile"
+    case duplicateProfile = "duplicate-profile"
+    case renameWorkspace = "rename-workspace"
+    case duplicateWorkspace = "duplicate-workspace"
+    case listHooks = "list-hooks"
+  }
+
+  public enum OutputFormat: String, Codable, Sendable, Equatable {
+    case plain
+    case json
+  }
+
+  public enum Option: String, Sendable {
+    case name
+    case profile
   }
 
   public struct Request: Codable, Sendable, Equatable {
-    public let command: Command
-    public let arguments: [String]
 
-    public init(command: Command, arguments: [String] = []) {
+    // MARK: Lifecycle
+
+    public init(
+      command: Command,
+      arguments: [String] = [],
+      options: [String: String] = [:],
+      outputFormat: OutputFormat = .plain,
+    ) {
       self.command = command
       self.arguments = arguments
+      self.options = options
+      self.outputFormat = outputFormat
+    }
+
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      command = try container.decode(Command.self, forKey: .command)
+      arguments = try container.decodeIfPresent([String].self, forKey: .arguments) ?? []
+      options = try container.decodeIfPresent([String: String].self, forKey: .options) ?? [:]
+      outputFormat = try container.decodeIfPresent(OutputFormat.self, forKey: .outputFormat) ?? .plain
+    }
+
+    // MARK: Public
+
+    public let command: Command
+    public let arguments: [String]
+    public let options: [String: String]
+    public let outputFormat: OutputFormat
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+      case command
+      case arguments
+      case options
+      case outputFormat
+    }
+
+  }
+
+  public struct ProfileInfo: Codable, Sendable, Equatable {
+    public init(id: UUID, name: String, isActive: Bool) {
+      self.id = id
+      self.name = name
+      self.isActive = isActive
+    }
+
+    public let id: UUID
+    public let name: String
+    public let isActive: Bool
+  }
+
+  public struct WorkspaceInfo: Codable, Sendable, Equatable {
+    public init(id: UUID, name: String, profileId: UUID, profileName: String, kind: String) {
+      self.id = id
+      self.name = name
+      self.profileId = profileId
+      self.profileName = profileName
+      self.kind = kind
+    }
+
+    public let id: UUID
+    public let name: String
+    public let profileId: UUID
+    public let profileName: String
+    public let kind: String
+  }
+
+  public struct AppInfo: Codable, Sendable, Equatable {
+    public init(bundleIdentifier: String, name: String, layout: String, autoOpen: Bool) {
+      self.bundleIdentifier = bundleIdentifier
+      self.name = name
+      self.layout = layout
+      self.autoOpen = autoOpen
+    }
+
+    public let bundleIdentifier: String
+    public let name: String
+    public let layout: String
+    public let autoOpen: Bool
+  }
+
+  public struct HookInfo: Codable, Sendable, Equatable {
+    public init(id: String, event: String, enabled: Bool, valid: Bool) {
+      self.id = id
+      self.event = event
+      self.enabled = enabled
+      self.valid = valid
+    }
+
+    public let id: String
+    public let event: String
+    public let enabled: Bool
+    public let valid: Bool
+  }
+
+  public enum DomainTarget: String, Codable, Sendable, Equatable {
+    case workspace
+    case profile
+  }
+
+  /// Stable internal routes behind the public domain-oriented CLI commands.
+  /// The `tatami` executable exposes these only through typed subcommands; it
+  /// deliberately has no generic route/action escape hatch.
+  public enum DomainCommand: String, Codable, CaseIterable, Hashable, Sendable {
+    case profileActivate = "profile.activate"
+
+    case workspaceActivate = "workspace.activate"
+    case workspaceNext = "workspace.next"
+    case workspacePrevious = "workspace.previous"
+    case workspaceRecent = "workspace.recent"
+    case workspaceMoveAppNext = "workspace.move-app.next"
+    case workspaceMoveAppPrevious = "workspace.move-app.previous"
+    case workspaceAssignAppTo = "workspace.assign-app.to"
+    case workspaceAssignAppNext = "workspace.assign-app.next"
+    case workspaceAssignAppPrevious = "workspace.assign-app.previous"
+    case workspaceAssignAppRecent = "workspace.assign-app.recent"
+    case workspaceBorrowFrom = "workspace.borrow.from"
+    case workspaceBorrowNext = "workspace.borrow.next"
+    case workspaceBorrowPrevious = "workspace.borrow.previous"
+    case workspaceBorrowRecent = "workspace.borrow.recent"
+    case workspaceDismissBorrow = "workspace.dismiss-borrow"
+
+    case windowFocusLeft = "window.focus.left"
+    case windowFocusRight = "window.focus.right"
+    case windowFocusUp = "window.focus.up"
+    case windowFocusDown = "window.focus.down"
+    case windowCycleNext = "window.cycle.next"
+    case windowCyclePrevious = "window.cycle.previous"
+    case windowResizeGrow = "window.resize.grow"
+    case windowResizeShrink = "window.resize.shrink"
+    case windowSwapLeft = "window.swap.left"
+    case windowSwapRight = "window.swap.right"
+    case windowSwapUp = "window.swap.up"
+    case windowSwapDown = "window.swap.down"
+    case windowToggleFullscreen = "window.toggle-fullscreen"
+    case windowToggleFloating = "window.toggle-floating"
+    case windowToggleSharedFloating = "window.toggle-shared-floating"
+
+    case displayFocusNext = "display.focus.next"
+    case displayFocusPrevious = "display.focus.previous"
+
+    case layoutToggleOrientation = "layout.toggle-orientation"
+    case layoutBalance = "layout.balance"
+    case layoutToggleTiling = "layout.toggle-tiling"
+
+    case appToggleWorkspace = "app.toggle-workspace"
+    case appToggleShared = "app.toggle-shared"
+
+    // MARK: Public
+
+    public var target: DomainTarget? {
+      switch self {
+      case .profileActivate:
+        .profile
+      case .workspaceActivate,
+           .workspaceAssignAppTo,
+           .workspaceBorrowFrom:
+        .workspace
+      default:
+        nil
+      }
     }
   }
 
-  public struct Response: Codable, Sendable, Equatable {
-    public let success: Bool
-    public let output: String?
-    public let error: String?
+  public enum DispatchStatus: String, Codable, Sendable, Equatable {
+    /// The shared Tatami dispatcher accepted the command. Window-manager
+    /// work can still become a no-op when live focus/topology has changed.
+    case accepted
+    /// The reducer's activation pipeline reported terminal success.
+    case completed
+  }
 
-    public init(success: Bool, output: String? = nil, error: String? = nil) {
+  public struct DomainCommandResult: Codable, Sendable, Equatable {
+    public init(
+      command: DomainCommand,
+      title: String,
+      status: DispatchStatus,
+    ) {
+      self.command = command
+      self.title = title
+      self.status = status
+    }
+
+    public let command: DomainCommand
+    public let title: String
+    public let status: DispatchStatus
+  }
+
+  public struct MutationInfo: Codable, Sendable, Equatable {
+    public init(id: String, name: String) {
+      self.id = id
+      self.name = name
+    }
+
+    public let id: String
+    public let name: String
+  }
+
+  public struct Response: Codable, Sendable, Equatable {
+
+    // MARK: Lifecycle
+
+    public init(
+      success: Bool,
+      output: String? = nil,
+      error: String? = nil,
+      outputFormat: OutputFormat = .plain,
+    ) {
       self.success = success
       self.output = output
       self.error = error
+      self.outputFormat = outputFormat
     }
 
-    public static func ok(_ output: String? = nil) -> Response {
-      Response(success: true, output: output)
+    public init(from decoder: Decoder) throws {
+      let container = try decoder.container(keyedBy: CodingKeys.self)
+      success = try container.decode(Bool.self, forKey: .success)
+      output = try container.decodeIfPresent(String.self, forKey: .output)
+      error = try container.decodeIfPresent(String.self, forKey: .error)
+      outputFormat = try container.decodeIfPresent(OutputFormat.self, forKey: .outputFormat)
+        ?? .plain
+    }
+
+    // MARK: Public
+
+    public let success: Bool
+    public let output: String?
+    public let error: String?
+    /// Explicit capability marker. Older apps omit it and decode as `.plain`,
+    /// letting a newer CLI reject accidental plain text for `--json`.
+    public let outputFormat: OutputFormat
+
+    public static func ok(
+      _ output: String? = nil,
+      outputFormat: OutputFormat = .plain,
+    ) -> Response {
+      Response(success: true, output: output, outputFormat: outputFormat)
     }
 
     public static func failure(_ error: String) -> Response {
       Response(success: false, error: error)
     }
+
+    // MARK: Private
+
+    private enum CodingKeys: String, CodingKey {
+      case success
+      case output
+      case error
+      case outputFormat
+    }
+
+  }
+
+  /// Unix-domain socket in the per-user temp directory
+  /// (`DARWIN_USER_TEMP_DIR`, mode 0700). A fixed path in world-writable
+  /// `/tmp` lets any local user pre-create the file. The sticky bit then
+  /// makes the server's `unlink` fail and `bind` error out (a CLI-server
+  /// DoS). The per-user dir is stable across processes of the same user,
+  /// so the app and the CLI resolve the same path, and it's short enough
+  /// for `sun_path`'s 104-byte limit.
+  public static var socketPath: String {
+    if
+      let override = ProcessInfo.processInfo.environment["TATAMI_SOCKET_PATH"],
+      !override.isEmpty
+    {
+      return override
+    }
+    return FileManager.default.temporaryDirectory.path + "/tatami.socket"
   }
 }

--- a/TatamiKit/Sources/AppFeature.swift
+++ b/TatamiKit/Sources/AppFeature.swift
@@ -46,11 +46,12 @@ public struct AppFeature {
 
     // MARK: Public
 
-    @Shared(.tatamiConfig) public var config = AppConfig()
+    @Shared(.tatamiConfig) public var config
     public var workspaceList = WorkspaceListFeature.State()
     public var activation = WorkspaceActivationFeature.State()
     public var hotKeys = HotKeysFeature.State()
     public var cli = CLIServerFeature.State()
+    public var hooks = HooksFeature.State()
     public var onboarding = OnboardingFeature.State()
     /// The selected top-level tab. Driven by the TabView and set
     /// programmatically for deep-links (e.g. jump to a Settings pane).
@@ -69,11 +70,21 @@ public struct AppFeature {
     /// must run once per process: the subscriptions below consume
     /// process-singleton `AsyncStream`s that support a single consumer.
     var didStartUp = false
+    /// Records the process launch event even when no matching hook existed at
+    /// startup, so adding one later cannot replay an event from the past.
+    var didPublishTatamiLaunched = false
+    /// Startup hooks require both the restored profile and a terminal CLI
+    /// listener result. A failed listener still completes Tatami startup.
+    var didRestoreStartupProfile = false
+    var didCompleteCLIStart = false
 
   }
 
   public enum Action {
     case task
+    /// Startup profile reconciliation completed; publish its initial hook
+    /// context without widening WorkspaceActivationFeature's delegate contract.
+    case startupProfileRestored
     /// The top-level tab changed (TabView selection).
     case tabSelected(AppTab)
     /// The Settings view routed to `pendingSettingsSection`; clear it.
@@ -87,6 +98,7 @@ public struct AppFeature {
     case activation(WorkspaceActivationFeature.Action)
     case hotKeys(HotKeysFeature.Action)
     case cli(CLIServerFeature.Action)
+    case hooks(HooksFeature.Action)
     case onboarding(OnboardingFeature.Action)
     case checkForUpdatesTapped
     /// An internal failure was reported or resolved (ErrorReportClient).
@@ -97,8 +109,9 @@ public struct AppFeature {
     /// the focused one after the switch's per-display retile (used by the detail
     /// Activate button on a non-active profile's workspace).
     case activateProfile(Profile.ID, focus: Workspace.ID?)
-    /// Deep-copy a profile (fresh ids + copied layouts) right after it.
-    case duplicateProfile(Profile.ID)
+    /// Switch after deleting the active profile while retaining the outgoing
+    /// profile snapshot for the `profileChanged` hook payload.
+    case activateProfileAfterDeletion(Profile.ID, previousProfile: Profile)
   }
 
   public var body: some ReducerOf<Self> {
@@ -113,6 +126,9 @@ public struct AppFeature {
     }
     Scope(state: \.cli, action: \.cli) {
       CLIServerFeature()
+    }
+    Scope(state: \.hooks, action: \.hooks) {
+      HooksFeature()
     }
     Scope(state: \.onboarding, action: \.onboarding) {
       OnboardingFeature()
@@ -157,8 +173,8 @@ public struct AppFeature {
                 )
               )
             )
+            await send(.startupProfileRestored)
             await send(.hotKeys(.refreshBindings))
-            await send(.activation(.activateInitial))
           },
           .merge(
             .run { [whatsNew] _ in await whatsNew.showIfNeeded(hasExistingConfig) },
@@ -168,6 +184,7 @@ public struct AppFeature {
             ))),
             .send(.hotKeys(.onAppear)),
             .send(.cli(.start)),
+            .send(.hooks(.start)),
             .send(.activation(.startObservingWindowEvents)),
             .send(.activation(.startObservingAppLaunches)),
             .send(.settingsChanged(settings)),
@@ -349,42 +366,19 @@ public struct AppFeature {
         return .send(.onboarding(.demoBorrowChordKey(key)))
 
       case .activateProfile(let id, let focus):
-        guard
-          state.config.activeProfileId != id,
-          state.config.profiles.contains(where: { $0.id == id })
-        else {
-          // Already the active profile — just focus the requested workspace, if any.
-          if let focus { return .send(.activation(.activate(workspaceId: focus, setFocus: true))) }
-          return .none
-        }
-        state.$config.withLock { $0.activeProfileId = id }
-        // The sidebar (col 1) is independent of the active profile, so switching
-        // which profile runs no longer disturbs what's being viewed/edited.
-        return .merge(
-          // Bindings change with the active profile's workspaces; re-register.
-          .send(.hotKeys(.refreshBindings)),
-          // Retile every display for the new profile (all workspaces update). When
-          // `focus` is set, the plan ends on that workspace so it lands active.
-          // The per-display profile-switch HUD is shown from here (it knows the
-          // actual plan) so each monitor names the workspace that lands on it.
-          .send(.activation(.reactivateActiveProfile(focus: focus))),
-          .run { [profileSessionStore] _ in await profileSessionStore.saveActiveProfileId(id) },
+        return activateProfileEffect(
+          id,
+          focus: focus,
+          previousProfile: nil,
+          state: &state,
         )
 
-      case .duplicateProfile(let id):
-        let remap = state.$config.withLock { $0.duplicateProfile(id) }
-        guard !remap.isEmpty else { return .none }
-        return .merge(
-          .send(.hotKeys(.refreshBindings)),
-          // Copy each source workspace's saved layout onto its fresh id so the
-          // clone opens looking identical (layouts are keyed by workspace id).
-          .run { [layoutStore] _ in
-            for (old, new) in remap {
-              if let snapshot = await layoutStore.load(old) {
-                await layoutStore.save(new, snapshot)
-              }
-            }
-          },
+      case .activateProfileAfterDeletion(let id, let previousProfile):
+        return activateProfileEffect(
+          id,
+          focus: nil,
+          previousProfile: previousProfile,
+          state: &state,
         )
 
       case .onboarding(.delegate(.applyRequested(let baseline, let draft, let activate))):
@@ -440,19 +434,97 @@ public struct AppFeature {
           await hotKeys.setRecording(recording)
         }
 
-      case .cli(.delegate(.activateRequested(let workspaceId))):
-        // The CLI drives the same activation pipeline as hotkeys.
-        return .send(.activation(.activate(workspaceId: workspaceId, setFocus: true)))
+      case .cli(.delegate(.activateProfileRequested(let profileId, let complete))):
+        guard state.config.profiles.contains(where: { $0.id == profileId }) else {
+          return .run { _ in complete("The requested profile no longer exists") }
+        }
+        let request = WorkspaceActivationFeature.CLIActivationRequest(
+          target: .profile(profileId),
+          complete: complete,
+        )
+        guard state.config.activeProfile?.id != profileId else {
+          if
+            state.activation.isActivating
+            || state.activation.activeActivationGeneration != nil
+            || !state.activation.pendingDisplayRestores.isEmpty
+          {
+            return .send(.activation(.trackCLIActivation(
+              request,
+              joinCurrentActivation: true,
+            )))
+          }
+          return .run { _ in complete(nil) }
+        }
+        return .concatenate(
+          .send(.activation(.trackCLIActivation(
+            request,
+            joinCurrentActivation: false,
+          ))),
+          .send(.activateProfile(profileId, focus: nil)),
+        )
+
+      case .cli(.delegate(.activateWorkspaceRequested(let workspaceId, let complete))):
+        // The CLI drives the same cross-profile activation pipeline as hotkeys.
+        guard let owner = state.config.profileId(owning: workspaceId) else {
+          return .run { _ in complete("The requested workspace no longer exists") }
+        }
+        let request = WorkspaceActivationFeature.CLIActivationRequest(
+          target: .workspace(workspaceId),
+          complete: complete,
+        )
+        let activation: Effect<Action> =
+          if owner != state.config.activeProfile?.id {
+            .send(.activateProfile(owner, focus: workspaceId))
+          } else {
+            .send(.activation(.activateFromCLI(
+              workspaceId: workspaceId,
+              requestID: request.id,
+            )))
+          }
+        return .concatenate(
+          .send(.activation(.trackCLIActivation(
+            request,
+            joinCurrentActivation: false,
+          ))),
+          activation,
+        )
+
+      case .cli(.delegate(.dispatchDomainCommandRequested(let action, let complete))):
+        if let error = actionAvailabilityError(action, config: state.config) {
+          return .run { _ in complete(error) }
+        }
+        // The CLI shares the exact dispatcher used by gestures and hotkeys.
+        // Its response is intentionally `accepted`: child reducers can still
+        // decide that changed live window/focus state leaves nothing to do.
+        return .concatenate(
+          route(action, config: state.config),
+          .run { _ in complete(nil) },
+        )
+
+      case .cli(.delegate(.configurationChanged)):
+        return .send(.hotKeys(.refreshBindings))
+
+      case .cli(.startCompleted):
+        state.didCompleteCLIStart = true
+        return publishStartupHooksIfReady(state: &state)
 
       case .workspaceList(.addWorkspaceFormSubmitted),
-           .workspaceList(.workspaceDeleteRequested),
+           .workspaceList(.alert(.presented(.confirmDeletion))),
            .workspaceList(.detail(.activateShortcutChanged)),
-           .workspaceList(.detail(.assignAppShortcutChanged)):
+           .workspaceList(.detail(.assignAppShortcutChanged)),
+           .workspaceList(.detail(.keyEquivalentChanged)),
+           .workspaceList(.detail(.borrowShortcutChanged)):
         return .send(.hotKeys(.refreshBindings))
 
       // Profile management (sidebar toolbar) routes its side-effecting ops here.
       case .workspaceList(.delegate(.activateProfile(let id))):
         return .send(.activateProfile(id, focus: nil))
+
+      case .workspaceList(.delegate(.activateProfileAfterDeletion(
+        let id,
+        previousProfile: let previousProfile,
+      ))):
+        return .send(.activateProfileAfterDeletion(id, previousProfile: previousProfile))
 
       case .workspaceList(.delegate(.profilesChanged)):
         return .send(.hotKeys(.refreshBindings))
@@ -462,20 +534,52 @@ public struct AppFeature {
       case .activation(.delegate(.profileSwitchRequested(let id, let focus))):
         return .send(.activateProfile(id, focus: focus))
 
-      case .activation(.delegate(.profileAutoActivated(let id))):
-        guard state.config.profiles.contains(where: { $0.id == id }) else { return .none }
+      case .activation(.delegate(.profileAutoActivated(let previousID, let id))):
+        guard let current = state.config.profiles.first(where: { $0.id == id }) else { return .none }
+        let previous = previousID.flatMap { previousID in
+          state.config.profiles.first(where: { $0.id == previousID })
+        }
         // The per-display HUD is shown from the activation reconfigure path
         // (it has the plan); here we just persist + rebind.
-        return .merge(
+        var effects: [Effect<Action>] = [
           .send(.hotKeys(.refreshBindings)),
           .run { [profileSessionStore] _ in await profileSessionStore.saveActiveProfileId(id) },
-        )
+        ]
+        if state.config.hasEnabledHook(for: .profileChanged) {
+          effects.append(.send(.hooks(.emit(HookInvocation(
+            event: .profileChanged,
+            occurredAt: now,
+            profile: .init(current),
+            previousProfile: previous.map(HookInvocation.ProfileSnapshot.init),
+          )))))
+        }
+        return .merge(effects)
+
+      case .startupProfileRestored:
+        state.didRestoreStartupProfile = true
+        return publishStartupHooksIfReady(state: &state)
 
       case .activation(.delegate(.startupProfileResolved(let id))):
         guard state.config.profiles.contains(where: { $0.id == id }) else { return .none }
         return .run { [profileSessionStore] _ in
           await profileSessionStore.saveActiveProfileId(id)
         }
+
+      case .activation(.activationCompleted(let workspaceId, let display, let generation)):
+        guard
+          state.activation.activeActivationGeneration == generation,
+          state.config.hasEnabledHook(for: .workspaceActivated),
+          let profileID = state.config.profileId(owning: workspaceId),
+          let profile = state.config.profiles.first(where: { $0.id == profileID }),
+          let workspace = profile.workspaces[id: workspaceId]
+        else { return .none }
+        return .send(.hooks(.emit(HookInvocation(
+          event: .workspaceActivated,
+          occurredAt: now,
+          profile: .init(profile),
+          workspace: .init(workspace),
+          display: display.map(HookInvocation.DisplaySnapshot.init),
+        ))))
 
       case .workspaceList(.detail(.layoutChanged)):
         // Re-tile now if the edited workspace is the active one, so the window
@@ -486,15 +590,12 @@ public struct AppFeature {
         else { return .none }
         return .send(.activation(.activate(workspaceId: wsId, setFocus: false)))
 
-      case .workspaceList(.detail(.importWorkspace)):
-        // An import can change the key equivalent (rebind) and the app set
-        // (re-tile if it's the active workspace).
+      case .workspaceList(.detail(.delegate(.importApplied(let workspaceId)))):
+        // Only a successfully committed import delegates here. A rejected
+        // conflict/stale review must not rebind or re-tile unchanged state.
         var effects: [Effect<Action>] = [.send(.hotKeys(.refreshBindings))]
-        if
-          let wsId = state.workspaceList.detail?.workspaceId,
-          state.activation.activeWorkspacesByDisplay.values.contains(wsId)
-        {
-          effects.append(.send(.activation(.activate(workspaceId: wsId, setFocus: false))))
+        if state.activation.activeWorkspacesByDisplay.values.contains(workspaceId) {
+          effects.append(.send(.activation(.activate(workspaceId: workspaceId, setFocus: false))))
         }
         return .merge(effects)
 
@@ -572,15 +673,117 @@ public struct AppFeature {
   @Dependency(\.debugLog) var debugLog
   @Dependency(\.errorReporter) var errorReporter
   @Dependency(\.workspaceHUD) var workspaceHUD
-  @Dependency(\.layoutStore) var layoutStore
   @Dependency(\.hotKeys) var hotKeys
   @Dependency(\.profileSessionStore) var profileSessionStore
+  @Dependency(\.date.now) var now
 
   // MARK: Private
 
   /// Identifies the app-lifetime subscription bundle so a duplicate
   /// `.task` (defensive; see `didStartUp`) replaces rather than doubles it.
   private enum CancelID { case startupSubscriptions }
+
+  /// Publishes startup work only after profile restoration and the CLI
+  /// listener's terminal result. Launch precedes the initial `profileChanged`
+  /// publication and workspace activation. The CLI is available to the launch
+  /// hook only when that terminal result was successful.
+  private func publishStartupHooksIfReady(state: inout State) -> Effect<Action> {
+    guard
+      state.didRestoreStartupProfile,
+      state.didCompleteCLIStart,
+      !state.didPublishTatamiLaunched
+    else { return .none }
+    state.didPublishTatamiLaunched = true
+
+    // `AppConfig` always seeds at least one profile. Treat an empty profile
+    // list as a broken startup invariant and surface it instead of silently
+    // dropping the launch lifecycle event.
+    guard let profile = state.config.activeProfile else {
+      errorReporter.report(
+        "StartupHooks",
+        String(localized: "Hook configuration is invalid"),
+        "Tatami launch context has no active profile after startup restoration",
+      )
+      return .none
+    }
+
+    let launchEffect: Effect<Action> =
+      if state.config.hasEnabledHook(for: .tatamiLaunched) {
+        .send(.hooks(.emit(HookInvocation(
+          event: .tatamiLaunched,
+          occurredAt: now,
+          profile: .init(profile),
+        ))))
+      } else {
+        .none
+      }
+    let profileChangedEffect: Effect<Action> =
+      if state.config.hasEnabledHook(for: .profileChanged) {
+        .send(.hooks(.emit(HookInvocation(
+          event: .profileChanged,
+          occurredAt: now,
+          profile: .init(profile),
+        ))))
+      } else {
+        .none
+      }
+    return .concatenate(
+      launchEffect,
+      profileChangedEffect,
+      .send(.activation(.activateInitial)),
+    )
+  }
+
+  private func activateProfileEffect(
+    _ id: Profile.ID,
+    focus: Workspace.ID?,
+    previousProfile: Profile?,
+    state: inout State,
+  ) -> Effect<Action> {
+    guard state.config.profiles.contains(where: { $0.id == id }) else {
+      guard
+        let request = state.activation.pendingCLIActivation,
+        request.target == .profile(id)
+      else { return .none }
+      return .send(.activation(.failCLIActivation(
+        requestID: request.id,
+        error: "The requested profile no longer exists",
+      )))
+    }
+    guard state.config.activeProfileId != id else {
+      // Already the active profile. Just focus the requested workspace, if any.
+      if let focus { return .send(.activation(.activate(workspaceId: focus, setFocus: true))) }
+      return .none
+    }
+    let outgoingProfile = previousProfile ?? state.config.activeProfile
+    state.$config.withLock { $0.activeProfileId = id }
+    let currentProfile = state.config.activeProfile
+    let hook: Effect<Action> =
+      if
+        state.config.hasEnabledHook(for: .profileChanged),
+        let currentProfile,
+        outgoingProfile?.id != currentProfile.id
+      {
+        .send(.hooks(.emit(HookInvocation(
+          event: .profileChanged,
+          occurredAt: now,
+          profile: .init(currentProfile),
+          previousProfile: outgoingProfile.map(HookInvocation.ProfileSnapshot.init),
+        ))))
+      } else {
+        .none
+      }
+    // The sidebar is independent of the active profile, so switching which
+    // profile runs does not disturb what is being viewed or edited.
+    return .merge(
+      .send(.hotKeys(.refreshBindings)),
+      // Retile every display for the new profile. When `focus` is set, the
+      // plan ends on that workspace so it lands active.
+      .send(.activation(.reactivateActiveProfile(focus: focus))),
+      .run { [profileSessionStore] _ in await profileSessionStore.saveActiveProfileId(id) },
+      hook,
+    )
+  }
 
   private func route(
     _ action: HotKeyAction,
@@ -726,6 +929,30 @@ public struct AppFeature {
     }
   }
 
+  private func actionAvailabilityError(
+    _ action: HotKeyAction,
+    config: AppConfig,
+  ) -> String? {
+    switch action {
+    case .activateWorkspace(let id),
+         .assignFocusedAppToWorkspace(let id):
+      config.workspace(id: id) == nil ? "The requested workspace no longer exists" : nil
+
+    case .borrowWorkspace(let id):
+      config.activeProfile?.workspaces[id: id] == nil
+        ? "The requested workspace is no longer available in the active profile"
+        : nil
+
+    case .activateProfile(let id):
+      config.profiles.contains(where: { $0.id == id })
+        ? nil
+        : "The requested profile no longer exists"
+
+    default:
+      nil
+    }
+  }
+
 }
 
 extension GestureAction {
@@ -770,6 +997,14 @@ extension GestureAction {
     case .assignAppToWorkspace(let id): .assignFocusedAppToWorkspace(id)
     case .borrowWorkspace(let id): .borrowWorkspace(id)
     case .activateProfile(let id): .activateProfile(id)
+    }
+  }
+}
+
+extension AppConfig {
+  fileprivate func hasEnabledHook(for event: HookEvent) -> Bool {
+    HookDefinition.validate(hooks).validHooks.contains {
+      $0.enabled && $0.event == event
     }
   }
 }

--- a/TatamiKit/Sources/Dependencies/ConfigPersistenceClient.swift
+++ b/TatamiKit/Sources/Dependencies/ConfigPersistenceClient.swift
@@ -1,0 +1,406 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Darwin
+import Dependencies
+import Foundation
+import Sharing
+
+// MARK: - ConfigPersistenceClient
+
+/// Performs a durable configuration transaction before publishing its value
+/// through `@Shared`. The raw revision is captured before asynchronous layout
+/// work, and the custom shared key suppresses the matching didSet write after
+/// the transaction has already replaced the file.
+struct ConfigPersistenceClient: Sendable {
+  var captureRevision: @Sendable (_ expected: AppConfig) throws -> Data?
+  var commit: @Sendable (
+    _ config: Shared<AppConfig>,
+    _ baseline: AppConfig,
+    _ revision: Data?,
+    _ updated: AppConfig,
+    _ reserve: @Sendable () -> Bool,
+  ) throws -> Void
+}
+
+// MARK: DependencyKey
+
+extension ConfigPersistenceClient: DependencyKey {
+  static let liveValue = ConfigPersistenceClient(
+    captureRevision: { expected in
+      try TatamiConfigTransactionCoordinator.shared.captureRevision(expected: expected)
+    },
+    commit: { config, baseline, revision, updated, reserve in
+      try config.withLock { current in
+        guard current.hasSamePersistedContent(as: baseline) else {
+          throw ConfigPersistenceError.changedInMemory
+        }
+        var next = updated
+        next.activeProfileId = current.activeProfileId
+        try TatamiConfigTransactionCoordinator.shared.replace(
+          revision: revision,
+          with: next,
+          reserve: reserve,
+        )
+        current = next
+      }
+    },
+  )
+
+  static let testValue = ConfigPersistenceClient(
+    captureRevision: { _ in nil },
+    commit: { config, baseline, _, updated, reserve in
+      try config.withLock { current in
+        guard current.hasSamePersistedContent(as: baseline) else {
+          throw ConfigPersistenceError.changedInMemory
+        }
+        var next = updated
+        next.activeProfileId = current.activeProfileId
+        guard reserve() else { throw ConfigPersistenceError.transactionExpired }
+        current = next
+      }
+    },
+  )
+  static let previewValue = testValue
+}
+
+// MARK: - TatamiConfigTransactionCoordinator
+
+final class TatamiConfigTransactionCoordinator: @unchecked Sendable {
+
+  // MARK: Internal
+
+  static let shared = TatamiConfigTransactionCoordinator()
+
+  func serialize<R>(_ operation: () throws -> R) rethrows -> R {
+    try lock.withLock(operation)
+  }
+
+  func consumeSuppressedDidSet(_ value: AppConfig) -> Bool {
+    lock.withLock {
+      guard
+        let suppressedDidSet,
+        suppressedDidSet.hasSamePersistedContent(as: value)
+      else { return false }
+      self.suppressedDidSet = nil
+      return true
+    }
+  }
+
+  func recordSelfWrite(_ value: AppConfig) {
+    lock.withLock {
+      sessionProfileID = value.activeProfileId
+      recentSelfWrite = (value, Date.now.addingTimeInterval(2))
+    }
+  }
+
+  func preservingSessionProfile(in decoded: AppConfig) -> AppConfig {
+    lock.withLock {
+      var decoded = decoded
+      if
+        let sessionProfileID,
+        decoded.profiles.contains(where: { $0.id == sessionProfileID })
+      {
+        decoded.activeProfileId = sessionProfileID
+      }
+      return decoded
+    }
+  }
+
+  func shouldSuppressFileEcho(_ value: AppConfig) -> Bool {
+    lock.withLock {
+      guard let recentSelfWrite else { return false }
+      guard recentSelfWrite.expiresAt >= .now else {
+        self.recentSelfWrite = nil
+        return false
+      }
+      return recentSelfWrite.value.hasSamePersistedContent(as: value)
+    }
+  }
+
+  func captureRevision(
+    expected: AppConfig,
+    at url: URL = ConfigLocation.fileURL,
+  ) throws -> Data? {
+    try serialize {
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true,
+      )
+      let revision = try readConfigDataIfPresent(at: url)
+      try validateConfigRevision(revision, expected: expected)
+      return revision
+    }
+  }
+
+  func replace(
+    revision: Data?,
+    with updated: AppConfig,
+    at url: URL = ConfigLocation.fileURL,
+    reserve: @Sendable () -> Bool = { true },
+    afterPreflightCheck: @Sendable () -> Void = { },
+    afterInitialExchange: @Sendable () -> Void = { },
+  ) throws {
+    try serialize {
+      try FileManager.default.createDirectory(
+        at: url.deletingLastPathComponent(),
+        withIntermediateDirectories: true,
+      )
+      let data = try encodeTatamiConfig(updated)
+      var coordinationError: NSError?
+      var operationError: (any Error)?
+      NSFileCoordinator().coordinate(
+        writingItemAt: url,
+        options: .forReplacing,
+        error: &coordinationError,
+      ) { coordinatedURL in
+        do {
+          try compareAndSwapConfigFile(
+            at: coordinatedURL,
+            expectedRevision: revision,
+            updatedData: data,
+            reserve: reserve,
+            afterPreflightCheck: afterPreflightCheck,
+            afterInitialExchange: afterInitialExchange,
+          )
+        } catch {
+          operationError = error
+        }
+      }
+      if let operationError { throw operationError }
+      if let coordinationError { throw coordinationError }
+      suppressedDidSet = updated
+      sessionProfileID = updated.activeProfileId
+      recentSelfWrite = (updated, Date.now.addingTimeInterval(2))
+    }
+  }
+
+  // MARK: Private
+
+  private let lock = NSRecursiveLock()
+  private var recentSelfWrite: (value: AppConfig, expiresAt: Date)?
+  private var sessionProfileID: Profile.ID?
+  private var suppressedDidSet: AppConfig?
+
+}
+
+// MARK: - Revision validation
+
+private let freshConfigSeed = AppConfig(settings: AppSettings(shortcuts: .recommended))
+
+func validateConfigRevision(_ revision: Data?, expected: AppConfig) throws {
+  if let revision, !revision.isEmpty {
+    let onDisk = try decodeTatamiConfig(revision)
+    guard onDisk.hasSamePersistedContent(as: expected) else {
+      throw ConfigPersistenceError.changedOnDisk
+    }
+  } else {
+    guard hasSameFreshSeedContent(expected) else {
+      throw ConfigPersistenceError.changedOnDisk
+    }
+  }
+}
+
+private func hasSameFreshSeedContent(_ config: AppConfig) -> Bool {
+  guard config.profiles.count == 1, freshConfigSeed.profiles.count == 1 else { return false }
+  var normalized = config
+  // The default profile UUID is generated per installation. Normalize only
+  // that identity while still comparing every persisted user-facing field.
+  normalized.profiles[0].id = freshConfigSeed.profiles[0].id
+  return normalized.hasSamePersistedContent(as: freshConfigSeed)
+}
+
+// MARK: - ConfigPersistenceError
+
+enum ConfigPersistenceError: Error, LocalizedError {
+  case changedInMemory
+  case changedOnDisk
+  case outcomeUnknown(recoveryPath: String?)
+  case transactionExpired
+
+  // MARK: Internal
+
+  var errorDescription: String? {
+    switch self {
+    case .changedInMemory:
+      "Configuration changed while the command was running"
+
+    case .changedOnDisk:
+      "config.toml changed on disk while the command was running"
+
+    case .outcomeUnknown(let recoveryPath):
+      if let recoveryPath {
+        "The config transaction outcome is unknown; preserved displaced data at \(recoveryPath)"
+      } else {
+        "The config transaction outcome is unknown"
+      }
+
+    case .transactionExpired:
+      "The CLI connection expired before the command could commit"
+    }
+  }
+}
+
+private func readConfigDataIfPresent(at url: URL = ConfigLocation.fileURL) throws -> Data? {
+  do {
+    return try Data(contentsOf: url)
+  } catch let error as CocoaError where error.code == .fileReadNoSuchFile {
+    return nil
+  }
+}
+
+/// Atomically exchanges the candidate with the live file, then validates the
+/// displaced bytes. This preserves a POSIX/rename writer that landed after
+/// revision capture but did not participate in NSFileCoordinator.
+private func compareAndSwapConfigFile(
+  at url: URL,
+  expectedRevision: Data?,
+  updatedData: Data,
+  reserve: @Sendable () -> Bool,
+  afterPreflightCheck: @Sendable () -> Void,
+  afterInitialExchange: @Sendable () -> Void,
+) throws {
+  let temporaryURL = url.deletingLastPathComponent()
+    .appendingPathComponent(".tatami-config-\(UUID().uuidString).tmp")
+  var shouldRemoveTemporary = true
+  defer {
+    if shouldRemoveTemporary {
+      try? FileManager.default.removeItem(at: temporaryURL)
+    }
+  }
+  try updatedData.write(to: temporaryURL, options: .atomic)
+  let candidateIdentity = try configFileIdentity(at: temporaryURL)
+  // Reject the common stale-revision case before touching the live inode. The
+  // exchange and displaced-byte validation below remain necessary for a writer
+  // that lands in the narrow interval after this check.
+  let liveRevision = try readConfigDataIfPresent(at: url)
+  guard liveRevision == expectedRevision else {
+    throw ConfigPersistenceError.changedOnDisk
+  }
+  afterPreflightCheck()
+  guard reserve() else { throw ConfigPersistenceError.transactionExpired }
+
+  if expectedRevision == nil {
+    let result = renameConfigFile(temporaryURL, url, flags: UInt32(RENAME_EXCL))
+    guard result == 0 else {
+      if errno == EEXIST { throw ConfigPersistenceError.changedOnDisk }
+      throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    return
+  }
+
+  let swapResult = renameConfigFile(temporaryURL, url, flags: UInt32(RENAME_SWAP))
+  guard swapResult == 0 else {
+    if errno == ENOENT { throw ConfigPersistenceError.changedOnDisk }
+    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+  }
+  afterInitialExchange()
+
+  let displaced: Data
+  let displacedIdentity: ConfigFileIdentity
+  do {
+    displaced = try Data(contentsOf: temporaryURL)
+    displacedIdentity = try configFileIdentity(at: temporaryURL)
+  } catch {
+    shouldRemoveTemporary = false
+    throw ConfigPersistenceError.outcomeUnknown(recoveryPath: temporaryURL.path)
+  }
+  guard displaced == expectedRevision else {
+    do {
+      try restoreDisplacedConfig(
+        at: url,
+        temporaryURL: temporaryURL,
+        displaced: displaced,
+        displacedIdentity: displacedIdentity,
+        candidate: updatedData,
+        candidateIdentity: candidateIdentity,
+      )
+    } catch {
+      shouldRemoveTemporary = false
+      throw ConfigPersistenceError.outcomeUnknown(recoveryPath: temporaryURL.path)
+    }
+    throw ConfigPersistenceError.changedOnDisk
+  }
+}
+
+/// Restores the value displaced by a failed exchange without deleting a newer
+/// uncoordinated writer. After each swap, the bytes moved into the temporary
+/// path prove whether the expected live value was replaced. If another writer
+/// won the race, that newer value becomes the next restoration candidate.
+private func restoreDisplacedConfig(
+  at url: URL,
+  temporaryURL: URL,
+  displaced: Data,
+  displacedIdentity: ConfigFileIdentity,
+  candidate: Data,
+  candidateIdentity: ConfigFileIdentity,
+) throws {
+  var desiredLive = displaced
+  var desiredLiveIdentity = displacedIdentity
+  var expectedLive = candidate
+  var expectedLiveIdentity = candidateIdentity
+  for _ in 0 ..< 8 {
+    let result = renameConfigFile(
+      temporaryURL,
+      url,
+      flags: UInt32(RENAME_SWAP),
+    )
+    guard result == 0 else {
+      throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+    }
+    let swappedOut = try Data(contentsOf: temporaryURL)
+    let swappedOutIdentity = try configFileIdentity(at: temporaryURL)
+    if swappedOut == expectedLive, swappedOutIdentity == expectedLiveIdentity {
+      return
+    }
+    expectedLive = desiredLive
+    expectedLiveIdentity = desiredLiveIdentity
+    desiredLive = swappedOut
+    desiredLiveIdentity = swappedOutIdentity
+  }
+  throw ConfigPersistenceError.outcomeUnknown(recoveryPath: temporaryURL.path)
+}
+
+// MARK: - ConfigFileIdentity
+
+/// Stable across `RENAME_SWAP`, but changes when the same inode is rewritten.
+/// Darwin updates ctime for the swap itself, so mtime is the content-generation
+/// clock here; nanosecond precision plus size closes the same-byte ABA that a
+/// device/inode pair alone cannot distinguish.
+private struct ConfigFileIdentity: Equatable {
+  var device: dev_t
+  var inode: ino_t
+  var size: off_t
+  var modifiedSeconds: Int64
+  var modifiedNanoseconds: Int64
+}
+
+private func configFileIdentity(at url: URL) throws -> ConfigFileIdentity {
+  var metadata = stat()
+  let result = url.path.withCString { Darwin.lstat($0, &metadata) }
+  guard result == 0 else {
+    throw POSIXError(POSIXErrorCode(rawValue: errno) ?? .EIO)
+  }
+  return ConfigFileIdentity(
+    device: metadata.st_dev,
+    inode: metadata.st_ino,
+    size: metadata.st_size,
+    modifiedSeconds: Int64(metadata.st_mtimespec.tv_sec),
+    modifiedNanoseconds: Int64(metadata.st_mtimespec.tv_nsec),
+  )
+}
+
+private func renameConfigFile(_ source: URL, _ destination: URL, flags: UInt32) -> Int32 {
+  source.path.withCString { sourcePath in
+    destination.path.withCString { destinationPath in
+      renameatx_np(AT_FDCWD, sourcePath, AT_FDCWD, destinationPath, flags)
+    }
+  }
+}
+
+extension DependencyValues {
+  var configPersistence: ConfigPersistenceClient {
+    get { self[ConfigPersistenceClient.self] }
+    set { self[ConfigPersistenceClient.self] = newValue }
+  }
+}

--- a/TatamiKit/Sources/Dependencies/HookRunnerClient.swift
+++ b/TatamiKit/Sources/Dependencies/HookRunnerClient.swift
@@ -1,0 +1,348 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Darwin
+import Dependencies
+import DependenciesMacros
+import Foundation
+import Subprocess
+
+// MARK: - HookExecutionResult
+
+public enum HookExecutionResult: Equatable, Sendable {
+  case success(stdout: String, stderr: String)
+  case failure(message: String, stdout: String, stderr: String)
+  case cancelled
+}
+
+// MARK: - HookRunnerClient
+
+@DependencyClient
+struct HookRunnerClient: Sendable {
+  var run: @Sendable (HookDefinition, HookInvocation) async -> HookExecutionResult = { _, _ in
+    .cancelled
+  }
+}
+
+// MARK: DependencyKey
+
+extension HookRunnerClient: DependencyKey {
+  static var liveValue: HookRunnerClient {
+    HookRunnerClient(run: runHook)
+  }
+
+  static var testValue: HookRunnerClient {
+    HookRunnerClient()
+  }
+
+  static var previewValue: HookRunnerClient {
+    testValue
+  }
+}
+
+extension DependencyValues {
+  var hookRunner: HookRunnerClient {
+    get { self[HookRunnerClient.self] }
+    set { self[HookRunnerClient.self] = newValue }
+  }
+}
+
+// MARK: - HookProcessResult
+
+private struct HookProcessResult: Sendable {
+  var termination: HookTermination
+  var stdout: String
+  var stderr: String
+}
+
+// MARK: - HookTermination
+
+private enum HookTermination: Sendable {
+  case exited(Int32)
+  case signaled(Int32)
+}
+
+// MARK: - HookSupervisionResult
+
+private enum HookSupervisionResult: Sendable {
+  case cancelled
+  case completed
+  case timedOut
+}
+
+// MARK: - HookSupervisionEvent
+
+private enum HookSupervisionEvent: Sendable {
+  case cancelled
+  case processExited
+  case timedOut
+}
+
+private func runHook(
+  _ hook: HookDefinition,
+  _ invocation: HookInvocation,
+) async -> HookExecutionResult {
+  do {
+    try Task.checkCancellation()
+
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = [.sortedKeys]
+    let input = String(decoding: try encoder.encode(invocation), as: UTF8.self) + "\n"
+
+    guard let executableValue = hook.command.first else {
+      return .failure(message: "Command is empty", stdout: "", stderr: "")
+    }
+    let expandedExecutable = expandHome(in: executableValue)
+    let executable: Executable = executableValue.contains("/")
+      ? .path(.init(expandedExecutable))
+      : .name(executableValue)
+    let arguments = Arguments(Array(hook.command.dropFirst()))
+
+    var environment = Subprocess.Environment.inherit
+      .updating(environmentOverrides(hook.environment))
+    environment = environment.updating(environmentOverrides(invocation.environment(hookID: hook.id)))
+    let processEnvironment = environment
+
+    var options = PlatformOptions()
+    options.createSession = true
+    options.qualityOfService = .utility
+    options.teardownSequence = [
+      .gracefulShutDown(
+        toProcessGroup: true,
+        allowedDurationToNextStep: .milliseconds(250),
+      )
+    ]
+    let platformOptions = options
+
+    let workingDirectory = hook.workingDirectory
+      .map(expandHome(in:))
+      ?? ConfigLocation.directory.path
+    let result = try await run(
+      executable,
+      arguments: arguments,
+      environment: processEnvironment,
+      workingDirectory: .init(workingDirectory),
+      platformOptions: platformOptions,
+      input: .string(input),
+      output: .string(limit: 65_536),
+      error: .string(limit: 65_536),
+    ) { execution in
+      await supervise(execution, timeoutMs: hook.timeoutMs)
+    }
+    if result.closureResult == .cancelled { return .cancelled }
+    if result.closureResult == .timedOut {
+      return .failure(
+        message: "Timed out after \(hook.timeoutMs) ms",
+        stdout: result.standardOutput,
+        stderr: result.standardError,
+      )
+    }
+    let termination: HookTermination =
+      switch result.terminationStatus {
+      case .exited(let code): .exited(code)
+      case .signaled(let signal): .signaled(signal)
+      }
+    let process = HookProcessResult(
+      termination: termination,
+      stdout: result.standardOutput,
+      stderr: result.standardError,
+    )
+
+    switch process.termination {
+    case .exited(0):
+      return .success(stdout: process.stdout, stderr: process.stderr)
+
+    case .exited(let code):
+      return .failure(
+        message: "Exited with status \(code)",
+        stdout: process.stdout,
+        stderr: process.stderr,
+      )
+
+    case .signaled(let signal):
+      return .failure(
+        message: "Terminated by signal \(signal)",
+        stdout: process.stdout,
+        stderr: process.stderr,
+      )
+    }
+  } catch is CancellationError {
+    return .cancelled
+  } catch {
+    if Task.isCancelled { return .cancelled }
+    return .failure(message: String(describing: error), stdout: "", stderr: "")
+  }
+}
+
+/// Supervise the isolated process session while swift-subprocess still owns the
+/// unreaped leader pid. This makes session identity stable: even if the leader
+/// exits before a TERM-ignoring descendant, the pid cannot be reused before
+/// the terminal group SIGKILL is sent.
+private func supervise(
+  _ execution: Execution<some InputProtocol, some OutputProtocol, some OutputProtocol>,
+  timeoutMs: Int,
+) async -> HookSupervisionResult {
+  let leaderPID = execution.processIdentifier.value
+  let sessionID = Darwin.getsid(leaderPID) == leaderPID ? leaderPID : nil
+  let exitEvents = processExitEvents(for: leaderPID)
+  let first = await withTaskGroup(of: HookSupervisionEvent.self) { group in
+    group.addTask {
+      for await _ in exitEvents { return .processExited }
+      return .cancelled
+    }
+    group.addTask {
+      do {
+        try await Task.sleep(for: .milliseconds(timeoutMs))
+        return .timedOut
+      } catch {
+        return .cancelled
+      }
+    }
+    let first = await group.next() ?? .cancelled
+    group.cancelAll()
+    return first
+  }
+
+  switch first {
+  case .processExited:
+    // Hooks may not daemonize descendants. Kill anything that outlived the
+    // command while its zombie leader still pins the session identity. Shells
+    // can put background jobs in separate process groups, so group-only cleanup
+    // is insufficient even though Tatami created a fresh session.
+    await killHookSession(sessionID, fallback: execution)
+    return .completed
+
+  case .timedOut:
+    await terminateHookSession(sessionID, fallback: execution)
+    return .timedOut
+
+  case .cancelled:
+    await terminateHookSession(sessionID, fallback: execution)
+    return .cancelled
+  }
+}
+
+private func terminateHookSession(
+  _ sessionID: pid_t?,
+  fallback execution: Execution<some InputProtocol, some OutputProtocol, some OutputProtocol>,
+) async {
+  if let sessionID {
+    signalProcesses(inSession: sessionID, signal: SIGTERM)
+  } else {
+    try? execution.send(signal: .terminate, toProcessGroup: true)
+  }
+  // Cancellation must not skip the grace period. This child task is awaited,
+  // and does not inherit the caller's cancelled state.
+  await Task { try? await Task.sleep(for: .milliseconds(250)) }.value
+  await killHookSession(sessionID, fallback: execution)
+}
+
+private func killHookSession(
+  _ sessionID: pid_t?,
+  fallback execution: Execution<some InputProtocol, some OutputProtocol, some OutputProtocol>,
+) async {
+  guard let sessionID else {
+    try? execution.send(signal: .kill, toProcessGroup: true)
+    return
+  }
+  // Re-scan to close the small fork-during-cleanup window. The leader remains
+  // unreaped until this function returns, so this session id cannot be reused.
+  for attempt in 0 ..< 3 {
+    signalProcesses(inSession: sessionID, signal: SIGKILL)
+    if attempt < 2 {
+      await Task { try? await Task.sleep(for: .milliseconds(10)) }.value
+    }
+  }
+}
+
+private func signalProcesses(inSession sessionID: pid_t, signal: Int32) {
+  let capacity = max(Int(Darwin.proc_listallpids(nil, 0)) + 64, 64)
+  var pids = [pid_t](repeating: 0, count: capacity)
+  let count = pids.withUnsafeMutableBytes { buffer in
+    Darwin.proc_listallpids(buffer.baseAddress, Int32(buffer.count))
+  }
+  guard count > 0 else { return }
+  for pid in pids.prefix(min(Int(count), pids.count))
+    where pid > 1 && Darwin.getsid(pid) == sessionID
+  {
+    _ = Darwin.kill(pid, signal)
+  }
+}
+
+private func processExitEvents(for pid: pid_t) -> AsyncStream<Void> {
+  AsyncStream { continuation in
+    let monitor = ProcessExitMonitor(pid: pid, continuation: continuation)
+    continuation.onTermination = { _ in monitor.cancel() }
+    monitor.activate()
+  }
+}
+
+// MARK: - ProcessExitMonitor
+
+private final class ProcessExitMonitor: @unchecked Sendable {
+
+  // MARK: Lifecycle
+
+  init(pid: pid_t, continuation: AsyncStream<Void>.Continuation) {
+    source = DispatchSource.makeProcessSource(
+      identifier: pid,
+      eventMask: .exit,
+      queue: .global(qos: .utility),
+    )
+    source.setEventHandler {
+      continuation.yield()
+      continuation.finish()
+    }
+    source.setCancelHandler { continuation.finish() }
+  }
+
+  // MARK: Internal
+
+  func activate() {
+    source.activate()
+  }
+
+  func cancel() {
+    source.cancel()
+  }
+
+  // MARK: Private
+
+  private let source: DispatchSourceProcess
+
+}
+
+private func environmentOverrides(_ values: [String: String]) -> [Subprocess.Environment.Key: String?] {
+  Dictionary(uniqueKeysWithValues: values.compactMap { key, value in
+    guard let environmentKey = Subprocess.Environment.Key(rawValue: key) else { return nil }
+    return (environmentKey, value)
+  })
+}
+
+private func expandHome(in path: String) -> String {
+  if path == "~" { return NSHomeDirectory() }
+  guard path.hasPrefix("~/") else { return path }
+  return NSHomeDirectory() + path.dropFirst()
+}
+
+extension HookInvocation {
+  fileprivate func environment(hookID: String) -> [String: String] {
+    var values = [
+      "TATAMI_HOOK_ID": hookID,
+      "TATAMI_HOOK_EVENT": event.rawValue,
+      "TATAMI_PROFILE_ID": profile.id.uuidString,
+      "TATAMI_PROFILE_NAME": profile.name,
+    ]
+    if let workspace {
+      values["TATAMI_WORKSPACE_ID"] = workspace.id.uuidString
+      values["TATAMI_WORKSPACE_NAME"] = workspace.name
+      values["TATAMI_WORKSPACE_KIND"] = workspace.kind.rawValue
+    }
+    if let display {
+      values["TATAMI_DISPLAY_NAME"] = display.name
+      if let uuid = display.uuid { values["TATAMI_DISPLAY_UUID"] = uuid }
+    }
+    return values
+  }
+}

--- a/TatamiKit/Sources/Dependencies/HookRunnerClient.swift
+++ b/TatamiKit/Sources/Dependencies/HookRunnerClient.swift
@@ -91,7 +91,7 @@ private func runHook(
     let input = String(decoding: try encoder.encode(invocation), as: UTF8.self) + "\n"
 
     guard let executableValue = hook.command.first else {
-      return .failure(message: "Command is empty", stdout: "", stderr: "")
+      return .failure(message: String(localized: "Command is empty"), stdout: "", stderr: "")
     }
     let expandedExecutable = expandHome(in: executableValue)
     let executable: Executable = executableValue.contains("/")
@@ -133,7 +133,9 @@ private func runHook(
     if result.closureResult == .cancelled { return .cancelled }
     if result.closureResult == .timedOut {
       return .failure(
-        message: "Timed out after \(hook.timeoutMs) ms",
+        message: String(
+          localized: "Timed out after \(hook.timeoutMs, format: .number.grouping(.never)) ms"
+        ),
         stdout: result.standardOutput,
         stderr: result.standardError,
       )
@@ -155,14 +157,14 @@ private func runHook(
 
     case .exited(let code):
       return .failure(
-        message: "Exited with status \(code)",
+        message: String(localized: "Exited with status \(code, format: .number.grouping(.never))"),
         stdout: process.stdout,
         stderr: process.stderr,
       )
 
     case .signaled(let signal):
       return .failure(
-        message: "Terminated by signal \(signal)",
+        message: String(localized: "Terminated by signal \(signal, format: .number.grouping(.never))"),
         stdout: process.stdout,
         stderr: process.stderr,
       )

--- a/TatamiKit/Sources/Dependencies/HotKeysClient.swift
+++ b/TatamiKit/Sources/Dependencies/HotKeysClient.swift
@@ -96,17 +96,17 @@ extension HotKeyAction {
     case .activateWorkspace(let id):
       String(
         localized:
-          "Activate \(config.activeProfile?.workspaces[id: id]?.name ?? String(localized: "workspace"))"
+          "Activate \(config.workspace(id: id)?.name ?? String(localized: "workspace"))"
       )
     case .assignFocusedAppToWorkspace(let id):
       String(
         localized:
-          "Assign app to \(config.activeProfile?.workspaces[id: id]?.name ?? String(localized: "workspace"))"
+          "Assign app to \(config.workspace(id: id)?.name ?? String(localized: "workspace"))"
       )
     case .borrowWorkspace(let id):
       String(
         localized:
-          "Borrow \(config.activeProfile?.workspaces[id: id]?.name ?? String(localized: "workspace"))"
+          "Borrow \(config.workspace(id: id)?.name ?? String(localized: "workspace"))"
       )
     case .switchToNextWorkspace: String(localized: "Next workspace")
     case .switchToPreviousWorkspace: String(localized: "Previous workspace")
@@ -194,6 +194,19 @@ extension HotKeyAction {
     case .borrowNextWorkspace: "borrow-next-workspace"
     case .borrowPreviousWorkspace: "borrow-prev-workspace"
     case .dismissBorrow: "dismiss-borrow"
+    }
+  }
+
+  /// The workspace whose profile scopes this action, or nil for an action that
+  /// is registered regardless of the active profile.
+  var workspaceId: Workspace.ID? {
+    switch self {
+    case .activateWorkspace(let id),
+         .assignFocusedAppToWorkspace(let id),
+         .borrowWorkspace(let id):
+      id
+    default:
+      nil
     }
   }
 

--- a/TatamiKit/Sources/Dependencies/LayoutStoreClient.swift
+++ b/TatamiKit/Sources/Dependencies/LayoutStoreClient.swift
@@ -18,6 +18,11 @@ struct LayoutStoreClient: Sendable {
   var save: @Sendable (UUID, LayoutSnapshot) async -> Void
   var load: @Sendable (UUID) async -> LayoutSnapshot?
   var clear: @Sendable (UUID) async -> Void
+  /// Copy zero or more workspace snapshots with one atomic map write. A source
+  /// without a saved snapshot is a successful no-op for that pair.
+  var copyLayouts: @Sendable ([UUID: UUID]) async -> Bool = { _ in false }
+  /// Remove multiple snapshots with one atomic map write.
+  var removeLayouts: @Sendable ([UUID]) async -> Bool = { _ in false }
 }
 
 /// On-disk shape of one workspace's tiling memory. Stores the BSP layout keyed
@@ -131,6 +136,8 @@ extension LayoutStoreClient: DependencyKey {
       save: { id, snapshot in await store.save(workspaceId: id, snapshot: snapshot) },
       load: { id in await store.load(workspaceId: id) },
       clear: { id in await store.clear(workspaceId: id) },
+      copyLayouts: { mapping in await store.copyLayouts(mapping) },
+      removeLayouts: { ids in await store.removeLayouts(ids) },
     )
   }()
 
@@ -138,6 +145,8 @@ extension LayoutStoreClient: DependencyKey {
     save: { _, _ in },
     load: { _ in nil },
     clear: { _ in },
+    copyLayouts: { _ in true },
+    removeLayouts: { _ in true },
   )
   static let previewValue = testValue
 }
@@ -170,8 +179,8 @@ private actor LayoutStore {
     var map = loadedMap()
     guard map[workspaceId.uuidString] != snapshot else { return }
     map[workspaceId.uuidString] = snapshot
+    guard writeMap(map) else { return }
     cachedMap = map
-    writeMap(map)
   }
 
   func load(workspaceId: UUID) -> LayoutSnapshot? {
@@ -179,10 +188,33 @@ private actor LayoutStore {
   }
 
   func clear(workspaceId: UUID) {
+    _ = removeLayouts([workspaceId])
+  }
+
+  func removeLayouts(_ workspaceIDs: [UUID]) -> Bool {
     var map = loadedMap()
-    guard map.removeValue(forKey: workspaceId.uuidString) != nil else { return }
+    var changed = false
+    for id in workspaceIDs {
+      changed = map.removeValue(forKey: id.uuidString) != nil || changed
+    }
+    guard changed else { return true }
+    guard writeMap(map) else { return false }
     cachedMap = map
-    writeMap(map)
+    return true
+  }
+
+  func copyLayouts(_ mapping: [UUID: UUID]) -> Bool {
+    let current = loadedMap()
+    var updated = current
+    for (source, destination) in mapping {
+      if let snapshot = current[source.uuidString] {
+        updated[destination.uuidString] = snapshot
+      }
+    }
+    guard updated != current else { return true }
+    guard writeMap(updated) else { return false }
+    cachedMap = updated
+    return true
   }
 
   private func loadedMap() -> [String: LayoutSnapshot] {
@@ -225,13 +257,14 @@ private actor LayoutStore {
     }
   }
 
-  private func writeMap(_ map: [String: LayoutSnapshot]) {
+  private func writeMap(_ map: [String: LayoutSnapshot]) -> Bool {
     @Dependency(\.errorReporter) var reporter
     do {
       try ConfigLocation.ensureDirectoryExists()
       let data = try YYJSONEncoder().encode(map)
       try data.write(to: fileURL, options: .atomic)
       reporter.resolve("Layouts")
+      return true
     } catch {
       logger.error("layout save failed: \(error.localizedDescription, privacy: .public)")
       reporter.report(
@@ -239,6 +272,7 @@ private actor LayoutStore {
         String(localized: "layouts.json could not be saved — layout changes won't persist"),
         ErrorReportClient.describe(error)
       )
+      return false
     }
   }
 }

--- a/TatamiKit/Sources/Dependencies/SocketServer.swift
+++ b/TatamiKit/Sources/Dependencies/SocketServer.swift
@@ -9,6 +9,8 @@ import OSLog
 import TatamiCLIProtocol
 import YYJSON
 
+// MARK: - SocketServerClient
+
 /// Accepts CLI connections on a Unix domain socket and exposes incoming
 /// `Request`s as an `AsyncStream`. Each request carries a continuation
 /// the caller fulfills with a `Response`; the connection is closed after
@@ -19,38 +21,40 @@ import YYJSON
 /// this is a low-traffic, blocking-accept loop on a background queue.
 @DependencyClient
 struct SocketServerClient: Sendable {
-  /// Start the listener at `path`. Idempotent — calling twice does nothing.
-  var start: @Sendable (_ path: String) async throws -> Void
-  var requests: @Sendable () -> AsyncStream<Incoming> = { AsyncStream { _ in } }
-
   /// A pending CLI request along with a one-shot reply continuation.
   struct Incoming: Sendable {
-    let request: CLIMessage.Request
-    /// Send a response. May only be invoked once.
-    let reply: @Sendable (CLIMessage.Response) -> Void
-
     init(
       request: CLIMessage.Request,
-      reply: @escaping @Sendable (CLIMessage.Response) -> Void
+      reply: CLIReply,
     ) {
       self.request = request
       self.reply = reply
     }
+
+    let request: CLIMessage.Request
+    /// Claim and finish the connection's one-shot response slot.
+    let reply: CLIReply
   }
+
+  /// Start the listener at `path`. Idempotent. Calling twice does nothing.
+  var start: @Sendable (_ path: String) async throws -> Void
+  var requests: @Sendable () -> AsyncStream<Incoming> = { AsyncStream { _ in } }
 }
+
+// MARK: DependencyKey
 
 extension SocketServerClient: DependencyKey {
   static let liveValue: SocketServerClient = {
     let server = SocketServer()
     return SocketServerClient(
       start: { path in try await server.start(path: path) },
-      requests: { server.stream }
+      requests: { server.stream },
     )
   }()
 
   static let testValue = SocketServerClient(
     start: { _ in },
-    requests: { AsyncStream { _ in } }
+    requests: { AsyncStream { _ in } },
   )
 
   static let previewValue = testValue
@@ -63,18 +67,21 @@ extension DependencyValues {
   }
 }
 
-private actor SocketServer {
-  @Dependency(\.debugLog) private var debugLog
+// MARK: - SocketServer
 
-  let stream: AsyncStream<SocketServerClient.Incoming>
-  private let continuation: AsyncStream<SocketServerClient.Incoming>.Continuation
-  private var listenFD: OwnedFileDescriptor?
+private actor SocketServer {
+
+  // MARK: Lifecycle
 
   init() {
     var continuation: AsyncStream<SocketServerClient.Incoming>.Continuation!
-    self.stream = AsyncStream(bufferingPolicy: .unbounded) { continuation = $0 }
+    stream = AsyncStream(bufferingPolicy: .unbounded) { continuation = $0 }
     self.continuation = continuation
   }
+
+  // MARK: Internal
+
+  let stream: AsyncStream<SocketServerClient.Incoming>
 
   func start(path: String) throws {
     guard listenFD == nil else { return }
@@ -128,13 +135,13 @@ private actor SocketServer {
     // accept loop.
     let connections = DispatchQueue(
       label: "dev.PangMo5.Tatami.socket-connections",
-      attributes: .concurrent
+      attributes: .concurrent,
     )
     let acceptThread = Thread {
       Self.acceptLoop(
         listenFD: listenFD,
         continuation: continuation,
-        connections: connections
+        connections: connections,
       )
     }
     acceptThread.name = "dev.PangMo5.Tatami.socket-accept"
@@ -142,10 +149,17 @@ private actor SocketServer {
     acceptThread.start()
   }
 
+  // MARK: Private
+
+  @Dependency(\.debugLog) private var debugLog
+
+  private let continuation: AsyncStream<SocketServerClient.Incoming>.Continuation
+  private var listenFD: OwnedFileDescriptor?
+
   private static func acceptLoop(
     listenFD: Int32,
     continuation: AsyncStream<SocketServerClient.Incoming>.Continuation,
-    connections: DispatchQueue
+    connections: DispatchQueue,
   ) {
     while true {
       let clientFD = Darwin.accept(listenFD, nil, nil)
@@ -162,12 +176,26 @@ private actor SocketServer {
 
   private static func handleConnection(
     clientFD: Int32,
-    continuation: AsyncStream<SocketServerClient.Incoming>.Continuation
+    continuation: AsyncStream<SocketServerClient.Incoming>.Continuation,
   ) {
     let descriptor = OwnedFileDescriptor(rawValue: clientFD)
+    var noSigPipe: Int32 = 1
+    guard
+      Darwin.setsockopt(
+        descriptor.rawValue,
+        SOL_SOCKET,
+        SO_NOSIGPIPE,
+        &noSigPipe,
+        socklen_t(MemoryLayout<Int32>.size),
+      ) == 0
+    else {
+      logger.error("setsockopt(SO_NOSIGPIPE) failed: \(errno)")
+      return
+    }
     guard let line = readLine(fd: descriptor.rawValue), !line.isEmpty else { return }
-    guard let data = line.data(using: .utf8),
-          let request = try? YYJSONDecoder().decode(CLIMessage.Request.self, from: data)
+    guard
+      let data = line.data(using: .utf8),
+      let request = try? YYJSONDecoder().decode(CLIMessage.Request.self, from: data)
     else {
       writeResponse(fd: descriptor.rawValue, response: .failure("Invalid request format"))
       return
@@ -179,15 +207,53 @@ private actor SocketServer {
     // 5s deadline elapses.
     let responseBox = ResponseBox()
     let replied = DispatchSemaphore(value: 0)
-    let incoming = SocketServerClient.Incoming(request: request) { response in
-      responseBox.set(response)
-      replied.signal()
-    }
+    let incoming = SocketServerClient.Incoming(
+      request: request,
+      reply: CLIReply(
+        claim: { responseBox.claim() },
+        finish: { response in
+          if responseBox.finish(response) { replied.signal() }
+        },
+        respond: { response in
+          let responded = responseBox.respond(response)
+          if responded { replied.signal() }
+          return responded
+        },
+      ),
+    )
     continuation.yield(incoming)
 
     if replied.wait(timeout: .now() + 5) == .timedOut {
-      writeResponse(fd: descriptor.rawValue, response: .failure("Timeout"))
-      return
+      switch responseBox.expirePending() {
+      case .expired:
+        writeResponse(fd: descriptor.rawValue, response: .failure("Timeout"))
+        return
+
+      case .claimed:
+        // Config mutations claim only at the final atomic replacement. Allow
+        // a bounded grace period for that syscall and reducer acknowledgment;
+        // if it still does not finish, report an explicitly unknown outcome
+        // instead of leaking this worker forever or claiming a false failure.
+        if replied.wait(timeout: .now() + 15) == .timedOut {
+          switch responseBox.expireClaimed() {
+          case .expired,
+               .claimed:
+            writeResponse(
+              fd: descriptor.rawValue,
+              response: .failure(
+                "Command outcome is unknown; inspect current state before retrying"
+              ),
+            )
+            return
+
+          case .finished:
+            break
+          }
+        }
+
+      case .finished:
+        break
+      }
     }
     writeResponse(fd: descriptor.rawValue, response: responseBox.value ?? .failure("Timeout"))
   }
@@ -225,35 +291,125 @@ private actor SocketServer {
       }
     }
   }
+
 }
+
+// MARK: - OwnedFileDescriptor
 
 /// Sole owner of a POSIX file descriptor. Moving this value transfers close
 /// responsibility; it cannot be copied into two owners that both close the
 /// same descriptor. Scope exit also closes every early-return/error path.
 private struct OwnedFileDescriptor: ~Copyable {
-  let rawValue: Int32
-
   deinit {
     Darwin.close(rawValue)
   }
+
+  let rawValue: Int32
 }
 
+// MARK: - ResponseBox
+
 private final class ResponseBox: @unchecked Sendable {
-  private let lock = NSLock()
-  private var _value: CLIMessage.Response?
+
+  // MARK: Internal
+
+  enum Expiration {
+    case claimed
+    case expired
+    case finished
+  }
 
   var value: CLIMessage.Response? {
     lock.lock()
     defer { lock.unlock() }
-    return _value
+    guard case .finished(let response) = state else { return nil }
+    return response
   }
 
-  func set(_ response: CLIMessage.Response) {
+  func claim() -> Bool {
     lock.lock()
     defer { lock.unlock() }
-    _value = response
+    guard case .pending = state else { return false }
+    state = .claimed
+    return true
   }
+
+  func finish(_ response: CLIMessage.Response) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    guard case .claimed = state else { return false }
+    state = .finished(response)
+    return true
+  }
+
+  func respond(_ response: CLIMessage.Response) -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    switch state {
+    case .pending,
+         .claimed:
+      state = .finished(response)
+      return true
+
+    case .expired,
+         .finished:
+      return false
+    }
+  }
+
+  func expirePending() -> Expiration {
+    lock.lock()
+    defer { lock.unlock() }
+    switch state {
+    case .pending:
+      state = .expired
+      return .expired
+
+    case .claimed:
+      return .claimed
+
+    case .finished:
+      return .finished
+
+    case .expired:
+      return .expired
+    }
+  }
+
+  func expireClaimed() -> Expiration {
+    lock.lock()
+    defer { lock.unlock() }
+    switch state {
+    case .claimed:
+      state = .expired
+      return .expired
+
+    case .finished:
+      return .finished
+
+    case .pending:
+      return .claimed
+
+    case .expired:
+      return .expired
+    }
+  }
+
+  // MARK: Private
+
+  private enum State {
+    case claimed
+    case expired
+    case finished(CLIMessage.Response)
+    case pending
+  }
+
+  private let lock = NSLock()
+  private var state = State.pending
+
 }
+
+// MARK: - SocketError
 
 enum SocketError: Error, Sendable {
   case create(Int32)

--- a/TatamiKit/Sources/Dependencies/WhatsNewClient.swift
+++ b/TatamiKit/Sources/Dependencies/WhatsNewClient.swift
@@ -134,7 +134,7 @@ private struct WhatsNewView: View {
 
           // MARK: Feature highlights
           VStack(alignment: .leading, spacing: 14) {
-            Label("New", systemImage: "sparkles")
+            Label("Highlights", systemImage: "sparkles")
               .font(.headline)
 
             item(

--- a/TatamiKit/Sources/Dependencies/WhatsNewClient.swift
+++ b/TatamiKit/Sources/Dependencies/WhatsNewClient.swift
@@ -122,9 +122,14 @@ private struct WhatsNewView: View {
           VStack(alignment: .leading, spacing: 4) {
             Text("What's New in Tatami \(version)")
               .font(.title.weight(.semibold))
-            Text("Tatami is now available in five interface languages, with clearer names and guidance written for each locale.")
-              .font(.subheadline)
-              .foregroundStyle(.secondary)
+            Text(
+              """
+              Tatami 1.12 adds scriptable control and lifecycle hooks, plus safer, more selective profile and \
+              workspace duplication.
+              """
+            )
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
           }
 
           // MARK: Feature highlights
@@ -133,24 +138,28 @@ private struct WhatsNewView: View {
               .font(.headline)
 
             item(
-              icon: "arrow.clockwise.circle",
-              title: "Use Tatami in your language",
-              detail: "Choose English, Korean, Japanese, Simplified Chinese, or Traditional Chinese. Tatami follows the language selected for the app in macOS.",
+              icon: "terminal",
+              title: "Control Tatami from the command line",
+              detail: """
+                Use domain commands for profiles, workspaces, windows, displays, layouts, and apps, with stable JSON \
+                output and every action available to trackpad gestures.
+                """,
             )
             item(
-              icon: "moon.zzz",
-              title: "Clearer names across the app",
-              detail: "Always on Top, Leave As Is, Window Switching, and On-Screen Feedback now describe what each control does.",
+              icon: "bolt.circle",
+              title: "Run programs on lifecycle events",
+              detail: """
+                Create and test hooks for Tatami launch, profile changes, and workspaces becoming visible on a \
+                display. Each event includes versioned JSON and useful environment variables.
+                """,
             )
             item(
-              icon: "bolt.horizontal.circle",
-              title: "Your configuration stays compatible",
-              detail: "Your workspaces, profiles, shortcuts, and existing `config.toml` continue to work. Stable configuration keys have not changed.",
-            )
-            item(
-              icon: "rectangle.3.group",
-              title: "Written for each language",
-              detail: "Instructions, empty states, errors, and confirmations are written around the task and next action instead of translated word for word.",
+              icon: "square.on.square",
+              title: "Choose what Duplicate keeps",
+              detail: """
+                Right-click a profile or workspace, review its workspaces, apps, settings, and saved layouts, then \
+                include only what you want.
+                """,
             )
           }
           .padding(.horizontal, 6)

--- a/TatamiKit/Sources/Dependencies/WorkspaceHUDClient.swift
+++ b/TatamiKit/Sources/Dependencies/WorkspaceHUDClient.swift
@@ -1267,10 +1267,16 @@ private struct WindowSwitcherItemView: View {
           .foregroundStyle(isSelected ? .primary : .secondary)
           .lineLimit(1)
         if showsWindowTitle {
-          Text(item.windowTitle ?? "Window")
-            .font(.caption2)
-            .foregroundStyle(isSelected ? .secondary : .tertiary)
-            .lineLimit(1)
+          Group {
+            if let windowTitle = item.windowTitle {
+              Text(windowTitle)
+            } else {
+              Text("Window")
+            }
+          }
+          .font(.caption2)
+          .foregroundStyle(isSelected ? .secondary : .tertiary)
+          .lineLimit(1)
         }
       }
       .frame(width: 84, height: showsWindowTitle ? 110 : 90)

--- a/TatamiKit/Sources/Domain/AppConfig.swift
+++ b/TatamiKit/Sources/Domain/AppConfig.swift
@@ -19,6 +19,9 @@ public struct AppConfig: Hashable, Sendable, Codable {
   /// into each workspace's layout when `false`, untiled + on top when `true`.
   public var sharedApps: [SharedApp]
   public var settings: AppSettings
+  /// User-authored lifecycle commands. Invalid entries remain visible but are
+  /// skipped by `HooksFeature` with a persistent diagnostic.
+  public var hooks: [HookDefinition]
   /// The active profile. `nil` → the first profile (back-compat with
   /// single-profile configs). Changed by a profile-switch hotkey or a
   /// display-activation rule.
@@ -28,16 +31,18 @@ public struct AppConfig: Hashable, Sendable, Codable {
     profiles: [Profile] = [Profile.makeDefault()],
     sharedApps: [SharedApp] = [],
     settings: AppSettings = AppSettings(),
+    hooks: [HookDefinition] = [],
     activeProfileId: Profile.ID? = nil
   ) {
     self.profiles = profiles
     self.sharedApps = sharedApps
     self.settings = settings
+    self.hooks = hooks
     self.activeProfileId = activeProfileId
   }
 
   private enum CodingKeys: String, CodingKey {
-    case profiles, sharedApps, settings
+    case profiles, sharedApps, settings, hooks
     // DEPRECATED: legacy key, read once to migrate into `sharedApps`. The
     // first GUI/CLI write re-serializes as `sharedApps`, so it disappears.
     // Remove after a few releases.
@@ -57,6 +62,9 @@ public struct AppConfig: Hashable, Sendable, Codable {
     self.settings = c.contains(.settings)
       ? try c.decode(AppSettings.self, forKey: .settings)
       : AppSettings()
+    self.hooks = c.contains(.hooks)
+      ? try c.decode([HookDefinition].self, forKey: .hooks)
+      : []
     if c.contains(.sharedApps) {
       self.sharedApps = try c.decode([SharedApp].self, forKey: .sharedApps)
     } else if c.contains(.floatingApps) {
@@ -80,6 +88,7 @@ public struct AppConfig: Hashable, Sendable, Codable {
     try c.encode(profiles, forKey: .profiles)
     try c.encode(sharedApps, forKey: .sharedApps)
     try c.encode(settings, forKey: .settings)
+    try c.encode(hooks, forKey: .hooks)
     // `activeProfileId` is intentionally not written — session state lives in
     // ProfileSessionStore (see the decode note above).
     // Legacy `floatingApps` is intentionally never written.
@@ -87,6 +96,30 @@ public struct AppConfig: Hashable, Sendable, Codable {
 }
 
 extension AppConfig {
+  /// Compare the configuration that is actually encoded to `config.toml`.
+  /// `activeProfileId` is session state and must not create false conflicts
+  /// while an asynchronous mutation prepares external data such as layouts.
+  func hasSamePersistedContent(as other: AppConfig) -> Bool {
+    var lhs = self
+    var rhs = other
+    lhs.activeProfileId = nil
+    rhs.activeProfileId = nil
+    return lhs == rhs
+  }
+
+  public struct ProfileDuplication: Equatable, Sendable {
+    public let profileId: Profile.ID
+    public let workspaceIdMap: [Workspace.ID: Workspace.ID]
+
+    public init(
+      profileId: Profile.ID,
+      workspaceIdMap: [Workspace.ID: Workspace.ID]
+    ) {
+      self.profileId = profileId
+      self.workspaceIdMap = workspaceIdMap
+    }
+  }
+
   /// The active profile: the one `activeProfileId` points at, falling back to
   /// the first by encounter order (back-compat with single-profile configs).
   public var activeProfile: Profile? {
@@ -191,11 +224,12 @@ extension AppConfig {
   /// old→new workspace-id remap so the caller can copy each workspace's saved
   /// layout (layouts are keyed by workspace id, which must be fresh here so
   /// the clone's tiling is independent). The clone drops its switch shortcut
-  /// and (future) auto-activation rule so it can't collide with the source.
-  /// Returns an empty map when `id` is unknown.
+  /// and auto-activation rule so it can't collide with the source.
+  /// Optionality distinguishes an unknown source from an empty profile, whose
+  /// valid workspace-id map is also empty.
   @discardableResult
-  public mutating func duplicateProfile(_ id: Profile.ID) -> [Workspace.ID: Workspace.ID] {
-    guard let srcIdx = profiles.firstIndex(where: { $0.id == id }) else { return [:] }
+  public mutating func duplicateProfile(_ id: Profile.ID) -> ProfileDuplication? {
+    guard let srcIdx = profiles.firstIndex(where: { $0.id == id }) else { return nil }
     let src = profiles[srcIdx]
     var remap: [Workspace.ID: Workspace.ID] = [:]
     var clonedWorkspaces: [Workspace] = []
@@ -207,14 +241,42 @@ extension AppConfig {
     }
     var clone = src
     clone.id = UUID()
-    clone.name = "\(src.name) copy"
+    clone.name = Self.duplicateName(
+      for: src.name,
+      existingNames: profiles.lazy.map(\.name)
+    )
     clone.shortcut = nil
     // Don't inherit the source's switch shortcut or auto-activation rule — two
     // profiles firing on the same hotkey / display set would collide.
     clone.autoActivation = nil
     clone.workspaces = IdentifiedArray(uniqueElements: clonedWorkspaces)
     profiles.insert(clone, at: srcIdx + 1)
-    return remap
+    return ProfileDuplication(profileId: clone.id, workspaceIdMap: remap)
+  }
+
+  /// Deep-copy a workspace beside its source. A same-profile clone drops all
+  /// direct and derived shortcut inputs so it cannot register duplicate global
+  /// bindings alongside the original.
+  @discardableResult
+  public mutating func duplicateWorkspace(_ id: Workspace.ID) -> Workspace.ID? {
+    guard
+      let profileIndex = profiles.firstIndex(where: { $0.workspaces[id: id] != nil }),
+      let sourceIndex = profiles[profileIndex].workspaces.firstIndex(where: { $0.id == id })
+    else { return nil }
+
+    let source = profiles[profileIndex].workspaces[sourceIndex]
+    var clone = source
+    clone.id = UUID()
+    clone.name = Self.duplicateName(
+      for: source.name,
+      existingNames: profiles[profileIndex].workspaces.lazy.map(\.name)
+    )
+    clone.keyEquivalent = nil
+    clone.activateShortcut = nil
+    clone.assignAppShortcut = nil
+    clone.borrowShortcut = nil
+    profiles[profileIndex].workspaces.insert(clone, at: sourceIndex + 1)
+    return clone.id
   }
 
   /// Names of workspaces in `targetId` that differ from the same-named
@@ -237,60 +299,147 @@ extension AppConfig {
     return diverged
   }
 
-  /// Copy a source profile's workspaces onto the target's, matched by name —
-  /// applying only the per-workspace app / field changes the user kept
-  /// (`excluded*ByWorkspace` map a workspace id to the app bundle ids / field
-  /// ids to skip). Nothing is hard-excluded, including the display pin: the
-  /// preview shows every difference and the user unchecks what to leave alone.
-  /// Profiles stay independent.
+  /// Project a source profile's reviewed changes onto the target, matched by
+  /// workspace name. The returned config is not published. Shortcut conflicts
+  /// are computed from the complete projected binding set, so selected fields
+  /// can conflict with either existing bindings or one another.
+  public func profileSyncProjection(
+    into targetId: Profile.ID,
+    from sourceId: Profile.ID,
+    excludedAppsByWorkspace: [Workspace.ID: Set<String>] = [:],
+    excludedFieldsByWorkspace: [Workspace.ID: Set<String>] = [:]
+  ) -> WorkspaceSyncProjection? {
+    guard targetId != sourceId,
+          let sourceIdx = profiles.firstIndex(where: { $0.id == sourceId }),
+          let targetIdx = profiles.firstIndex(where: { $0.id == targetId })
+    else { return nil }
+
+    let source = profiles[sourceIdx]
+    var projected = self
+    var shortcutSelections = Set<WorkspaceShortcutSelection>()
+    for workspace in profiles[targetIdx].workspaces {
+      guard
+        let match = source.workspaces.first(where: { $0.name == workspace.name }),
+        var updated = projected.profiles[targetIdx].workspaces[id: workspace.id]
+      else { continue }
+      let appChanges = WorkspaceSync.appChanges(from: match.apps, to: workspace.apps)
+      let fieldChanges = WorkspaceSync.fieldChanges(from: match, to: workspace)
+      guard !appChanges.isEmpty || !fieldChanges.isEmpty else { continue }
+      let excludedFields = excludedFieldsByWorkspace[workspace.id] ?? []
+      for change in fieldChanges where !excludedFields.contains(change.id) {
+        if let field = change.shortcutField {
+          shortcutSelections.insert(.init(workspaceId: workspace.id, field: field))
+        }
+      }
+      updated.apps = WorkspaceSync.apply(
+        appChanges,
+        to: updated.apps,
+        excluding: excludedAppsByWorkspace[workspace.id] ?? []
+      )
+      WorkspaceSync.apply(fieldChanges, to: &updated, excluding: excludedFields)
+      projected.profiles[targetIdx].workspaces[id: workspace.id] = updated
+    }
+    return WorkspaceSyncProjection(
+      config: projected,
+      conflicts: projected.shortcutCopyConflicts(
+        for: shortcutSelections,
+        comparedTo: self
+      )
+    )
+  }
+
+  /// Copy a source profile's workspaces onto the target's, matched by name,
+  /// applying only the per-workspace app / field changes the user kept.
+  /// The mutation is atomic: if any selected shortcut field conflicts after
+  /// the full selection is projected, nothing is copied and every collision
+  /// is returned to the caller.
+  @discardableResult
   public mutating func applyProfileSync(
     into targetId: Profile.ID,
     from sourceId: Profile.ID,
     excludedAppsByWorkspace: [Workspace.ID: Set<String>] = [:],
     excludedFieldsByWorkspace: [Workspace.ID: Set<String>] = [:]
-  ) {
-    guard targetId != sourceId,
-          let sourceIdx = profiles.firstIndex(where: { $0.id == sourceId }),
-          let targetIdx = profiles.firstIndex(where: { $0.id == targetId })
-    else { return }
-    let source = profiles[sourceIdx]
-    for ws in profiles[targetIdx].workspaces {
-      guard let match = source.workspaces.first(where: { $0.name == ws.name }) else { continue }
-      let appChanges = WorkspaceSync.appChanges(from: match.apps, to: ws.apps)
-      let fieldChanges = WorkspaceSync.fieldChanges(from: match, to: ws)
-      guard !appChanges.isEmpty || !fieldChanges.isEmpty,
-            var updated = profiles[targetIdx].workspaces[id: ws.id]
-      else { continue }
-      updated.apps = WorkspaceSync.apply(
-        appChanges, to: updated.apps, excluding: excludedAppsByWorkspace[ws.id] ?? []
-      )
-      WorkspaceSync.apply(
-        fieldChanges, to: &updated, excluding: excludedFieldsByWorkspace[ws.id] ?? []
-      )
-      profiles[targetIdx].workspaces[id: ws.id] = updated
-    }
+  ) -> [WorkspaceShortcutConflict] {
+    guard let projection = profileSyncProjection(
+      into: targetId,
+      from: sourceId,
+      excludedAppsByWorkspace: excludedAppsByWorkspace,
+      excludedFieldsByWorkspace: excludedFieldsByWorkspace
+    ) else { return [] }
+    guard projection.conflicts.isEmpty else { return projection.conflicts }
+    self = projection.config
+    return []
   }
 
-  /// Copy a source profile's workspace onto the target workspace: apply the app
-  /// changes (by bundle id) and setting changes (by field id) the user kept,
-  /// never touching the target's display pin. `targetWsId` is resolved in
-  /// whichever profile owns it (workspace ids are unique).
+  /// Project one source workspace's reviewed changes onto a target workspace.
+  /// The target workspace determines the profile scope used for validation.
+  public func workspaceImportProjection(
+    into targetWorkspaceId: Workspace.ID,
+    from sourceProfileId: Profile.ID,
+    sourceWorkspace sourceWorkspaceId: Workspace.ID,
+    excludingApps: Set<String> = [],
+    excludingFields: Set<String> = []
+  ) -> WorkspaceSyncProjection? {
+    guard
+      let sourceWorkspace = profiles.first(where: { $0.id == sourceProfileId })?
+        .workspaces[id: sourceWorkspaceId],
+      let targetWorkspace = workspace(id: targetWorkspaceId)
+    else { return nil }
+
+    let appChanges = WorkspaceSync.appChanges(
+      from: sourceWorkspace.apps,
+      to: targetWorkspace.apps
+    )
+    let fieldChanges = WorkspaceSync.fieldChanges(
+      from: sourceWorkspace,
+      to: targetWorkspace
+    )
+    var shortcutSelections = Set<WorkspaceShortcutSelection>()
+    for change in fieldChanges where !excludingFields.contains(change.id) {
+      if let field = change.shortcutField {
+        shortcutSelections.insert(.init(workspaceId: targetWorkspaceId, field: field))
+      }
+    }
+
+    var projected = self
+    projected.mutateWorkspace(targetWorkspaceId) { workspace in
+      workspace.apps = WorkspaceSync.apply(
+        appChanges,
+        to: workspace.apps,
+        excluding: excludingApps
+      )
+      WorkspaceSync.apply(fieldChanges, to: &workspace, excluding: excludingFields)
+    }
+    return WorkspaceSyncProjection(
+      config: projected,
+      conflicts: projected.shortcutCopyConflicts(
+        for: shortcutSelections,
+        comparedTo: self
+      )
+    )
+  }
+
+  /// Copy one source workspace onto the target. Like profile Copy, this is an
+  /// all-or-nothing validated mutation; a caller must resolve returned
+  /// conflicts instead of silently publishing duplicate bindings.
+  @discardableResult
   public mutating func importWorkspace(
     into targetWsId: Workspace.ID,
     from sourceProfileId: Profile.ID,
     sourceWorkspace sourceWsId: Workspace.ID,
     excludingApps: Set<String> = [],
     excludingFields: Set<String> = []
-  ) {
-    guard let sourceWs = profiles.first(where: { $0.id == sourceProfileId })?
-      .workspaces[id: sourceWsId]
-    else { return }
-    mutateWorkspace(targetWsId) { ws in
-      let appChanges = WorkspaceSync.appChanges(from: sourceWs.apps, to: ws.apps)
-      ws.apps = WorkspaceSync.apply(appChanges, to: ws.apps, excluding: excludingApps)
-      let fieldChanges = WorkspaceSync.fieldChanges(from: sourceWs, to: ws)
-      WorkspaceSync.apply(fieldChanges, to: &ws, excluding: excludingFields)
-    }
+  ) -> [WorkspaceShortcutConflict] {
+    guard let projection = workspaceImportProjection(
+      into: targetWsId,
+      from: sourceProfileId,
+      sourceWorkspace: sourceWsId,
+      excludingApps: excludingApps,
+      excludingFields: excludingFields
+    ) else { return [] }
+    guard projection.conflicts.isEmpty else { return projection.conflicts }
+    self = projection.config
+    return []
   }
 
   /// Mutate the workspace with `id` in whichever profile owns it — not just the
@@ -339,5 +488,38 @@ extension AppConfig {
       rest.insert(moved, at: insertionIndex)
       profile.workspaces = IdentifiedArray(uniqueElements: rest)
     }
+  }
+
+  /// Finder-style duplicate names: `Name copy`, then `Name copy 2`, while
+  /// continuing an existing suffix instead of producing `copy copy`.
+  private static func duplicateName(
+    for sourceName: String,
+    existingNames: some Sequence<String>
+  ) -> String {
+    let (baseName, firstIndex) = duplicateNameComponents(sourceName)
+    let existingNames = Set(existingNames)
+    var index = firstIndex
+    while true {
+      let candidate = index == 1
+        ? "\(baseName) copy"
+        : "\(baseName) copy \(index)"
+      if !existingNames.contains(candidate) { return candidate }
+      index += 1
+    }
+  }
+
+  private static func duplicateNameComponents(_ name: String) -> (baseName: String, index: Int) {
+    let copySuffix = " copy"
+    if name.hasSuffix(copySuffix) {
+      return (String(name.dropLast(copySuffix.count)), 2)
+    }
+    if
+      let range = name.range(of: " copy ", options: .backwards),
+      let suffix = Int(name[range.upperBound...]),
+      suffix >= 2
+    {
+      return (String(name[..<range.lowerBound]), suffix + 1)
+    }
+    return (name, 1)
   }
 }

--- a/TatamiKit/Sources/Domain/Gesture.swift
+++ b/TatamiKit/Sources/Domain/Gesture.swift
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import Foundation
+import TatamiCLIProtocol
 
 // MARK: - GestureDirection
 
@@ -104,6 +105,41 @@ public enum GestureAction: Codable, Hashable, Sendable, Identifiable {
   case borrowWorkspace(Workspace.ID)
   case activateProfile(Profile.ID)
 
+  // MARK: Lifecycle
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let value = try container.decode(String.self)
+    guard let action = Self(storageValue: value) else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unknown gesture action: \(value)",
+      )
+    }
+    self = action
+  }
+
+  private init?(storageValue: String) {
+    if let id = Self.id(after: Self.activateWorkspacePrefix, in: storageValue) {
+      self = .activateWorkspace(id)
+      return
+    }
+    if let id = Self.id(after: Self.assignAppToWorkspacePrefix, in: storageValue) {
+      self = .assignAppToWorkspace(id)
+      return
+    }
+    if let id = Self.id(after: Self.borrowWorkspacePrefix, in: storageValue) {
+      self = .borrowWorkspace(id)
+      return
+    }
+    if let id = Self.id(after: Self.activateProfilePrefix, in: storageValue) {
+      self = .activateProfile(id)
+      return
+    }
+    guard let action = Self.fixedActionByStorageValue[storageValue] else { return nil }
+    self = action
+  }
+
   // MARK: Public
 
   public enum Category: String, CaseIterable, Identifiable, Sendable {
@@ -191,60 +227,12 @@ public enum GestureAction: Codable, Hashable, Sendable, Identifiable {
     }
   }
 
-  public var id: String {
-    storageValue
-  }
-
   /// Fixed commands grouped by `Category`. Workspace/profile-specific actions
   /// are generated from the live config by the Settings picker.
   public static let fixedActions = Category.allCases.flatMap(\.actions)
 
-  public func title(in config: AppConfig) -> LocalizedStringResource {
-    switch self {
-    case .none: "None"
-    case .nextWorkspace: "Next workspace"
-    case .previousWorkspace: "Previous workspace"
-    case .recentWorkspace: "Recent workspace"
-    case .moveAppToNextWorkspace: "Move app to next workspace"
-    case .moveAppToPreviousWorkspace: "Move app to previous workspace"
-    case .assignAppToRecentWorkspace: "Assign app to recent workspace"
-    case .assignAppToNextWorkspace: "Assign app to next workspace"
-    case .assignAppToPreviousWorkspace: "Assign app to previous workspace"
-    case .focusNextDisplay: "Focus next display"
-    case .focusPreviousDisplay: "Focus previous display"
-    case .focusLeft: "Focus left"
-    case .focusRight: "Focus right"
-    case .focusUp: "Focus up"
-    case .focusDown: "Focus down"
-    case .cycleNextWindow: "Cycle next window"
-    case .cyclePreviousWindow: "Cycle previous window"
-    case .growWindow: "Grow window"
-    case .shrinkWindow: "Shrink window"
-    case .swapLeft: "Swap left"
-    case .swapRight: "Swap right"
-    case .swapUp: "Swap up"
-    case .swapDown: "Swap down"
-    case .toggleOrientation: "Toggle orientation"
-    case .toggleFullscreen: "Toggle fullscreen"
-    case .balanceLayout: "Balance layout"
-    case .toggleFloating: "Toggle floating"
-    case .toggleSharedFloating: "Toggle shared floating"
-    case .toggleTiling: "Pause or resume tiling"
-    case .toggleAppInWorkspace: "Toggle app in workspace"
-    case .toggleAppInSharedApps: "Toggle app in Shared Apps"
-    case .borrowRecentWorkspace: "Borrow recent workspace"
-    case .borrowNextWorkspace: "Borrow next workspace"
-    case .borrowPreviousWorkspace: "Borrow previous workspace"
-    case .dismissBorrow: "Dismiss borrow"
-    case .activateWorkspace(let id):
-      "Switch to \(workspaceName(id, in: config))"
-    case .assignAppToWorkspace(let id):
-      "Assign app to \(workspaceName(id, in: config))"
-    case .borrowWorkspace(let id):
-      "Borrow \(workspaceName(id, in: config))"
-    case .activateProfile(let id):
-      "Switch to \(profileName(id, in: config))"
-    }
+  public var id: String {
+    storageValue
   }
 
   public var category: Category {
@@ -300,35 +288,204 @@ public enum GestureAction: Codable, Hashable, Sendable, Identifiable {
     }
   }
 
+  public func title(in config: AppConfig) -> LocalizedStringResource {
+    switch self {
+    case .none: "None"
+    case .nextWorkspace: "Next workspace"
+    case .previousWorkspace: "Previous workspace"
+    case .recentWorkspace: "Recent workspace"
+    case .moveAppToNextWorkspace: "Move app to next workspace"
+    case .moveAppToPreviousWorkspace: "Move app to previous workspace"
+    case .assignAppToRecentWorkspace: "Assign app to recent workspace"
+    case .assignAppToNextWorkspace: "Assign app to next workspace"
+    case .assignAppToPreviousWorkspace: "Assign app to previous workspace"
+    case .focusNextDisplay: "Focus next display"
+    case .focusPreviousDisplay: "Focus previous display"
+    case .focusLeft: "Focus left"
+    case .focusRight: "Focus right"
+    case .focusUp: "Focus up"
+    case .focusDown: "Focus down"
+    case .cycleNextWindow: "Cycle next window"
+    case .cyclePreviousWindow: "Cycle previous window"
+    case .growWindow: "Grow window"
+    case .shrinkWindow: "Shrink window"
+    case .swapLeft: "Swap left"
+    case .swapRight: "Swap right"
+    case .swapUp: "Swap up"
+    case .swapDown: "Swap down"
+    case .toggleOrientation: "Toggle orientation"
+    case .toggleFullscreen: "Toggle fullscreen"
+    case .balanceLayout: "Balance layout"
+    case .toggleFloating: "Toggle floating"
+    case .toggleSharedFloating: "Toggle shared floating"
+    case .toggleTiling: "Pause or resume tiling"
+    case .toggleAppInWorkspace: "Toggle app in workspace"
+    case .toggleAppInSharedApps: "Toggle app in Shared Apps"
+    case .borrowRecentWorkspace: "Borrow recent workspace"
+    case .borrowNextWorkspace: "Borrow next workspace"
+    case .borrowPreviousWorkspace: "Borrow previous workspace"
+    case .dismissBorrow: "Dismiss borrow"
+    case .activateWorkspace(let id):
+      "Switch to \(workspaceName(id, in: config))"
+    case .assignAppToWorkspace(let id):
+      "Assign app to \(workspaceName(id, in: config))"
+    case .borrowWorkspace(let id):
+      "Borrow \(workspaceName(id, in: config))"
+    case .activateProfile(let id):
+      "Switch to \(profileName(id, in: config))"
+    }
+  }
+
   public func isAvailable(in config: AppConfig) -> Bool {
     switch self {
     case .activateWorkspace(let id),
          .assignAppToWorkspace(let id):
-      return config.profiles.contains { $0.workspaces[id: id] != nil }
+      config.profiles.contains { $0.workspaces[id: id] != nil }
     case .borrowWorkspace(let id):
-      return config.activeProfile?.workspaces[id: id] != nil
+      config.activeProfile?.workspaces[id: id] != nil
     case .activateProfile(let id):
-      return config.profiles.contains(where: { $0.id == id })
+      config.profiles.contains(where: { $0.id == id })
     default:
-      return true
+      true
     }
-  }
-
-  public init(from decoder: Decoder) throws {
-    let container = try decoder.singleValueContainer()
-    let value = try container.decode(String.self)
-    guard let action = Self(storageValue: value) else {
-      throw DecodingError.dataCorruptedError(
-        in: container,
-        debugDescription: "Unknown gesture action: \(value)"
-      )
-    }
-    self = action
   }
 
   public func encode(to encoder: Encoder) throws {
     var container = encoder.singleValueContainer()
     try container.encode(storageValue)
+  }
+
+  // MARK: Internal
+
+  /// The typed domain command that exposes this behavior through the CLI.
+  /// `.none` is configuration state, not executable behavior.
+  var cliDomainCommand: CLIMessage.DomainCommand? {
+    switch self {
+    case .none: nil
+    case .nextWorkspace: .workspaceNext
+    case .previousWorkspace: .workspacePrevious
+    case .recentWorkspace: .workspaceRecent
+    case .moveAppToNextWorkspace: .workspaceMoveAppNext
+    case .moveAppToPreviousWorkspace: .workspaceMoveAppPrevious
+    case .assignAppToRecentWorkspace: .workspaceAssignAppRecent
+    case .assignAppToNextWorkspace: .workspaceAssignAppNext
+    case .assignAppToPreviousWorkspace: .workspaceAssignAppPrevious
+    case .focusNextDisplay: .displayFocusNext
+    case .focusPreviousDisplay: .displayFocusPrevious
+    case .focusLeft: .windowFocusLeft
+    case .focusRight: .windowFocusRight
+    case .focusUp: .windowFocusUp
+    case .focusDown: .windowFocusDown
+    case .cycleNextWindow: .windowCycleNext
+    case .cyclePreviousWindow: .windowCyclePrevious
+    case .growWindow: .windowResizeGrow
+    case .shrinkWindow: .windowResizeShrink
+    case .swapLeft: .windowSwapLeft
+    case .swapRight: .windowSwapRight
+    case .swapUp: .windowSwapUp
+    case .swapDown: .windowSwapDown
+    case .toggleOrientation: .layoutToggleOrientation
+    case .toggleFullscreen: .windowToggleFullscreen
+    case .balanceLayout: .layoutBalance
+    case .toggleFloating: .windowToggleFloating
+    case .toggleSharedFloating: .windowToggleSharedFloating
+    case .toggleTiling: .layoutToggleTiling
+    case .toggleAppInWorkspace: .appToggleWorkspace
+    case .toggleAppInSharedApps: .appToggleShared
+    case .borrowRecentWorkspace: .workspaceBorrowRecent
+    case .borrowNextWorkspace: .workspaceBorrowNext
+    case .borrowPreviousWorkspace: .workspaceBorrowPrevious
+    case .dismissBorrow: .workspaceDismissBorrow
+    case .activateWorkspace: .workspaceActivate
+    case .assignAppToWorkspace: .workspaceAssignAppTo
+    case .borrowWorkspace: .workspaceBorrowFrom
+    case .activateProfile: .profileActivate
+    }
+  }
+
+  static func cliAction(
+    for command: CLIMessage.DomainCommand,
+    workspaceId: Workspace.ID? = nil,
+    profileId: Profile.ID? = nil,
+  ) -> Self? {
+    switch command {
+    case .profileActivate:
+      profileId.map(Self.activateProfile)
+    case .workspaceActivate:
+      workspaceId.map(Self.activateWorkspace)
+    case .workspaceNext:
+      .nextWorkspace
+    case .workspacePrevious:
+      .previousWorkspace
+    case .workspaceRecent:
+      .recentWorkspace
+    case .workspaceMoveAppNext:
+      .moveAppToNextWorkspace
+    case .workspaceMoveAppPrevious:
+      .moveAppToPreviousWorkspace
+    case .workspaceAssignAppTo:
+      workspaceId.map(Self.assignAppToWorkspace)
+    case .workspaceAssignAppNext:
+      .assignAppToNextWorkspace
+    case .workspaceAssignAppPrevious:
+      .assignAppToPreviousWorkspace
+    case .workspaceAssignAppRecent:
+      .assignAppToRecentWorkspace
+    case .workspaceBorrowFrom:
+      workspaceId.map(Self.borrowWorkspace)
+    case .workspaceBorrowNext:
+      .borrowNextWorkspace
+    case .workspaceBorrowPrevious:
+      .borrowPreviousWorkspace
+    case .workspaceBorrowRecent:
+      .borrowRecentWorkspace
+    case .workspaceDismissBorrow:
+      .dismissBorrow
+    case .windowFocusLeft:
+      .focusLeft
+    case .windowFocusRight:
+      .focusRight
+    case .windowFocusUp:
+      .focusUp
+    case .windowFocusDown:
+      .focusDown
+    case .windowCycleNext:
+      .cycleNextWindow
+    case .windowCyclePrevious:
+      .cyclePreviousWindow
+    case .windowResizeGrow:
+      .growWindow
+    case .windowResizeShrink:
+      .shrinkWindow
+    case .windowSwapLeft:
+      .swapLeft
+    case .windowSwapRight:
+      .swapRight
+    case .windowSwapUp:
+      .swapUp
+    case .windowSwapDown:
+      .swapDown
+    case .windowToggleFullscreen:
+      .toggleFullscreen
+    case .windowToggleFloating:
+      .toggleFloating
+    case .windowToggleSharedFloating:
+      .toggleSharedFloating
+    case .displayFocusNext:
+      .focusNextDisplay
+    case .displayFocusPrevious:
+      .focusPreviousDisplay
+    case .layoutToggleOrientation:
+      .toggleOrientation
+    case .layoutBalance:
+      .balanceLayout
+    case .layoutToggleTiling:
+      .toggleTiling
+    case .appToggleWorkspace:
+      .toggleAppInWorkspace
+    case .appToggleShared:
+      .toggleAppInSharedApps
+    }
   }
 
   // MARK: Private
@@ -338,26 +495,10 @@ public enum GestureAction: Codable, Hashable, Sendable, Identifiable {
   private static let borrowWorkspacePrefix = "borrowWorkspace:"
   private static let activateProfilePrefix = "activateProfile:"
 
-  private init?(storageValue: String) {
-    if let id = Self.id(after: Self.activateWorkspacePrefix, in: storageValue) {
-      self = .activateWorkspace(id)
-      return
-    }
-    if let id = Self.id(after: Self.assignAppToWorkspacePrefix, in: storageValue) {
-      self = .assignAppToWorkspace(id)
-      return
-    }
-    if let id = Self.id(after: Self.borrowWorkspacePrefix, in: storageValue) {
-      self = .borrowWorkspace(id)
-      return
-    }
-    if let id = Self.id(after: Self.activateProfilePrefix, in: storageValue) {
-      self = .activateProfile(id)
-      return
-    }
-    guard let action = Self.fixedActionByStorageValue[storageValue] else { return nil }
-    self = action
-  }
+  private static let fixedActionByStorageValue: [String: Self] = Dictionary(uniqueKeysWithValues: fixedActions.map { (
+    $0.storageValue,
+    $0,
+  ) })
 
   private var storageValue: String {
     switch self {
@@ -402,10 +543,6 @@ public enum GestureAction: Codable, Hashable, Sendable, Identifiable {
     case .activateProfile(let id): Self.activateProfilePrefix + id.uuidString
     }
   }
-
-  private static let fixedActionByStorageValue: [String: Self] = {
-    Dictionary(uniqueKeysWithValues: fixedActions.map { ($0.storageValue, $0) })
-  }()
 
   private static func id(after prefix: String, in value: String) -> UUID? {
     guard value.hasPrefix(prefix) else { return nil }

--- a/TatamiKit/Sources/Domain/Hook.swift
+++ b/TatamiKit/Sources/Domain/Hook.swift
@@ -197,6 +197,29 @@ public struct HookValidationIssue: Equatable, Hashable, Sendable {
     case timeoutOutOfRange
     case invalidWorkingDirectory
     case invalidEnvironment
+
+    // MARK: Public
+
+    public var localizedMessage: LocalizedStringResource {
+      switch self {
+      case .emptyID:
+        "Enter an identifier."
+      case .invalidID:
+        "Use only ASCII letters, numbers, period, underscore, or hyphen in the identifier."
+      case .duplicateID:
+        "Choose a unique identifier."
+      case .emptyCommand:
+        "Choose an executable."
+      case .nulCommand:
+        "Executable and arguments cannot contain NUL."
+      case .timeoutOutOfRange:
+        "Timeout must be between 100 and 300000 milliseconds."
+      case .invalidWorkingDirectory:
+        "Working directory must be absolute or start with ~/."
+      case .invalidEnvironment:
+        "Environment variable names must be valid and values cannot contain NUL."
+      }
+    }
   }
 
   public let hookIndex: Int

--- a/TatamiKit/Sources/Domain/Hook.swift
+++ b/TatamiKit/Sources/Domain/Hook.swift
@@ -1,0 +1,353 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import Foundation
+
+// MARK: - HookEvent
+
+/// Stable lifecycle events that can launch a configured hook.
+public enum HookEvent: String, Codable, Sendable, CaseIterable {
+  /// Tatami finished restoring its startup profile for this process.
+  case tatamiLaunched
+  /// The active profile selection changed. `previousProfile` is nil at startup.
+  case profileChanged
+  /// A workspace activation published its visible state on a display.
+  case workspaceActivated
+}
+
+// MARK: - HookDefinition
+
+/// One direct executable invocation persisted in `config.toml`.
+///
+/// `command` is argv, not a shell command: element zero is the executable and
+/// every remaining element is passed as one argument. A shell must be opted
+/// into explicitly (for example, `["/bin/zsh", "-lc", "..."]`).
+public struct HookDefinition: Hashable, Sendable, Codable, Identifiable {
+
+  // MARK: Lifecycle
+
+  public init(
+    id: String,
+    event: HookEvent,
+    enabled: Bool = true,
+    command: [String],
+    timeoutMs: Int = 5_000,
+    workingDirectory: String? = nil,
+    environment: [String: String] = [:],
+  ) {
+    self.id = id
+    self.event = event
+    self.enabled = enabled
+    self.command = command
+    self.timeoutMs = timeoutMs
+    self.workingDirectory = workingDirectory
+    self.environment = environment
+  }
+
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    id = try container.decode(String.self, forKey: .id)
+    event = try container.decode(HookEvent.self, forKey: .event)
+    enabled = try container.decodeIfPresent(Bool.self, forKey: .enabled) ?? true
+    command = try container.decode([String].self, forKey: .command)
+    timeoutMs = try container.decodeIfPresent(Int.self, forKey: .timeoutMs) ?? 5_000
+    workingDirectory = try container.decodeIfPresent(String.self, forKey: .workingDirectory)
+    environment = try container.decodeIfPresent([String: String].self, forKey: .environment) ?? [:]
+  }
+
+  // MARK: Public
+
+  public var id: String
+  public var event: HookEvent
+  public var enabled: Bool
+  public var command: [String]
+  public var timeoutMs: Int
+  public var workingDirectory: String?
+  public var environment: [String: String]
+
+  // MARK: Private
+
+  private enum CodingKeys: String, CodingKey {
+    case id
+    case event
+    case enabled
+    case command
+    case timeoutMs
+    case workingDirectory
+    case environment
+  }
+
+}
+
+// MARK: - HookInvocation
+
+/// A small, versioned event envelope written to a hook's standard input.
+public struct HookInvocation: Hashable, Sendable, Codable {
+
+  // MARK: Lifecycle
+
+  public init(
+    schemaVersion: Int = 1,
+    event: HookEvent,
+    occurredAt: Date,
+    profile: ProfileSnapshot,
+    previousProfile: ProfileSnapshot? = nil,
+    workspace: WorkspaceSnapshot? = nil,
+    display: DisplaySnapshot? = nil,
+  ) {
+    self.schemaVersion = schemaVersion
+    self.event = event
+    self.occurredAt = occurredAt
+    self.profile = profile
+    self.previousProfile = previousProfile
+    self.workspace = workspace
+    self.display = display
+  }
+
+  // MARK: Public
+
+  public struct ProfileSnapshot: Hashable, Sendable, Codable {
+    public init(id: UUID, name: String) {
+      self.id = id
+      self.name = name
+    }
+
+    public init(_ profile: Profile) {
+      self.init(id: profile.id, name: profile.name)
+    }
+
+    public var id: UUID
+    public var name: String
+  }
+
+  public struct WorkspaceSnapshot: Hashable, Sendable, Codable {
+    public init(id: UUID, name: String, kind: WorkspaceKind) {
+      self.id = id
+      self.name = name
+      self.kind = kind
+    }
+
+    public init(_ workspace: Workspace) {
+      self.init(id: workspace.id, name: workspace.name, kind: workspace.kind)
+    }
+
+    public var id: UUID
+    public var name: String
+    public var kind: WorkspaceKind
+  }
+
+  public struct DisplaySnapshot: Hashable, Sendable, Codable {
+    public init(uuid: String?, name: String) {
+      self.uuid = uuid
+      self.name = name
+    }
+
+    public init(_ display: DisplayName) {
+      self.init(uuid: display.uuid, name: display.name)
+    }
+
+    public var uuid: String?
+    public var name: String
+  }
+
+  public var schemaVersion: Int
+  public var event: HookEvent
+  public var occurredAt: Date
+  public var profile: ProfileSnapshot
+  public var previousProfile: ProfileSnapshot?
+  public var workspace: WorkspaceSnapshot?
+  public var display: DisplaySnapshot?
+
+}
+
+// MARK: - HookValidationIssue
+
+public struct HookValidationIssue: Equatable, Hashable, Sendable {
+
+  // MARK: Lifecycle
+
+  public init(
+    hookIndex: Int,
+    field: Field,
+    code: Code,
+    message: String,
+  ) {
+    self.hookIndex = hookIndex
+    self.field = field
+    self.code = code
+    self.message = message
+  }
+
+  // MARK: Public
+
+  public enum Field: Equatable, Hashable, Sendable {
+    case id
+    case command
+    case timeoutMs
+    case workingDirectory
+    case environment(key: String)
+  }
+
+  public enum Code: Equatable, Hashable, Sendable {
+    case emptyID
+    case invalidID
+    case duplicateID
+    case emptyCommand
+    case nulCommand
+    case timeoutOutOfRange
+    case invalidWorkingDirectory
+    case invalidEnvironment
+  }
+
+  public let hookIndex: Int
+  public let field: Field
+  public let code: Code
+  public let message: String
+
+}
+
+// MARK: - HookConfigurationValidation
+
+public struct HookConfigurationValidation: Equatable, Sendable {
+  public init(
+    validHooks: [HookDefinition],
+    issues: [String],
+    detailedIssues: [HookValidationIssue] = [],
+  ) {
+    self.validHooks = validHooks
+    self.issues = issues
+    self.detailedIssues = detailedIssues
+  }
+
+  public var validHooks: [HookDefinition]
+  public var issues: [String]
+  public var detailedIssues: [HookValidationIssue]
+}
+
+extension HookDefinition {
+  /// Validate semantics that Codable cannot express without silently repairing
+  /// user input. Invalid entries stay visible in the config but never execute.
+  public static func validate(_ hooks: [HookDefinition]) -> HookConfigurationValidation {
+    let duplicateIDs = Set(
+      Dictionary(grouping: hooks, by: \.id)
+        .filter { $0.value.count > 1 }
+        .keys
+    )
+    var validHooks = [HookDefinition]()
+    var issues = [String]()
+    var detailedIssues = [HookValidationIssue]()
+
+    for (hookIndex, hook) in hooks.enumerated() {
+      let issueStartIndex = detailedIssues.endIndex
+      func appendIssue(
+        field: HookValidationIssue.Field,
+        code: HookValidationIssue.Code,
+        message: String,
+      ) {
+        detailedIssues.append(HookValidationIssue(
+          hookIndex: hookIndex,
+          field: field,
+          code: code,
+          message: message,
+        ))
+        if !issues.contains(message) { issues.append(message) }
+      }
+
+      if hook.id.isEmpty {
+        appendIssue(
+          field: .id,
+          code: .emptyID,
+          message: "A hook id cannot be empty",
+        )
+      }
+      if hook.id.count > 64 || !hook.id.unicodeScalars.allSatisfy(isValidIDScalar) {
+        appendIssue(
+          field: .id,
+          code: .invalidID,
+          message: "Hook \"\(hook.id)\" has an invalid id (use ASCII letters, numbers, '.', '_' or '-')",
+        )
+      }
+      if duplicateIDs.contains(hook.id) {
+        appendIssue(
+          field: .id,
+          code: .duplicateID,
+          message: "Hook id \"\(hook.id)\" is duplicated",
+        )
+      }
+      if hook.command.first?.isEmpty != false {
+        appendIssue(
+          field: .command,
+          code: .emptyCommand,
+          message: "Hook \"\(hook.id)\" has an empty command",
+        )
+      }
+      if hook.command.contains(where: { $0.utf8.contains(0) }) {
+        appendIssue(
+          field: .command,
+          code: .nulCommand,
+          message: "Hook \"\(hook.id)\" has a command argument containing NUL",
+        )
+      }
+      if !(100 ... 300_000).contains(hook.timeoutMs) {
+        appendIssue(
+          field: .timeoutMs,
+          code: .timeoutOutOfRange,
+          message: "Hook \"\(hook.id)\" timeoutMs must be between 100 and 300000",
+        )
+      }
+      if
+        let directory = hook.workingDirectory,
+        !(directory.hasPrefix("/") || directory.hasPrefix("~/"))
+      {
+        appendIssue(
+          field: .workingDirectory,
+          code: .invalidWorkingDirectory,
+          message: "Hook \"\(hook.id)\" workingDirectory must be absolute or start with ~/",
+        )
+      }
+      for (key, value) in hook.environment.sorted(by: { $0.key < $1.key })
+        where !isValidEnvironmentKey(key) || value.utf8.contains(0)
+      {
+        appendIssue(
+          field: .environment(key: key),
+          code: .invalidEnvironment,
+          message: "Hook \"\(hook.id)\" has an invalid environment entry \"\(key)\"",
+        )
+      }
+
+      if detailedIssues.endIndex == issueStartIndex {
+        validHooks.append(hook)
+      }
+    }
+    return HookConfigurationValidation(
+      validHooks: validHooks,
+      issues: issues,
+      detailedIssues: detailedIssues,
+    )
+  }
+}
+
+private func isValidIDScalar(_ scalar: Unicode.Scalar) -> Bool {
+  switch scalar.value {
+  case 45,
+       46,
+       48 ... 57,
+       65 ... 90,
+       95,
+       97 ... 122:
+    true
+  default:
+    false
+  }
+}
+
+private func isValidEnvironmentKey(_ key: String) -> Bool {
+  guard let first = key.unicodeScalars.first else { return false }
+  let isInitial = first == "_" || (65 ... 90).contains(first.value)
+    || (97 ... 122).contains(first.value)
+  guard isInitial else { return false }
+  return key.unicodeScalars.dropFirst().allSatisfy { scalar in
+    scalar == "_" || (48 ... 57).contains(scalar.value)
+      || (65 ... 90).contains(scalar.value) || (97 ... 122).contains(scalar.value)
+  }
+}

--- a/TatamiKit/Sources/Domain/WorkspaceSync.swift
+++ b/TatamiKit/Sources/Domain/WorkspaceSync.swift
@@ -80,6 +80,20 @@ public enum WorkspaceFieldChange: Equatable, Identifiable, Sendable {
   public var beforeText: String { Self.text(before: true, self) }
   public var afterText: String { Self.text(before: false, self) }
 
+  /// The hotkey-producing workspace field this change controls, if any.
+  /// Keeping this semantic identity beside the diff prevents Copy/Duplicate
+  /// callers from maintaining a second, drifting list of shortcut fields.
+  public var shortcutField: WorkspaceShortcutField? {
+    switch self {
+    case .keyEquivalent: .keyEquivalent
+    case .activateShortcut: .activateShortcut
+    case .assignAppShortcut: .assignAppShortcut
+    case .borrowShortcut: .borrowShortcut
+    case .icon, .kind, .appToFocus, .displayHint, .borrowEdge, .borrowFraction:
+      nil
+    }
+  }
+
   private static func text(before: Bool, _ change: WorkspaceFieldChange) -> String {
     func pick<T>(_ b: T, _ a: T) -> T { before ? b : a }
     switch change {
@@ -99,11 +113,75 @@ public enum WorkspaceFieldChange: Equatable, Identifiable, Sendable {
   }
 }
 
+/// A workspace field that can change one or more registered hotkeys.
+public enum WorkspaceShortcutField: String, Hashable, Sendable {
+  case keyEquivalent
+  case activateShortcut
+  case assignAppShortcut
+  case borrowShortcut
+}
+
+/// One selected Copy/Duplicate field in the destination configuration.
+/// `workspaceId` always identifies the destination workspace, even when the
+/// chooser row is namespaced by a source workspace id.
+public struct WorkspaceShortcutSelection: Hashable, Sendable {
+  public var field: WorkspaceShortcutField
+  public var workspaceId: Workspace.ID
+
+  public init(workspaceId: Workspace.ID, field: WorkspaceShortcutField) {
+    self.workspaceId = workspaceId
+    self.field = field
+  }
+}
+
+/// A concrete collision caused by a selected Copy/Duplicate field after all
+/// selected changes have been projected together.
+public struct WorkspaceShortcutConflict: Hashable, Sendable {
+  public var hotKey: HotKey
+  public var owner: String
+  public var selection: WorkspaceShortcutSelection
+
+  public init(
+    selection: WorkspaceShortcutSelection,
+    hotKey: HotKey,
+    owner: String
+  ) {
+    self.selection = selection
+    self.hotKey = hotKey
+    self.owner = owner
+  }
+}
+
+/// The all-or-nothing result of projecting a reviewed Copy operation.
+public struct WorkspaceSyncProjection: Equatable, Sendable {
+  public var conflicts: [WorkspaceShortcutConflict]
+  public var config: AppConfig
+
+  public init(config: AppConfig, conflicts: [WorkspaceShortcutConflict]) {
+    self.config = config
+    self.conflicts = conflicts
+  }
+}
+
 /// Pure diff + apply for copying one workspace's apps / settings onto another.
 /// The direction is always "make the target look like the source" — changes
 /// transform the target toward the source, and the caller applies only the
 /// ones the user kept selected (by excluding the rest).
 public enum WorkspaceSync {
+  /// Resolve the current chooser selection against the rows that still exist.
+  /// A stale id must never keep Apply enabled after a live group disappears;
+  /// child rows also become ineffective while their parent is unselected.
+  public static func effectiveSelection(
+    selected: Set<String>,
+    validIDs: Set<String>,
+    parentByItemID: [String: String]
+  ) -> Set<String> {
+    selected.intersection(validIDs).filter { id in
+      guard let parentID = parentByItemID[id] else { return true }
+      return selected.contains(parentID) && validIDs.contains(parentID)
+    }
+  }
+
   /// App changes that would transform `target`'s apps toward `source`'s. Adds
   /// and modifies follow the source's order (stable); removes trail. `modify`
   /// fires only on a `layout` / `autoOpen` difference (name / iconPath ignored).

--- a/TatamiKit/Sources/Domain/WorkspaceSync.swift
+++ b/TatamiKit/Sources/Domain/WorkspaceSync.swift
@@ -97,18 +97,18 @@ public enum WorkspaceFieldChange: Equatable, Identifiable, Sendable {
   private static func text(before: Bool, _ change: WorkspaceFieldChange) -> String {
     func pick<T>(_ b: T, _ a: T) -> T { before ? b : a }
     switch change {
-    case let .icon(b, a): return pick(b, a) ?? "Default"
-    case let .keyEquivalent(b, a): return pick(b, a).map { "“\($0)”" } ?? "—"
+    case let .icon(b, a): return pick(b, a) ?? String(localized: "Default")
+    case let .keyEquivalent(b, a): return pick(b, a).map { "“\($0)”" } ?? String(localized: "None")
     case let .kind(b, a): return String(localized: pick(b, a).displayName)
-    case let .appToFocus(b, a): return pick(b, a) ?? "Most recent"
-    case let .displayHint(b, a): return pick(b, a)?.name ?? "Dynamic"
+    case let .appToFocus(b, a): return pick(b, a) ?? String(localized: "Most recent")
+    case let .displayHint(b, a): return pick(b, a)?.name ?? String(localized: "Dynamic")
     case let .borrowEdge(b, a):
       return pick(b, a).map { String(localized: $0.displayName) } ?? String(localized: "Global")
     case let .borrowFraction(b, a):
-      guard let v = pick(b, a) else { return "Global" }
+      guard let v = pick(b, a) else { return String(localized: "Global") }
       return "\(Int((v * 100).rounded()))%"
     case let .activateShortcut(b, a), let .assignAppShortcut(b, a), let .borrowShortcut(b, a):
-      return pick(b, a)?.symbols ?? "—"
+      return pick(b, a)?.symbols ?? String(localized: "None")
     }
   }
 }

--- a/TatamiKit/Sources/Features/CLI/CLIServerFeature.swift
+++ b/TatamiKit/Sources/Features/CLI/CLIServerFeature.swift
@@ -5,6 +5,72 @@ import ComposableArchitecture
 import Foundation
 import Sharing
 import TatamiCLIProtocol
+import YYJSON
+
+// MARK: - CLIReply
+
+/// A one-shot socket reply lease. Mutations claim the live connection before
+/// committing state; the socket cannot time out after that claim and then
+/// report failure for a mutation that still lands.
+public struct CLIReply: Sendable {
+
+  // MARK: Lifecycle
+
+  public init(_ send: @escaping @Sendable (CLIMessage.Response) -> Void) {
+    let state = LocalCLIReplyState(send: send)
+    claimOperation = { state.claim() }
+    finishOperation = { state.finish($0) }
+    respondOperation = { state.respond($0) }
+  }
+
+  init(
+    claim: @escaping @Sendable () -> Bool,
+    finish: @escaping @Sendable (CLIMessage.Response) -> Void,
+    respond: @escaping @Sendable (CLIMessage.Response) -> Bool,
+  ) {
+    claimOperation = claim
+    finishOperation = finish
+    respondOperation = respond
+  }
+
+  init(
+    claim: @escaping @Sendable () -> Bool,
+    finish: @escaping @Sendable (CLIMessage.Response) -> Void,
+  ) {
+    claimOperation = claim
+    finishOperation = finish
+    respondOperation = { response in
+      guard claim() else { return false }
+      finish(response)
+      return true
+    }
+  }
+
+  // MARK: Public
+
+  @discardableResult
+  public func claim() -> Bool {
+    claimOperation()
+  }
+
+  public func finish(_ response: CLIMessage.Response) {
+    finishOperation(response)
+  }
+
+  @discardableResult
+  public func send(_ response: CLIMessage.Response) -> Bool {
+    respondOperation(response)
+  }
+
+  // MARK: Private
+
+  private let claimOperation: @Sendable () -> Bool
+  private let finishOperation: @Sendable (CLIMessage.Response) -> Void
+  private let respondOperation: @Sendable (CLIMessage.Response) -> Bool
+
+}
+
+// MARK: - CLIServerFeature
 
 /// Hosts the CLI socket server and translates incoming requests into
 /// reducer actions / dependency calls. The reducer holds nothing other
@@ -13,19 +79,38 @@ import TatamiCLIProtocol
 /// action so it drives the same activation pipeline as hotkeys.
 @Reducer
 public struct CLIServerFeature {
+
+  // MARK: Lifecycle
+
+  public init() { }
+
+  // MARK: Public
+
   @ObservableState
   public struct State: Equatable {
-    @Shared(.tatamiConfig) public var config = AppConfig()
-    public var isRunning = false
+    public init() { }
 
-    public init() {}
+    @Shared(.tatamiConfig) public var config
+    public var isRunning = false
   }
 
   public enum Action {
     case start
     case startCompleted(Result<Void, Error>)
-    case incomingRequest(CLIMessage.Request, reply: @Sendable (CLIMessage.Response) -> Void)
+    case incomingRequest(CLIMessage.Request, reply: CLIReply)
+    case duplicationPrepared(
+      baseline: AppConfig,
+      updated: AppConfig,
+      configRevision: Data?,
+      newWorkspaceIDs: [Workspace.ID],
+      response: CLIMessage.Response,
+      reply: CLIReply,
+      layoutCopied: Bool,
+      layoutTimedOut: Bool,
+    )
     case delegate(Delegate)
+
+    // MARK: Public
 
     /// Requests the parent must route into other features. The CLI's
     /// `activate` used to call `WorkspaceManagerClient` + a fresh
@@ -33,32 +118,104 @@ public struct CLIServerFeature {
     /// left session trees, persisted layouts, mirrors, and
     /// `activeWorkspacesByDisplay` anchored to the outgoing workspace.
     public enum Delegate: Equatable {
-      case activateRequested(Workspace.ID)
+      case activateProfileRequested(
+        Profile.ID,
+        complete: @Sendable (_ error: String?) -> Void,
+      )
+      case activateWorkspaceRequested(
+        Workspace.ID,
+        complete: @Sendable (_ error: String?) -> Void,
+      )
+      /// Routes a typed domain command through `AppFeature.route`, the same
+      /// dispatcher used by keyboard shortcuts and gestures. Completion means
+      /// the command was accepted, not that every later AX/window operation
+      /// reached a terminal state.
+      case dispatchDomainCommandRequested(
+        HotKeyAction,
+        complete: @Sendable (_ error: String?) -> Void,
+      )
+      case configurationChanged
+
+      // MARK: Public
+
+      public static func ==(lhs: Self, rhs: Self) -> Bool {
+        switch (lhs, rhs) {
+        case (
+          .activateProfileRequested(let lhsID, _),
+          .activateProfileRequested(let rhsID, _),
+        ):
+          lhsID == rhsID
+        case (
+          .activateWorkspaceRequested(let lhsID, _),
+          .activateWorkspaceRequested(let rhsID, _),
+        ):
+          lhsID == rhsID
+        case (
+          .dispatchDomainCommandRequested(let lhsAction, _),
+          .dispatchDomainCommandRequested(let rhsAction, _),
+        ):
+          lhsAction == rhsAction
+        case (.configurationChanged, .configurationChanged):
+          true
+        default:
+          false
+        }
+      }
     }
 
-    public static func == (lhs: Action, rhs: Action) -> Bool {
+    public static func ==(lhs: Action, rhs: Action) -> Bool {
       switch (lhs, rhs) {
       case (.start, .start): true
+
       case (.startCompleted(let l), .startCompleted(let r)):
         // `Error` isn't Equatable; compare by Result case so a success and a
         // failure don't collapse to equal (which silently broke exhaustive
         // `TestStore` assertions and `_printChanges` diffing on this case).
         switch (l, r) {
-        case (.success, .success), (.failure, .failure): true
+        case (.success, .success),
+             (.failure, .failure): true
         default: false
         }
+
       case (.incomingRequest(let lhsReq, _), .incomingRequest(let rhsReq, _)):
         lhsReq == rhsReq
+
+      case (
+        .duplicationPrepared(
+          let lhsBaseline,
+          let lhsUpdated,
+          let lhsRevision,
+          let lhsIDs,
+          let lhsResponse,
+          _,
+          let lhsCopied,
+          let lhsTimedOut,
+        ),
+        .duplicationPrepared(
+          let rhsBaseline,
+          let rhsUpdated,
+          let rhsRevision,
+          let rhsIDs,
+          let rhsResponse,
+          _,
+          let rhsCopied,
+          let rhsTimedOut,
+        ),
+      ):
+        lhsBaseline == rhsBaseline
+          && lhsUpdated == rhsUpdated
+          && lhsRevision == rhsRevision
+          && lhsIDs == rhsIDs
+          && lhsResponse == rhsResponse
+          && lhsCopied == rhsCopied
+          && lhsTimedOut == rhsTimedOut
+
       case (.delegate(let lhs), .delegate(let rhs)): lhs == rhs
+
       default: false
       }
     }
   }
-
-  @Dependency(\.socketServer) var socketServer
-  @Dependency(\.errorReporter) var errorReporter
-
-  public init() {}
 
   public var body: some ReducerOf<Self> {
     Reduce { state, action in
@@ -79,7 +236,7 @@ public struct CLIServerFeature {
             for await incoming in client.requests() {
               await send(.incomingRequest(incoming.request, reply: incoming.reply))
             }
-          }
+          },
         )
 
       case .startCompleted(.success):
@@ -93,34 +250,376 @@ public struct CLIServerFeature {
           String(
             localized: "Command-line server failed to start — `tatami` CLI won't respond"
           ),
-          ErrorReportClient.describe(error)
+          ErrorReportClient.describe(error),
         )
         return .none
 
       case .incomingRequest(let request, let reply):
-        if request.command == .activate {
-          guard let key = request.arguments.first else {
-            return .run { _ in
-              reply(.failure("Missing workspace name. Usage: tatami activate <workspace>"))
+        switch request.command {
+        case .dispatchDomainCommand:
+          do {
+            let resolved = try resolveDomainCommand(request: request, config: state.config)
+            let action = resolved.action
+            guard action.isAvailable(in: state.config) else {
+              return replyEffect(
+                reply,
+                .failure(
+                  "Command is not available in the active configuration: "
+                    + resolved.command.rawValue
+                ),
+              )
             }
+            let title = String(localized: action.title(in: state.config))
+            switch (resolved.command, action) {
+            case (.profileActivate, .activateProfile(let profileId)):
+              let profileName = state.config.profiles.first(where: { $0.id == profileId })?.name
+                ?? title
+              let completed = response(
+                plain: "Activated profile: \(profileName)",
+                value: CLIMessage.DomainCommandResult(
+                  command: resolved.command,
+                  title: title,
+                  status: .completed,
+                ),
+                format: request.outputFormat,
+              )
+              guard reply.claim() else { return .none }
+              return .send(.delegate(.activateProfileRequested(
+                profileId,
+                complete: { error in
+                  reply.finish(error.map(CLIMessage.Response.failure) ?? completed)
+                },
+              )))
+
+            case (.workspaceActivate, .activateWorkspace(let workspaceId)):
+              guard let workspace = state.config.workspace(id: workspaceId) else {
+                return replyEffect(reply, .failure("The requested workspace no longer exists"))
+              }
+              guard workspace.kind != .scratchpad else {
+                return replyEffect(
+                  reply,
+                  .failure("Scratchpads are borrow-only and cannot be activated from the CLI"),
+                )
+              }
+              let completed = response(
+                plain: "Activated workspace: \(workspace.name)",
+                value: CLIMessage.DomainCommandResult(
+                  command: resolved.command,
+                  title: title,
+                  status: .completed,
+                ),
+                format: request.outputFormat,
+              )
+              guard reply.claim() else { return .none }
+              return .send(.delegate(.activateWorkspaceRequested(
+                workspaceId,
+                complete: { error in
+                  reply.finish(error.map(CLIMessage.Response.failure) ?? completed)
+                },
+              )))
+
+            default:
+              guard let hotKeyAction = action.hotKeyAction else {
+                return replyEffect(reply, .failure("The `none` action cannot be dispatched"))
+              }
+              let accepted = response(
+                plain: "Accepted: \(title)",
+                value: CLIMessage.DomainCommandResult(
+                  command: resolved.command,
+                  title: title,
+                  status: .accepted,
+                ),
+                format: request.outputFormat,
+              )
+              guard reply.claim() else { return .none }
+              return .send(.delegate(.dispatchDomainCommandRequested(
+                hotKeyAction,
+                complete: { error in
+                  reply.finish(error.map(CLIMessage.Response.failure) ?? accepted)
+                },
+              )))
+            }
+          } catch {
+            return replyEffect(reply, .failure(String(describing: error)))
           }
-          guard let workspace = state.config.activeProfile?.workspaces
-            .first(where: { workspaceMatches($0, key) })
-          else {
-            return .run { _ in reply(.failure("Workspace not found: \(key)")) }
+
+        case .activate:
+          guard let key = request.arguments.first else {
+            return replyEffect(
+              reply,
+              .failure("Missing workspace name. Usage: tatami activate <workspace>"),
+            )
           }
-          // Acknowledge immediately (the CLI's 5 s reply window must not
-          // wait on the activation's tile pass) and hand the switch to
-          // the activation reducer via the parent.
-          return .merge(
-            .run { _ in reply(.ok("Activating: \(workspace.name)")) },
-            .send(.delegate(.activateRequested(workspace.id)))
+          do {
+            let (_, workspace) = try resolveWorkspace(
+              key,
+              profileKey: request.option(.profile),
+              config: state.config,
+            )
+            guard workspace.kind != .scratchpad else {
+              return replyEffect(
+                reply,
+                .failure("Scratchpads are borrow-only and cannot be activated from the CLI"),
+              )
+            }
+            let response = response(
+              plain: "Activating: \(workspace.name)",
+              value: CLIMessage.MutationInfo(
+                id: workspace.id.uuidString,
+                name: workspace.name,
+              ),
+              format: request.outputFormat,
+            )
+            guard reply.claim() else { return .none }
+            return .send(.delegate(.activateWorkspaceRequested(
+              workspace.id,
+              complete: { error in
+                reply.finish(error.map(CLIMessage.Response.failure) ?? response)
+              },
+            )))
+          } catch {
+            return replyEffect(reply, .failure(String(describing: error)))
+          }
+
+        case .renameProfile:
+          guard request.arguments.count >= 2 else {
+            return replyEffect(
+              reply,
+              .failure("Usage: tatami profile rename <profile> <new-name>"),
+            )
+          }
+          let newName = request.arguments[1].trimmingCharacters(in: .whitespacesAndNewlines)
+          guard !newName.isEmpty else {
+            return replyEffect(reply, .failure("Profile name cannot be empty"))
+          }
+          do {
+            let baseline = state.config
+            let configRevision = try configPersistence.captureRevision(baseline)
+            let profile = try resolveProfile(request.arguments[0], config: baseline)
+            var updated = baseline
+            updated.mutateProfile(profile.id) { $0.name = newName }
+            if
+              let failure = commitConfig(
+                updated,
+                baseline: baseline,
+                configRevision: configRevision,
+                config: state.$config,
+                reserve: { reply.claim() },
+              )
+            {
+              reply.send(.failure(failure))
+              return .none
+            }
+            let response = response(
+              plain: "Renamed profile to: \(newName)",
+              value: CLIMessage.MutationInfo(id: profile.id.uuidString, name: newName),
+              format: request.outputFormat,
+            )
+            reply.finish(response)
+            return .send(.delegate(.configurationChanged))
+          } catch {
+            return replyEffect(reply, .failure(String(describing: error)))
+          }
+
+        case .duplicateProfile:
+          guard let key = request.arguments.first else {
+            return replyEffect(
+              reply,
+              .failure("Usage: tatami profile duplicate <profile> [--name <new-name>]"),
+            )
+          }
+          let requestedName = request.option(.name)?.trimmingCharacters(in: .whitespacesAndNewlines)
+          if let requestedName, requestedName.isEmpty {
+            return replyEffect(reply, .failure("Profile name cannot be empty"))
+          }
+          do {
+            let baseline = state.config
+            let configRevision = try configPersistence.captureRevision(baseline)
+            let profile = try resolveProfile(key, config: baseline)
+            var updated = baseline
+            guard let duplicated = updated.duplicateProfile(profile.id) else {
+              return replyEffect(reply, .failure("Profile no longer exists: \(key)"))
+            }
+            if let requestedName {
+              updated.mutateProfile(duplicated.profileId) { $0.name = requestedName }
+            }
+            guard
+              let clone = updated.profiles.first(where: { $0.id == duplicated.profileId })
+            else {
+              return replyEffect(reply, .failure("Profile no longer exists: \(key)"))
+            }
+            let response = response(
+              plain: "Duplicated profile: \(clone.name)",
+              value: CLIMessage.MutationInfo(
+                id: clone.id.uuidString,
+                name: clone.name,
+              ),
+              format: request.outputFormat,
+            )
+            return prepareDuplication(
+              baseline: baseline,
+              updated: updated,
+              configRevision: configRevision,
+              layoutMapping: duplicated.workspaceIdMap,
+              response: response,
+              reply: reply,
+            )
+          } catch {
+            return replyEffect(reply, .failure(String(describing: error)))
+          }
+
+        case .renameWorkspace:
+          guard request.arguments.count >= 2 else {
+            return replyEffect(
+              reply,
+              .failure(
+                "Usage: tatami workspace rename <workspace> <new-name> [--profile <profile>]"
+              ),
+            )
+          }
+          let newName = request.arguments[1].trimmingCharacters(in: .whitespacesAndNewlines)
+          guard !newName.isEmpty else {
+            return replyEffect(reply, .failure("Workspace name cannot be empty"))
+          }
+          do {
+            let baseline = state.config
+            let configRevision = try configPersistence.captureRevision(baseline)
+            let (_, workspace) = try resolveWorkspace(
+              request.arguments[0],
+              profileKey: request.option(.profile),
+              config: baseline,
+            )
+            var updated = baseline
+            updated.mutateWorkspace(workspace.id) { $0.name = newName }
+            if
+              let failure = commitConfig(
+                updated,
+                baseline: baseline,
+                configRevision: configRevision,
+                config: state.$config,
+                reserve: { reply.claim() },
+              )
+            {
+              reply.send(.failure(failure))
+              return .none
+            }
+            let response = response(
+              plain: "Renamed workspace to: \(newName)",
+              value: CLIMessage.MutationInfo(id: workspace.id.uuidString, name: newName),
+              format: request.outputFormat,
+            )
+            reply.finish(response)
+            return .send(.delegate(.configurationChanged))
+          } catch {
+            return replyEffect(reply, .failure(String(describing: error)))
+          }
+
+        case .duplicateWorkspace:
+          guard let key = request.arguments.first else {
+            return replyEffect(
+              reply,
+              .failure(
+                "Usage: tatami workspace duplicate <workspace> [--profile <profile>] [--name <new-name>]"
+              ),
+            )
+          }
+          let requestedName = request.option(.name)?.trimmingCharacters(in: .whitespacesAndNewlines)
+          if let requestedName, requestedName.isEmpty {
+            return replyEffect(reply, .failure("Workspace name cannot be empty"))
+          }
+          do {
+            let baseline = state.config
+            let configRevision = try configPersistence.captureRevision(baseline)
+            let (_, workspace) = try resolveWorkspace(
+              key,
+              profileKey: request.option(.profile),
+              config: baseline,
+            )
+            var updated = baseline
+            guard let duplicateID = updated.duplicateWorkspace(workspace.id) else {
+              return replyEffect(reply, .failure("Workspace no longer exists: \(key)"))
+            }
+            if let requestedName {
+              updated.mutateWorkspace(duplicateID) { $0.name = requestedName }
+            }
+            guard let duplicate = updated.workspace(id: duplicateID) else {
+              return replyEffect(reply, .failure("Workspace no longer exists: \(key)"))
+            }
+            let response = response(
+              plain: "Duplicated workspace: \(duplicate.name)",
+              value: CLIMessage.MutationInfo(
+                id: duplicate.id.uuidString,
+                name: duplicate.name,
+              ),
+              format: request.outputFormat,
+            )
+            return prepareDuplication(
+              baseline: baseline,
+              updated: updated,
+              configRevision: configRevision,
+              layoutMapping: [workspace.id: duplicateID],
+              response: response,
+              reply: reply,
+            )
+          } catch {
+            return replyEffect(reply, .failure(String(describing: error)))
+          }
+
+        case .version,
+             .listProfiles,
+             .listWorkspaces,
+             .listApps,
+             .listHooks:
+          let config = state.config
+          return .run { _ in
+            reply.send(Self.handle(request: request, config: config))
+          }
+        }
+
+      case .duplicationPrepared(
+        let baseline,
+        let updated,
+        let configRevision,
+        let newWorkspaceIDs,
+        let response,
+        let reply,
+        let layoutCopied,
+        let layoutTimedOut,
+      ):
+        if layoutTimedOut {
+          return replyEffect(
+            reply,
+            .failure("Saved layout duplication timed out; configuration was not changed"),
           )
         }
-        let config = state.config
-        return .run { _ in
-          reply(Self.handle(request: request, config: config))
+        guard layoutCopied else {
+          return replyEffect(
+            reply,
+            .failure("Saved layout could not be duplicated; configuration was not changed"),
+          )
         }
+        // The persistence transaction reserves the still-live socket slot only
+        // after coordination and temp-file preparation, immediately before its
+        // atomic exchange.
+        if
+          let failure = commitConfig(
+            updated,
+            baseline: baseline,
+            configRevision: configRevision,
+            config: state.$config,
+            reserve: { reply.claim() },
+          )
+        {
+          reply.send(.failure(failure))
+          // An indeterminate exchange may already have published the config.
+          // Preserve its layouts so a watcher/relaunch cannot expose a clone
+          // whose copied layout was deleted by error handling.
+          return failure.hasPrefix("Command outcome is unknown")
+            ? .none
+            : clearLayouts(newWorkspaceIDs)
+        }
+        reply.finish(response)
+        return .send(.delegate(.configurationChanged))
 
       case .delegate:
         return .none
@@ -128,38 +627,493 @@ public struct CLIServerFeature {
     }
   }
 
+  // MARK: Internal
+
+  @Dependency(\.socketServer) var socketServer
+  @Dependency(\.configPersistence) var configPersistence
+  @Dependency(\.errorReporter) var errorReporter
+  @Dependency(\.layoutStore) var layoutStore
+
   /// Read-only CLI queries. `activate` never reaches here — it is routed
   /// through the reducer (see `Delegate.activateRequested`).
   static func handle(
     request: CLIMessage.Request,
-    config: AppConfig
+    config: AppConfig,
   ) -> CLIMessage.Response {
     switch request.command {
     case .version:
-      return .ok("tatami \(TatamiKit.version)")
+      return response(
+        plain: "tatami \(TatamiKit.version)",
+        value: VersionInfo(version: TatamiKit.version),
+        format: request.outputFormat,
+      )
+
+    case .listProfiles:
+      let activeID = config.activeProfile?.id
+      let values = config.profiles.map {
+        CLIMessage.ProfileInfo(id: $0.id, name: $0.name, isActive: $0.id == activeID)
+      }
+      return response(
+        plain: config.profiles.map(\.name).joined(separator: "\n"),
+        value: values,
+        format: request.outputFormat,
+      )
 
     case .listWorkspaces:
-      let names = config.activeProfile?.workspaces.map(\.name) ?? []
-      return .ok(names.joined(separator: "\n"))
+      do {
+        let profile = try request.option(.profile)
+          .map { try resolveProfile($0, config: config) }
+          ?? config.activeProfile.orThrow(CLIResolveError.noActiveProfile)
+        let values = profile.workspaces.map {
+          CLIMessage.WorkspaceInfo(
+            id: $0.id,
+            name: $0.name,
+            profileId: profile.id,
+            profileName: profile.name,
+            kind: $0.kind.rawValue,
+          )
+        }
+        return response(
+          plain: profile.workspaces.map(\.name).joined(separator: "\n"),
+          value: values,
+          format: request.outputFormat,
+        )
+      } catch {
+        return .failure(String(describing: error))
+      }
 
     case .listApps:
       guard let key = request.arguments.first else {
         return .failure("Missing workspace name. Usage: tatami list-apps <workspace>")
       }
-      guard let workspace = config.activeProfile?.workspaces
-        .first(where: { workspaceMatches($0, key) })
-      else {
-        return .failure("Workspace not found: \(key)")
+      do {
+        let (_, workspace) = try resolveWorkspace(
+          key,
+          profileKey: request.option(.profile),
+          config: config,
+        )
+        let values = workspace.apps.map {
+          CLIMessage.AppInfo(
+            bundleIdentifier: $0.bundleIdentifier,
+            name: $0.name,
+            layout: $0.layout.rawValue,
+            autoOpen: $0.autoOpen,
+          )
+        }
+        return response(
+          plain: workspace.apps.map(\.bundleIdentifier).joined(separator: "\n"),
+          value: values,
+          format: request.outputFormat,
+        )
+      } catch {
+        return .failure(String(describing: error))
       }
-      let names = workspace.apps.map(\.bundleIdentifier).joined(separator: "\n")
-      return .ok(names)
 
-    case .activate:
+    case .listHooks:
+      let validation = HookDefinition.validate(config.hooks)
+      let validIDs = Set(validation.validHooks.map(\.id))
+      let values = config.hooks.map {
+        CLIMessage.HookInfo(
+          id: $0.id,
+          event: $0.event.rawValue,
+          enabled: $0.enabled,
+          valid: validIDs.contains($0.id),
+        )
+      }
+      let plain = values.map {
+        "\($0.id)\t\($0.event)\t\($0.enabled ? "enabled" : "disabled")"
+          + ($0.valid ? "" : "\tinvalid")
+      }.joined(separator: "\n")
+      return response(plain: plain, value: values, format: request.outputFormat)
+
+    case .activate,
+         .dispatchDomainCommand,
+         .renameProfile,
+         .duplicateProfile,
+         .renameWorkspace,
+         .duplicateWorkspace:
       return .failure("Internal routing error")
+    }
+  }
+
+  // MARK: Private
+
+  /// Durably replace the captured file revision, then publish the same value
+  /// through the custom shared key without issuing a second write.
+  private func commitConfig(
+    _ updated: AppConfig,
+    baseline: AppConfig,
+    configRevision: Data?,
+    config: Shared<AppConfig>,
+    reserve: @escaping @Sendable () -> Bool,
+  ) -> String? {
+    do {
+      try configPersistence.commit(config, baseline, configRevision, updated, reserve)
+      errorReporter.resolve("ConfigSave")
+      return nil
+    } catch {
+      errorReporter.report(
+        "ConfigSave",
+        String(localized: "config.toml could not be saved"),
+        ErrorReportClient.describe(error),
+      )
+      if case ConfigPersistenceError.outcomeUnknown = error {
+        return "Command outcome is unknown; inspect config.toml before retrying: \(ErrorReportClient.describe(error))"
+      }
+      return "config.toml could not be saved: \(ErrorReportClient.describe(error))"
+    }
+  }
+
+  private func prepareDuplication(
+    baseline: AppConfig,
+    updated: AppConfig,
+    configRevision: Data?,
+    layoutMapping: [Workspace.ID: Workspace.ID],
+    response: CLIMessage.Response,
+    reply: CLIReply,
+  ) -> Effect<Action> {
+    .run { [layoutStore] send in
+      let (events, continuation) = AsyncStream<LayoutCopyOutcome>.makeStream()
+      let copyTask = Task {
+        let copied = await layoutStore.copyLayouts(layoutMapping)
+        continuation.yield(.completed(copied))
+        return copied
+      }
+      let timeoutTask = Task {
+        do {
+          try await Task.sleep(for: .seconds(4))
+          continuation.yield(.timedOut)
+        } catch { }
+      }
+      var iterator = events.makeAsyncIterator()
+      let outcome = await iterator.next() ?? .timedOut
+      continuation.finish()
+
+      let layoutCopied: Bool
+      let layoutTimedOut: Bool
+      switch outcome {
+      case .completed(let copied):
+        timeoutTask.cancel()
+        layoutCopied = copied
+        layoutTimedOut = false
+
+      case .timedOut:
+        copyTask.cancel()
+        // A synchronous filesystem write may not observe task cancellation.
+        // If it completes later, remove its unreachable destination snapshots.
+        _ = Task {
+          if await copyTask.value {
+            _ = await layoutStore.removeLayouts(Array(layoutMapping.values))
+          }
+        }
+        layoutCopied = false
+        layoutTimedOut = true
+      }
+      await send(.duplicationPrepared(
+        baseline: baseline,
+        updated: updated,
+        configRevision: configRevision,
+        newWorkspaceIDs: Array(layoutMapping.values),
+        response: response,
+        reply: reply,
+        layoutCopied: layoutCopied,
+        layoutTimedOut: layoutTimedOut,
+      ))
+    }
+  }
+
+  private func clearLayouts(_ workspaceIDs: [Workspace.ID]) -> Effect<Action> {
+    .run { [layoutStore] _ in
+      _ = await layoutStore.removeLayouts(workspaceIDs)
+    }
+  }
+
+}
+
+// MARK: - ResolvedCLIDomainCommand
+
+private struct ResolvedCLIDomainCommand {
+  let command: CLIMessage.DomainCommand
+  let action: GestureAction
+}
+
+// MARK: - CLIDomainCommandResolveError
+
+private enum CLIDomainCommandResolveError: Error, CustomStringConvertible {
+  case missingCommand
+  case missingTarget(command: CLIMessage.DomainCommand, target: CLIMessage.DomainTarget)
+  case tooManyArguments(String)
+  case unexpectedTarget(command: CLIMessage.DomainCommand)
+  case profileOptionNotAllowed(command: CLIMessage.DomainCommand)
+  case unknownCommand(String)
+  case inactiveBorrowProfile(String)
+  case invalidRoute(CLIMessage.DomainCommand)
+
+  // MARK: Internal
+
+  var description: String {
+    switch self {
+    case .missingCommand:
+      "Missing internal domain command"
+    case .missingTarget(let command, let target):
+      "Command `\(command.rawValue)` requires a \(target.rawValue) name or UUID"
+    case .tooManyArguments(let command):
+      "Command `\(command)` accepts at most one workspace/profile target"
+    case .unexpectedTarget(let command):
+      "Command `\(command.rawValue)` does not accept a target"
+    case .profileOptionNotAllowed(let command):
+      "Command `\(command.rawValue)` does not accept --profile"
+    case .unknownCommand(let command):
+      "Unknown internal domain command: \(command)"
+    case .inactiveBorrowProfile(let profile):
+      "Borrow can only target a workspace in the active profile; `\(profile)` is inactive"
+    case .invalidRoute(let command):
+      "Invalid internal domain command mapping: \(command.rawValue)"
     }
   }
 }
 
-private func workspaceMatches(_ workspace: Workspace, _ key: String) -> Bool {
-  workspace.name == key || workspace.id.uuidString == key
+private func resolveDomainCommand(
+  request: CLIMessage.Request,
+  config: AppConfig,
+) throws -> ResolvedCLIDomainCommand {
+  guard let rawCommand = request.arguments.first else {
+    throw CLIDomainCommandResolveError.missingCommand
+  }
+  guard let command = CLIMessage.DomainCommand(rawValue: rawCommand) else {
+    throw CLIDomainCommandResolveError.unknownCommand(rawCommand)
+  }
+  guard request.arguments.count <= 2 else {
+    throw CLIDomainCommandResolveError.tooManyArguments(rawCommand)
+  }
+  let targetKey = request.arguments.dropFirst().first
+  let profileKey = request.option(.profile)
+
+  func requireTarget(_ kind: CLIMessage.DomainTarget) throws -> String {
+    guard let targetKey else {
+      throw CLIDomainCommandResolveError.missingTarget(command: command, target: kind)
+    }
+    return targetKey
+  }
+
+  let workspaceId: Workspace.ID?
+  let profileId: Profile.ID?
+  switch command.target {
+  case .workspace:
+    if command == .workspaceBorrowFrom, profileKey != nil {
+      throw CLIDomainCommandResolveError.profileOptionNotAllowed(command: command)
+    }
+    let (profile, workspace) = try resolveWorkspace(
+      try requireTarget(.workspace),
+      profileKey: profileKey,
+      config: config,
+    )
+    if command == .workspaceBorrowFrom, profile.id != config.activeProfile?.id {
+      throw CLIDomainCommandResolveError.inactiveBorrowProfile(profile.name)
+    }
+    workspaceId = workspace.id
+    profileId = nil
+
+  case .profile:
+    guard profileKey == nil else {
+      throw CLIDomainCommandResolveError.profileOptionNotAllowed(command: command)
+    }
+    workspaceId = nil
+    profileId = try resolveProfile(try requireTarget(.profile), config: config).id
+
+  case nil:
+    guard targetKey == nil else {
+      throw CLIDomainCommandResolveError.unexpectedTarget(command: command)
+    }
+    guard profileKey == nil else {
+      throw CLIDomainCommandResolveError.profileOptionNotAllowed(command: command)
+    }
+    workspaceId = nil
+    profileId = nil
+  }
+
+  guard
+    let action = GestureAction.cliAction(
+      for: command,
+      workspaceId: workspaceId,
+      profileId: profileId,
+    )
+  else {
+    throw CLIDomainCommandResolveError.invalidRoute(command)
+  }
+  return ResolvedCLIDomainCommand(command: command, action: action)
+}
+
+// MARK: - LayoutCopyOutcome
+
+private enum LayoutCopyOutcome: Sendable {
+  case completed(Bool)
+  case timedOut
+}
+
+// MARK: - VersionInfo
+
+private struct VersionInfo: Codable {
+  var version: String
+}
+
+// MARK: - CLIResolveError
+
+private enum CLIResolveError: Error, CustomStringConvertible {
+  case ambiguousProfile(String, [Profile])
+  case ambiguousWorkspace(String, [Workspace])
+  case noActiveProfile
+  case profileNotFound(String)
+  case workspaceNotFound(String)
+
+  // MARK: Internal
+
+  var description: String {
+    switch self {
+    case .ambiguousProfile(let key, let profiles):
+      let candidates = profiles.map { "\($0.name) (\($0.id.uuidString))" }.joined(separator: ", ")
+      return "Profile name is ambiguous: \(key). Candidates: \(candidates)"
+
+    case .ambiguousWorkspace(let key, let workspaces):
+      let candidates = workspaces.map { "\($0.name) (\($0.id.uuidString))" }.joined(separator: ", ")
+      return "Workspace name is ambiguous: \(key). Candidates: \(candidates)"
+
+    case .noActiveProfile:
+      return "No active profile"
+
+    case .profileNotFound(let key):
+      return "Profile not found: \(key)"
+
+    case .workspaceNotFound(let key):
+      return "Workspace not found: \(key)"
+    }
+  }
+}
+
+private func resolveProfile(_ key: String, config: AppConfig) throws -> Profile {
+  if
+    let id = UUID(uuidString: key),
+    let profile = config.profiles.first(where: { $0.id == id })
+  {
+    return profile
+  }
+  let matches = config.profiles.filter { $0.name == key }
+  guard matches.count <= 1 else { throw CLIResolveError.ambiguousProfile(key, matches) }
+  guard let profile = matches.first else { throw CLIResolveError.profileNotFound(key) }
+  return profile
+}
+
+private func resolveWorkspace(
+  _ key: String,
+  profileKey: String?,
+  config: AppConfig,
+) throws -> (Profile, Workspace) {
+  if let id = UUID(uuidString: key), profileKey == nil {
+    for profile in config.profiles {
+      if let workspace = profile.workspaces[id: id] { return (profile, workspace) }
+    }
+    // A valid UUID string can also be a user-chosen workspace name. Prefer a
+    // globally unique ID when it exists, then fall through to the ordinary
+    // active-profile name lookup instead of making that name unaddressable.
+  }
+  let profile = try profileKey
+    .map { try resolveProfile($0, config: config) }
+    ?? config.activeProfile.orThrow(CLIResolveError.noActiveProfile)
+  if let id = UUID(uuidString: key), let workspace = profile.workspaces[id: id] {
+    return (profile, workspace)
+  }
+  let matches = profile.workspaces.filter { $0.name == key }
+  guard matches.count <= 1 else { throw CLIResolveError.ambiguousWorkspace(key, Array(matches)) }
+  guard let workspace = matches.first else { throw CLIResolveError.workspaceNotFound(key) }
+  return (profile, workspace)
+}
+
+private func response(
+  plain: String,
+  value: some Encodable,
+  format: CLIMessage.OutputFormat,
+) -> CLIMessage.Response {
+  guard format == .json else { return .ok(plain) }
+  do {
+    let data = try YYJSONEncoder().encode(value)
+    return .ok(String(decoding: data, as: UTF8.self), outputFormat: .json)
+  } catch {
+    return .failure("Could not encode JSON response: \(error)")
+  }
+}
+
+private func replyEffect(
+  _ reply: CLIReply,
+  _ response: CLIMessage.Response,
+) -> Effect<CLIServerFeature.Action> {
+  .run { _ in reply.send(response) }
+}
+
+private func finishReplyEffect(
+  _ reply: CLIReply,
+  _ response: CLIMessage.Response,
+) -> Effect<CLIServerFeature.Action> {
+  .run { _ in reply.finish(response) }
+}
+
+extension CLIMessage.Request {
+  fileprivate func option(_ option: CLIMessage.Option) -> String? {
+    options[option.rawValue]
+  }
+}
+
+extension Optional {
+  fileprivate func orThrow(_ error: @autoclosure () -> any Error) throws -> Wrapped {
+    guard let self else { throw error() }
+    return self
+  }
+}
+
+// MARK: - LocalCLIReplyState
+
+private final class LocalCLIReplyState: @unchecked Sendable {
+
+  // MARK: Lifecycle
+
+  init(send: @escaping @Sendable (CLIMessage.Response) -> Void) {
+    self.send = send
+  }
+
+  // MARK: Internal
+
+  func claim() -> Bool {
+    lock.lock()
+    defer { lock.unlock() }
+    guard !claimed, send != nil else { return false }
+    claimed = true
+    return true
+  }
+
+  func finish(_ response: CLIMessage.Response) {
+    lock.lock()
+    let send = claimed ? send : nil
+    self.send = nil
+    lock.unlock()
+    send?(response)
+  }
+
+  func respond(_ response: CLIMessage.Response) -> Bool {
+    lock.lock()
+    guard let send else {
+      lock.unlock()
+      return false
+    }
+    claimed = true
+    self.send = nil
+    lock.unlock()
+    send(response)
+    return true
+  }
+
+  // MARK: Private
+
+  private let lock = NSLock()
+  private var claimed = false
+  private var send: (@Sendable (CLIMessage.Response) -> Void)?
+
 }

--- a/TatamiKit/Sources/Features/Hooks/HooksFeature.swift
+++ b/TatamiKit/Sources/Features/Hooks/HooksFeature.swift
@@ -1,0 +1,210 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Perception
+import Sharing
+
+// MARK: - HooksFeature
+
+@Reducer
+public struct HooksFeature {
+
+  // MARK: Lifecycle
+
+  public init() { }
+
+  // MARK: Public
+
+  @ObservableState
+  public struct State: Equatable {
+    public init() { }
+
+    @Shared(.tatamiConfig) public var config
+
+    var activeDefinitions = [String: HookDefinition]()
+    var activeGenerationsByHookID = [String: Set<UInt64>]()
+    var failingHookIDs = Set<String>()
+    var latestGenerationByHookID = [String: UInt64]()
+  }
+
+  public enum Action {
+    case configurationChanged
+    case emit(HookInvocation)
+    case hookFinished(id: String, generation: UInt64, HookExecutionResult)
+    case start
+  }
+
+  public var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .start:
+        let sharedConfig = state.$config
+        return .run { send in
+          for await _ in Perceptions({ sharedConfig.wrappedValue.hooks }) {
+            await send(.configurationChanged)
+          }
+        }
+        .cancellable(id: CancelID.configuration, cancelInFlight: true)
+
+      case .configurationChanged:
+        // Observer delivery may lag behind newer file changes or lifecycle
+        // events. Always reconcile the current Shared value, never a captured
+        // historical hooks array.
+        let reconciliation = reconcile(state.config.hooks, state: &state)
+        return .merge(reconciliation.cancellations.map { .cancel(id: $0) })
+
+      case .emit(let invocation):
+        // Reconcile from the same config snapshot used to select matching
+        // hooks. This closes the observer race where a new definition could
+        // be launched and then cancelled by its delayed change notification.
+        let reconciliation = reconcile(state.config.hooks, state: &state)
+        let matching = reconciliation.validation.validHooks.filter {
+          $0.enabled && $0.event == invocation.event
+        }
+        var effects = reconciliation.cancellations.map { Effect<Action>.cancel(id: $0) }
+        for hook in matching {
+          state.latestGenerationByHookID[hook.id, default: 0] &+= 1
+          let generation = state.latestGenerationByHookID[hook.id, default: 0]
+          state.activeGenerationsByHookID[hook.id, default: []].insert(generation)
+          effects.append(
+            .run { [hookRunner] send in
+              let result = await hookRunner.run(hook, invocation)
+              await send(.hookFinished(id: hook.id, generation: generation, result))
+            }
+            // Every published lifecycle event gets its own execution. The
+            // generation keeps diagnostics ordered without dropping events;
+            // only a definition change/removal cancels active executions.
+            .cancellable(id: HookRunID(id: hook.id, generation: generation))
+          )
+        }
+        return .merge(effects)
+
+      case .hookFinished(let id, let generation, .success(let stdout, let stderr)):
+        removeActiveGeneration(id: id, generation: generation, state: &state)
+        logOutput(id: id, stdout: stdout, stderr: stderr)
+        guard state.latestGenerationByHookID[id] == generation else { return .none }
+        state.failingHookIDs.remove(id)
+        errorReporter.resolve(runtimeDomain(id))
+        return .none
+
+      case .hookFinished(let id, let generation, .failure(let message, let stdout, let stderr)):
+        removeActiveGeneration(id: id, generation: generation, state: &state)
+        logFailure(id: id, message: message, stdout: stdout, stderr: stderr)
+        guard state.latestGenerationByHookID[id] == generation else { return .none }
+        state.failingHookIDs.insert(id)
+        let detail = firstDiagnostic(message: message, stderr: stderr, stdout: stdout)
+        errorReporter.report(
+          runtimeDomain(id),
+          String(localized: "Hook \"\(id)\" failed"),
+          detail,
+        )
+        return .none
+
+      case .hookFinished(let id, let generation, .cancelled):
+        removeActiveGeneration(id: id, generation: generation, state: &state)
+        guard state.latestGenerationByHookID[id] == generation else { return .none }
+        return .none
+      }
+    }
+  }
+
+  // MARK: Internal
+
+  @Dependency(\.debugLog) var debugLog
+  @Dependency(\.errorReporter) var errorReporter
+  @Dependency(\.hookRunner) var hookRunner
+
+  // MARK: Private
+
+  private enum CancelID { case configuration }
+
+  private struct HookRunID: Hashable {
+    var id: String
+    var generation: UInt64
+  }
+
+  private struct Reconciliation {
+    var validation: HookConfigurationValidation
+    var cancellations: [HookRunID]
+  }
+
+  private func reconcile(
+    _ hooks: [HookDefinition],
+    state: inout State,
+  ) -> Reconciliation {
+    let validation = HookDefinition.validate(hooks)
+    reportValidation(validation)
+    let nextDefinitions = Dictionary(
+      uniqueKeysWithValues: validation.validHooks
+        .filter(\.enabled)
+        .map { ($0.id, $0) }
+    )
+    let knownIDs = Set(state.activeDefinitions.keys)
+      .union(state.activeGenerationsByHookID.keys)
+      .union(state.failingHookIDs)
+    let invalidatedIDs = knownIDs.filter {
+      state.activeDefinitions[$0] != nextDefinitions[$0]
+    }
+    var cancellations = [HookRunID]()
+    for id in invalidatedIDs {
+      state.latestGenerationByHookID[id, default: 0] &+= 1
+      for generation in state.activeGenerationsByHookID.removeValue(forKey: id) ?? [] {
+        cancellations.append(HookRunID(id: id, generation: generation))
+      }
+    }
+    let retiredFailures = state.failingHookIDs.intersection(invalidatedIDs)
+    state.failingHookIDs.subtract(retiredFailures)
+    state.activeDefinitions = nextDefinitions
+    for id in retiredFailures {
+      errorReporter.resolve(runtimeDomain(id))
+    }
+    return Reconciliation(validation: validation, cancellations: cancellations)
+  }
+
+  private func removeActiveGeneration(
+    id: String,
+    generation: UInt64,
+    state: inout State,
+  ) {
+    state.activeGenerationsByHookID[id]?.remove(generation)
+    if state.activeGenerationsByHookID[id]?.isEmpty == true {
+      state.activeGenerationsByHookID[id] = nil
+    }
+  }
+
+  private func reportValidation(_ validation: HookConfigurationValidation) {
+    guard let issue = validation.issues.first else {
+      errorReporter.resolve("Hooks")
+      return
+    }
+    errorReporter.report(
+      "Hooks",
+      String(localized: "Hook configuration is invalid"),
+      String(issue.prefix(200)),
+    )
+  }
+
+  private func logOutput(id: String, stdout: String, stderr: String) {
+    guard debugLog.isEnabled() else { return }
+    if !stdout.isEmpty { debugLog.log("Hook", "\(id) stdout: \(stdout)") }
+    if !stderr.isEmpty { debugLog.log("Hook", "\(id) stderr: \(stderr)") }
+  }
+
+  private func logFailure(id: String, message: String, stdout: String, stderr: String) {
+    guard debugLog.isEnabled() else { return }
+    debugLog.log("Hook", "\(id) failed: \(message)")
+    logOutput(id: id, stdout: stdout, stderr: stderr)
+  }
+
+}
+
+private func runtimeDomain(_ id: String) -> String {
+  "Hook:\(id)"
+}
+
+private func firstDiagnostic(message: String, stderr: String, stdout: String) -> String {
+  let source = stderr.isEmpty ? (stdout.isEmpty ? message : stdout) : stderr
+  let line = source.split(separator: "\n", maxSplits: 1).first.map(String.init) ?? message
+  return String(line.prefix(200))
+}

--- a/TatamiKit/Sources/Features/Hooks/HooksFeature.swift
+++ b/TatamiKit/Sources/Features/Hooks/HooksFeature.swift
@@ -174,14 +174,17 @@ public struct HooksFeature {
   }
 
   private func reportValidation(_ validation: HookConfigurationValidation) {
-    guard let issue = validation.issues.first else {
+    guard !validation.issues.isEmpty else {
       errorReporter.resolve("Hooks")
       return
     }
+    let detail = validation.detailedIssues.first
+      .map { String(localized: $0.code.localizedMessage) }
+      ?? String(localized: "Hook configuration is invalid")
     errorReporter.report(
       "Hooks",
       String(localized: "Hook configuration is invalid"),
-      String(issue.prefix(200)),
+      detail,
     )
   }
 

--- a/TatamiKit/Sources/Features/HotKeys/AppConfig+HotKeys.swift
+++ b/TatamiKit/Sources/Features/HotKeys/AppConfig+HotKeys.swift
@@ -10,8 +10,18 @@ extension AppConfig {
   /// conflict detection (Settings / workspace detail), so the two can never
   /// disagree about what's bound.
   public var hotKeyBindings: [HotKeyBinding] {
+    hotKeyBindings(for: activeProfile?.id)
+  }
+
+  /// The bindings that would be active while `profileId` is running. Workspace
+  /// shortcuts are profile-scoped; profile-switch and Settings shortcuts are
+  /// global and therefore appear in every projection. Passing nil represents
+  /// a config with no active profile and still returns its global bindings.
+  func hotKeyBindings(for profileId: Profile.ID?) -> [HotKeyBinding] {
     var out: [HotKeyBinding] = []
-    let workspaces = activeProfile?.workspaces ?? []
+    let workspaces = profileId
+      .flatMap { id in profiles.first(where: { $0.id == id }) }
+      .map(\.workspaces) ?? []
     // Default workspace shortcuts: a global modifier combo + a workspace's
     // single `keyEquivalent`. One key drives several actions, each with its
     // own modifier combo. Skipped when the combo is empty (a bare-key global
@@ -106,9 +116,353 @@ extension AppConfig {
   /// The display title of an action already bound to `candidate`, or nil if
   /// the combo is free. `action` is excluded so a recorder treats its own
   /// current combo as available (re-recording the same key isn't a conflict).
+  /// Workspace actions only overlap actions in their owning profile; global
+  /// actions overlap the possible runtime binding set of every profile.
   public func shortcutConflict(for candidate: HotKey, excluding action: HotKeyAction) -> String? {
-    hotKeyBindings
+    if
+      let workspaceId = action.workspaceId,
+      let profileId = profileId(owning: workspaceId)
+    {
+      return shortcutConflict(for: candidate, excluding: action, in: profileId)
+    }
+    return shortcutConflictAcrossProfiles(for: candidate, excluding: action)
+  }
+
+  /// Conflict lookup for a workspace action edited in a specific profile.
+  func shortcutConflict(
+    for candidate: HotKey,
+    excluding action: HotKeyAction,
+    in profileId: Profile.ID
+  ) -> String? {
+    shortcutConflict(
+      for: candidate,
+      excluding: action,
+      among: hotKeyBindings(for: profileId)
+    )
+  }
+
+  /// Conflict lookup for a global action, which must remain available no
+  /// matter which profile is active.
+  func shortcutConflictAcrossProfiles(
+    for candidate: HotKey,
+    excluding action: HotKeyAction
+  ) -> String? {
+    let profileIds: [Profile.ID?] = profiles.isEmpty ? [nil] : profiles.map { $0.id }
+    for profileId in profileIds {
+      if let conflict = shortcutConflict(
+        for: candidate,
+        excluding: action,
+        among: hotKeyBindings(for: profileId)
+      ) {
+        return conflict
+      }
+    }
+    return nil
+  }
+
+  /// Conflict for a workspace key equivalent after applying the same
+  /// explicit-override precedence used by `hotKeyBindings(for:)`. A derived
+  /// activate/assign/borrow combo does not exist while that action has its own
+  /// explicit shortcut, so it must not reject an otherwise valid key.
+  public func workspaceKeyEquivalentConflict(
+    for keyName: String,
+    workspaceId: Workspace.ID
+  ) -> String? {
+    guard
+      let workspace = workspace(id: workspaceId),
+      let profileId = profileId(owning: workspaceId)
+    else { return nil }
+    let shortcuts = settings.shortcuts
+    return keyEquivalentConflict(
+      for: keyName,
+      candidates: [
+        .init(
+          modifiers: shortcuts.keyEquivalentModifiers,
+          action: .activateWorkspace(workspaceId),
+          explicitOverride: workspace.activateShortcut
+        ),
+        .init(
+          modifiers: shortcuts.assignModifiers,
+          action: .assignFocusedAppToWorkspace(workspaceId),
+          explicitOverride: workspace.assignAppShortcut
+        ),
+        .init(
+          modifiers: shortcuts.borrowModifiers,
+          action: .borrowWorkspace(workspaceId),
+          explicitOverride: workspace.borrowShortcut
+        ),
+      ],
+      conflict: { hotKey, action in
+        shortcutConflict(for: hotKey, excluding: action, in: profileId)
+      }
+    )
+  }
+
+  /// Equivalent validation for the recent/next/previous key recorders. These
+  /// actions are global settings, so every profile projection is checked, but
+  /// only for actions that still use their derived modifier + key binding.
+  public func navigationKeyEquivalentConflict(
+    for keyName: String,
+    switchAction: HotKeyAction,
+    switchOverride: HotKey?,
+    assignAction: HotKeyAction,
+    assignOverride: HotKey?,
+    borrowAction: HotKeyAction,
+    borrowOverride: HotKey?
+  ) -> String? {
+    let shortcuts = settings.shortcuts
+    return keyEquivalentConflict(
+      for: keyName,
+      candidates: [
+        .init(
+          modifiers: shortcuts.keyEquivalentModifiers,
+          action: switchAction,
+          explicitOverride: switchOverride
+        ),
+        .init(
+          modifiers: shortcuts.assignModifiers,
+          action: assignAction,
+          explicitOverride: assignOverride
+        ),
+        .init(
+          modifiers: shortcuts.borrowModifiers,
+          action: borrowAction,
+          explicitOverride: borrowOverride
+        ),
+      ],
+      conflict: { hotKey, action in
+        shortcutConflictAcrossProfiles(for: hotKey, excluding: action)
+      }
+    )
+  }
+
+  /// Validate shortcut-producing fields selected by Copy/Duplicate against
+  /// the complete projected configuration. For an existing destination, a
+  /// field owns only collisions that disappear when that field alone is
+  /// restored from `baseline`; this avoids highlighting representation-only
+  /// changes that merely happen to participate in another field's collision.
+  /// A duplicated workspace has no baseline destination, so all of its
+  /// collisions are new. Workspace bindings are checked only in their
+  /// destination profile; global profile/settings bindings are still present
+  /// in every projection. This is the same scope and precedence used by actual
+  /// registration in `hotKeyBindings(for:)`.
+  public func shortcutCopyConflicts(
+    for selections: some Sequence<WorkspaceShortcutSelection>,
+    comparedTo baseline: AppConfig? = nil
+  ) -> [WorkspaceShortcutConflict] {
+    let contexts = selections.compactMap { selection -> ShortcutSelectionContext? in
+      guard
+        workspace(id: selection.workspaceId) != nil,
+        let profileId = profileId(owning: selection.workspaceId)
+      else { return nil }
+      return ShortcutSelectionContext(
+        actions: Set(shortcutActions(
+          potentiallyAffectedBy: selection.field,
+          workspaceId: selection.workspaceId
+        )),
+        profileId: profileId,
+        selection: selection
+      )
+    }
+
+    // First establish the authoritative set of collision pairs introduced by
+    // the full selection. Per-field attribution below may be empty for a
+    // joint/redundant cause, but it must never erase this gate.
+    var projectedPairs = Set<ShortcutCollisionPair>()
+    var baselinePairs = Set<ShortcutCollisionPair>()
+    for context in contexts {
+      for action in context.actions {
+        projectedPairs.formUnion(shortcutCollisionPairs(
+          for: action,
+          in: context.profileId
+        ))
+        if let baseline {
+          baselinePairs.formUnion(baseline.shortcutCollisionPairs(for: action))
+        }
+      }
+    }
+    let introducedPairs = projectedPairs.subtracting(baselinePairs)
+
+    var pairsBySelection = [WorkspaceShortcutSelection: Set<ShortcutCollisionPair>]()
+    var attributedPairs = Set<ShortcutCollisionPair>()
+    for context in contexts {
+      let projectedForField = collisionPairs(
+        for: context.actions,
+        in: context.profileId
+      )
+      let counterfactual = baseline.flatMap { reverting(context.selection, to: $0) }
+      let remainingForField = counterfactual?.collisionPairs(
+        for: context.actions,
+        in: context.profileId
+      ) ?? []
+      let causalPairs = projectedForField
+        .subtracting(remainingForField)
+        .intersection(introducedPairs)
+      pairsBySelection[context.selection] = causalPairs
+      attributedPairs.formUnion(causalPairs)
+    }
+
+    // If no single revert removes an introduced pair, the fields are a joint
+    // or redundant cause (for example explicit X plus key-equivalent-derived
+    // X). Attribute the still-uncovered pair to every relevant selected field
+    // so Apply remains blocked until the combination is actually resolved.
+    for pair in introducedPairs.subtracting(attributedPairs) {
+      for context in contexts
+        where context.profileId == pair.profileId
+        && !context.actions.isDisjoint(with: pair.actions)
+      {
+        pairsBySelection[context.selection, default: []].insert(pair)
+      }
+    }
+
+    var conflicts = [WorkspaceShortcutConflict]()
+    var seen = Set<WorkspaceShortcutConflict>()
+    for context in contexts {
+      for pair in pairsBySelection[context.selection] ?? [] {
+        guard let owner = collisionOwner(in: pair, for: context.actions) else { continue }
+        let conflict = WorkspaceShortcutConflict(
+          selection: context.selection,
+          hotKey: pair.hotKey,
+          owner: owner.title(in: self)
+        )
+        if seen.insert(conflict).inserted {
+          conflicts.append(conflict)
+        }
+      }
+    }
+    return conflicts.sorted {
+      let lhs = ($0.selection.workspaceId.uuidString, $0.selection.field.rawValue, $0.hotKey.displayString, $0.owner)
+      let rhs = ($1.selection.workspaceId.uuidString, $1.selection.field.rawValue, $1.hotKey.displayString, $1.owner)
+      return lhs < rhs
+    }
+  }
+
+  private func collisionOwner(
+    in pair: ShortcutCollisionPair,
+    for controlledActions: Set<HotKeyAction>
+  ) -> HotKeyAction? {
+    let actions = pair.actions.sorted { $0.nameKey < $1.nameKey }
+    guard let controlled = actions.first(where: controlledActions.contains) else { return nil }
+    return actions.first { $0 != controlled }
+  }
+
+  private func collisionPairs(
+    for actions: Set<HotKeyAction>,
+    in profileId: Profile.ID
+  ) -> Set<ShortcutCollisionPair> {
+    actions.reduce(into: Set<ShortcutCollisionPair>()) { result, action in
+      result.formUnion(shortcutCollisionPairs(for: action, in: profileId))
+    }
+  }
+
+  /// Return the projected config with exactly one selected destination field
+  /// restored to its reviewed baseline value. Nil means the destination is new
+  /// (profile duplication), where there is no counterfactual old field.
+  private func reverting(
+    _ selection: WorkspaceShortcutSelection,
+    to baseline: AppConfig
+  ) -> AppConfig? {
+    guard let previous = baseline.workspace(id: selection.workspaceId) else { return nil }
+    var counterfactual = self
+    counterfactual.mutateWorkspace(selection.workspaceId) { workspace in
+      switch selection.field {
+      case .keyEquivalent:
+        workspace.keyEquivalent = previous.keyEquivalent
+      case .activateShortcut:
+        workspace.activateShortcut = previous.activateShortcut
+      case .assignAppShortcut:
+        workspace.assignAppShortcut = previous.assignAppShortcut
+      case .borrowShortcut:
+        workspace.borrowShortcut = previous.borrowShortcut
+      }
+    }
+    return counterfactual
+  }
+
+  private func shortcutConflict(
+    for candidate: HotKey,
+    excluding action: HotKeyAction,
+    among bindings: [HotKeyBinding]
+  ) -> String? {
+    bindings
       .first { $0.hotKey == candidate && $0.action != action }?
       .action.title(in: self)
   }
+
+  /// Effective collision pairs for one workspace action in one profile scope.
+  private func shortcutCollisionPairs(
+    for action: HotKeyAction,
+    in profileId: Profile.ID? = nil
+  ) -> Set<ShortcutCollisionPair> {
+    guard
+      let workspaceId = action.workspaceId,
+      let ownerProfileId = profileId ?? self.profileId(owning: workspaceId)
+    else { return [] }
+    let bindings = hotKeyBindings(for: ownerProfileId)
+    guard let binding = bindings.first(where: { $0.action == action }) else { return [] }
+    return Set(bindings.compactMap { other in
+      guard other.action != action, other.hotKey == binding.hotKey else { return nil }
+      return ShortcutCollisionPair(
+        actions: [action, other.action],
+        hotKey: binding.hotKey,
+        profileId: ownerProfileId
+      )
+    })
+  }
+
+  private func keyEquivalentConflict(
+    for keyName: String,
+    candidates: [KeyEquivalentCandidate],
+    conflict: (HotKey, HotKeyAction) -> String?
+  ) -> String? {
+    guard let keyCode = HotKey.keyCode(forName: keyName) else { return nil }
+    for candidate in candidates where candidate.explicitOverride == nil {
+      let modifiers = HotKey.carbonModifiers(from: candidate.modifiers)
+      guard modifiers != 0 else { continue }
+      let hotKey = HotKey(carbonKeyCode: keyCode, carbonModifiers: modifiers)
+      if let owner = conflict(hotKey, candidate.action) { return owner }
+    }
+    return nil
+  }
+
+  private func shortcutActions(
+    potentiallyAffectedBy field: WorkspaceShortcutField,
+    workspaceId: Workspace.ID
+  ) -> [HotKeyAction] {
+    switch field {
+    case .keyEquivalent:
+      return [
+        .activateWorkspace(workspaceId),
+        .assignFocusedAppToWorkspace(workspaceId),
+        .borrowWorkspace(workspaceId),
+      ]
+
+    case .activateShortcut:
+      return [.activateWorkspace(workspaceId)]
+
+    case .assignAppShortcut:
+      return [.assignFocusedAppToWorkspace(workspaceId)]
+
+    case .borrowShortcut:
+      return [.borrowWorkspace(workspaceId)]
+    }
+  }
+}
+
+private struct KeyEquivalentCandidate {
+  let modifiers: [String]
+  let action: HotKeyAction
+  let explicitOverride: HotKey?
+}
+
+private struct ShortcutCollisionPair: Hashable {
+  let actions: Set<HotKeyAction>
+  let hotKey: HotKey
+  let profileId: Profile.ID
+}
+
+private struct ShortcutSelectionContext {
+  let actions: Set<HotKeyAction>
+  let profileId: Profile.ID
+  let selection: WorkspaceShortcutSelection
 }

--- a/TatamiKit/Sources/Features/HotKeys/HotKeysFeature.swift
+++ b/TatamiKit/Sources/Features/HotKeys/HotKeysFeature.swift
@@ -11,7 +11,7 @@ import Sharing
 public struct HotKeysFeature {
   @ObservableState
   public struct State: Equatable {
-    @Shared(.tatamiConfig) public var config = AppConfig()
+    @Shared(.tatamiConfig) public var config
     public init() {}
 
     // Derived from the config — see `AppConfig.hotKeyBindings`, shared with

--- a/TatamiKit/Sources/Features/Onboarding/OnboardingFeature.swift
+++ b/TatamiKit/Sources/Features/Onboarding/OnboardingFeature.swift
@@ -569,7 +569,7 @@ public struct OnboardingFeature {
     }
 
     public func workspaceName(_ id: Workspace.ID) -> String {
-      draft.workspace(id: id)?.name ?? "Workspace"
+      draft.workspace(id: id)?.name ?? String(localized: "Workspace")
     }
 
     public func shortcut(for action: HotKeyAction) -> HotKey? {
@@ -1790,9 +1790,9 @@ public struct OnboardingFeature {
   ) -> String {
     switch block {
     case .host:
-      state.demoAppBySlot[slot]?.name ?? "the hovered window"
+      state.demoAppBySlot[slot]?.name ?? String(localized: "the hovered window")
     case .borrowed:
-      state.demoBorrowAppBySlot[slot]?.name ?? "the hovered window"
+      state.demoBorrowAppBySlot[slot]?.name ?? String(localized: "the hovered window")
     }
   }
 

--- a/TatamiKit/Sources/Features/Settings/HookEditorFeature.swift
+++ b/TatamiKit/Sources/Features/Settings/HookEditorFeature.swift
@@ -1,0 +1,505 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Foundation
+
+// MARK: - HookEditorFeature
+
+@Reducer
+public struct HookEditorFeature {
+
+  // MARK: Lifecycle
+
+  public init() { }
+
+  // MARK: Public
+
+  public enum Mode: Equatable, Sendable {
+    case add
+    case edit(HookLocator)
+  }
+
+  public struct ArgumentRow: Equatable, Identifiable, Sendable {
+    public init(id: UUID, value: String) {
+      self.id = id
+      self.value = value
+    }
+
+    public var id: UUID
+    public var value: String
+  }
+
+  public struct EnvironmentRow: Equatable, Identifiable, Sendable {
+    public init(id: UUID, key: String, value: String) {
+      self.id = id
+      self.key = key
+      self.value = value
+    }
+
+    public var id: UUID
+    public var key: String
+    public var value: String
+  }
+
+  public struct Draft: Equatable, Sendable {
+
+    // MARK: Lifecycle
+
+    public init(
+      id: String,
+      event: HookEvent,
+      enabled: Bool,
+      executable: String,
+      arguments: [ArgumentRow],
+      timeoutMs: Int,
+      workingDirectory: String,
+      environment: [EnvironmentRow],
+    ) {
+      self.id = id
+      self.event = event
+      self.enabled = enabled
+      self.executable = executable
+      self.arguments = arguments
+      self.timeoutMs = timeoutMs
+      self.workingDirectory = workingDirectory
+      self.environment = environment
+    }
+
+    // MARK: Public
+
+    public var id: String
+    public var event: HookEvent
+    public var enabled: Bool
+    public var executable: String
+    public var arguments: [ArgumentRow]
+    public var timeoutMs: Int
+    public var workingDirectory: String
+    public var environment: [EnvironmentRow]
+
+    public var definition: HookDefinition {
+      HookDefinition(
+        id: id,
+        event: event,
+        enabled: enabled,
+        command: [executable] + arguments.map(\.value),
+        timeoutMs: timeoutMs,
+        workingDirectory: workingDirectory.isEmpty ? nil : workingDirectory,
+        environment: Dictionary(
+          environment.map { ($0.key, $0.value) },
+          uniquingKeysWith: { _, newest in newest },
+        ),
+      )
+    }
+
+  }
+
+  public struct ValidationIssue: Equatable, Hashable, Sendable {
+
+    // MARK: Lifecycle
+
+    public init(field: Field, code: Code, message: String) {
+      self.field = field
+      self.code = code
+      self.message = message
+    }
+
+    // MARK: Public
+
+    public enum Field: Equatable, Hashable, Sendable {
+      case id
+      case executable
+      case argument(UUID)
+      case timeoutMs
+      case workingDirectory
+      case environment(UUID)
+      case testWorkspace
+    }
+
+    public enum Code: Equatable, Hashable, Sendable {
+      case definition(HookValidationIssue.Code)
+      case duplicateEnvironmentKey
+      case noActiveProfile
+      case noWorkspace
+      case staleDefinition
+    }
+
+    public var field: Field
+    public var code: Code
+    public var message: String
+
+  }
+
+  public enum TestStatus: Equatable, Sendable {
+    case idle
+    case running(UUID)
+    case succeeded(stdout: String, stderr: String)
+    case failed(message: String, stdout: String, stderr: String)
+    case cancelled
+  }
+
+  @ObservableState
+  public struct State: Equatable {
+
+    // MARK: Lifecycle
+
+    public init(
+      mode: Mode,
+      baseline: AppConfig,
+      hook: HookDefinition,
+      makeUUID: () -> UUID,
+    ) {
+      self.mode = mode
+      self.baseline = baseline
+      draft = Draft(
+        id: hook.id,
+        event: hook.event,
+        enabled: hook.enabled,
+        executable: hook.command.first ?? "",
+        arguments: hook.command.dropFirst().map {
+          ArgumentRow(id: makeUUID(), value: $0)
+        },
+        timeoutMs: hook.timeoutMs,
+        workingDirectory: hook.workingDirectory ?? "",
+        environment: hook.environment.sorted(by: { $0.key < $1.key }).map {
+          EnvironmentRow(id: makeUUID(), key: $0.key, value: $0.value)
+        },
+      )
+      testWorkspaceID = baseline.activeProfile?.workspaces.first {
+        $0.kind == .normal
+      }?.id
+    }
+
+    // MARK: Public
+
+    public var mode: Mode
+    public var baseline: AppConfig
+    public var draft: Draft
+    public var testWorkspaceID: Workspace.ID?
+    public var testStatus = TestStatus.idle
+    public var showsValidation = false
+    public var showsTestValidation = false
+    public var saveError: String?
+
+    public var testWorkspaces: [Workspace] {
+      Array((baseline.activeProfile?.workspaces ?? []).filter { $0.kind == .normal })
+    }
+
+    public var validationIssues: [ValidationIssue] {
+      let targetIndex: Int
+      var hooks = baseline.hooks
+      switch mode {
+      case .add:
+        targetIndex = hooks.endIndex
+        hooks.append(draft.definition)
+
+      case .edit(let locator):
+        guard hooks.indices.contains(locator.offset), hooks[locator.offset] == locator.expected else {
+          return [ValidationIssue(
+            field: .id,
+            code: .staleDefinition,
+            message: String(localized: "The hook changed while it was being edited"),
+          )]
+        }
+        targetIndex = locator.offset
+        hooks[targetIndex] = draft.definition
+      }
+
+      var issues = HookDefinition.validate(hooks).detailedIssues
+        .filter { $0.hookIndex == targetIndex }
+        .map(localIssue)
+
+      let groupedEnvironment = Dictionary(grouping: draft.environment, by: \.key)
+      for row in draft.environment where (groupedEnvironment[row.key]?.count ?? 0) > 1 {
+        issues.append(ValidationIssue(
+          field: .environment(row.id),
+          code: .duplicateEnvironmentKey,
+          message: String(localized: "Environment variable names must be unique"),
+        ))
+      }
+      return issues
+    }
+
+    public var testValidationIssues: [ValidationIssue] {
+      var issues = validationIssues
+      guard baseline.activeProfile != nil else {
+        issues.append(ValidationIssue(
+          field: .testWorkspace,
+          code: .noActiveProfile,
+          message: String(localized: "A profile is required to run this hook"),
+        ))
+        return issues
+      }
+      if
+        draft.event == .workspaceActivated,
+        !testWorkspaces.contains(where: { $0.id == testWorkspaceID })
+      {
+        issues.append(ValidationIssue(
+          field: .testWorkspace,
+          code: .noWorkspace,
+          message: String(localized: "Choose a workspace for the test event"),
+        ))
+      }
+      return issues
+    }
+
+    // MARK: Private
+
+    private func localIssue(_ issue: HookValidationIssue) -> ValidationIssue {
+      let field: ValidationIssue.Field =
+        switch issue.field {
+        case .id:
+          .id
+
+        case .command:
+          if let argument = draft.arguments.first(where: { $0.value.utf8.contains(0) }) {
+            .argument(argument.id)
+          } else {
+            .executable
+          }
+
+        case .timeoutMs:
+          .timeoutMs
+
+        case .workingDirectory:
+          .workingDirectory
+
+        case .environment(let key):
+          draft.environment.first(where: { $0.key == key }).map {
+            .environment($0.id)
+          } ?? .executable
+        }
+      return ValidationIssue(
+        field: field,
+        code: .definition(issue.code),
+        message: issue.message,
+      )
+    }
+
+  }
+
+  public enum Action {
+    case argumentAddButtonTapped
+    case argumentDeleteButtonTapped(UUID)
+    case argumentValueChanged(UUID, String)
+    case cancelButtonTapped
+    case cancelTestButtonTapped
+    case enabledChanged(Bool)
+    case environmentAddButtonTapped
+    case environmentDeleteButtonTapped(UUID)
+    case environmentKeyChanged(UUID, String)
+    case environmentValueChanged(UUID, String)
+    case eventChanged(HookEvent)
+    case executableChanged(String)
+    case idChanged(String)
+    case saveButtonTapped
+    case testButtonTapped
+    case testResponse(UUID, HookExecutionResult)
+    case testWorkspaceChanged(Workspace.ID?)
+    case timeoutChanged(Int)
+    case workingDirectoryChanged(String)
+    case delegate(Delegate)
+
+    // MARK: Public
+
+    public enum Delegate: Equatable {
+      case cancelRequested
+      case saveRequested(
+        mode: Mode,
+        baseline: AppConfig,
+        definition: HookDefinition,
+      )
+    }
+  }
+
+  public var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .argumentAddButtonTapped:
+        resetTest(&state)
+        state.draft.arguments.append(ArgumentRow(id: uuid(), value: ""))
+        return .cancel(id: CancelID.test)
+
+      case .argumentDeleteButtonTapped(let id):
+        resetTest(&state)
+        state.draft.arguments.removeAll { $0.id == id }
+        return .cancel(id: CancelID.test)
+
+      case .argumentValueChanged(let id, let value):
+        resetTest(&state)
+        state.draft.arguments[id: id]?.value = value
+        return .cancel(id: CancelID.test)
+
+      case .enabledChanged(let enabled):
+        resetTest(&state)
+        state.draft.enabled = enabled
+        return .cancel(id: CancelID.test)
+
+      case .environmentAddButtonTapped:
+        resetTest(&state)
+        state.draft.environment.append(EnvironmentRow(id: uuid(), key: "", value: ""))
+        return .cancel(id: CancelID.test)
+
+      case .environmentDeleteButtonTapped(let id):
+        resetTest(&state)
+        state.draft.environment.removeAll { $0.id == id }
+        return .cancel(id: CancelID.test)
+
+      case .environmentKeyChanged(let id, let key):
+        resetTest(&state)
+        state.draft.environment[id: id]?.key = key
+        return .cancel(id: CancelID.test)
+
+      case .environmentValueChanged(let id, let value):
+        resetTest(&state)
+        state.draft.environment[id: id]?.value = value
+        return .cancel(id: CancelID.test)
+
+      case .eventChanged(let event):
+        resetTest(&state)
+        state.draft.event = event
+        if
+          event == .workspaceActivated,
+          !state.testWorkspaces.contains(where: { $0.id == state.testWorkspaceID })
+        {
+          state.testWorkspaceID = state.testWorkspaces.first?.id
+        }
+        return .cancel(id: CancelID.test)
+
+      case .executableChanged(let executable):
+        resetTest(&state)
+        state.draft.executable = executable
+        return .cancel(id: CancelID.test)
+
+      case .idChanged(let id):
+        resetTest(&state)
+        state.draft.id = id
+        return .cancel(id: CancelID.test)
+
+      case .testWorkspaceChanged(let workspaceID):
+        resetTest(&state)
+        state.testWorkspaceID = workspaceID
+        return .cancel(id: CancelID.test)
+
+      case .timeoutChanged(let timeoutMs):
+        resetTest(&state)
+        state.draft.timeoutMs = timeoutMs
+        return .cancel(id: CancelID.test)
+
+      case .workingDirectoryChanged(let directory):
+        resetTest(&state)
+        state.draft.workingDirectory = directory
+        return .cancel(id: CancelID.test)
+
+      case .saveButtonTapped:
+        state.showsValidation = true
+        state.showsTestValidation = false
+        state.saveError = nil
+        guard state.validationIssues.isEmpty else { return .none }
+        return .send(.delegate(.saveRequested(
+          mode: state.mode,
+          baseline: state.baseline,
+          definition: state.draft.definition,
+        )))
+
+      case .cancelButtonTapped:
+        return .concatenate(
+          .cancel(id: CancelID.test),
+          .send(.delegate(.cancelRequested)),
+        )
+
+      case .testButtonTapped:
+        state.showsValidation = false
+        state.showsTestValidation = true
+        guard
+          state.testValidationIssues.isEmpty,
+          let invocation = testInvocation(state: state, occurredAt: now)
+        else { return .none }
+        let runID = uuid()
+        let definition = state.draft.definition
+        state.testStatus = .running(runID)
+        return .run { [hookRunner] send in
+          let result = await hookRunner.run(definition, invocation)
+          await send(.testResponse(runID, result))
+        }
+        .cancellable(id: CancelID.test, cancelInFlight: true)
+
+      case .cancelTestButtonTapped:
+        guard case .running = state.testStatus else { return .none }
+        state.testStatus = .cancelled
+        return .cancel(id: CancelID.test)
+
+      case .testResponse(let runID, let result):
+        guard case .running(runID) = state.testStatus else { return .none }
+        state.testStatus =
+          switch result {
+          case .success(let stdout, let stderr):
+            .succeeded(stdout: stdout, stderr: stderr)
+          case .failure(let message, let stdout, let stderr):
+            .failed(message: message, stdout: stdout, stderr: stderr)
+          case .cancelled:
+            .cancelled
+          }
+        return .none
+
+      case .delegate:
+        return .none
+      }
+    }
+  }
+
+  // MARK: Internal
+
+  @Dependency(\.date.now) var now
+  @Dependency(\.hookRunner) var hookRunner
+  @Dependency(\.uuid) var uuid
+
+  // MARK: Private
+
+  private enum CancelID { case test }
+
+  private func resetTest(_ state: inout State) {
+    state.showsValidation = false
+    state.showsTestValidation = false
+    state.saveError = nil
+    state.testStatus = .idle
+  }
+
+  private func testInvocation(state: State, occurredAt: Date) -> HookInvocation? {
+    guard let profile = state.baseline.activeProfile else { return nil }
+    let workspace: Workspace? =
+      if state.draft.event == .workspaceActivated {
+        state.testWorkspaces.first { $0.id == state.testWorkspaceID }
+      } else {
+        nil
+      }
+    if state.draft.event == .workspaceActivated, workspace == nil { return nil }
+    return HookInvocation(
+      event: state.draft.event,
+      occurredAt: occurredAt,
+      profile: .init(profile),
+      workspace: workspace.map(HookInvocation.WorkspaceSnapshot.init),
+    )
+  }
+
+}
+
+extension [HookEditorFeature.ArgumentRow] {
+  fileprivate subscript(id id: UUID) -> Element? {
+    get { first { $0.id == id } }
+    set {
+      guard let index = firstIndex(where: { $0.id == id }), let newValue else { return }
+      self[index] = newValue
+    }
+  }
+}
+
+extension [HookEditorFeature.EnvironmentRow] {
+  fileprivate subscript(id id: UUID) -> Element? {
+    get { first { $0.id == id } }
+    set {
+      guard let index = firstIndex(where: { $0.id == id }), let newValue else { return }
+      self[index] = newValue
+    }
+  }
+}

--- a/TatamiKit/Sources/Features/Settings/HookSettingsFeature.swift
+++ b/TatamiKit/Sources/Features/Settings/HookSettingsFeature.swift
@@ -1,0 +1,407 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Foundation
+import Perception
+import Sharing
+
+// MARK: - HookLocator
+
+public struct HookLocator: Equatable, Hashable, Sendable {
+  public init(offset: Int, expected: HookDefinition) {
+    self.offset = offset
+    self.expected = expected
+  }
+
+  public var offset: Int
+  public var expected: HookDefinition
+}
+
+// MARK: - HookSettingsFeature
+
+@Reducer
+public struct HookSettingsFeature {
+
+  // MARK: Lifecycle
+
+  public init() { }
+
+  // MARK: Public
+
+  public enum Mutation: Equatable, Sendable {
+    case add
+    case delete(HookLocator)
+    case edit(HookLocator)
+    case setEnabled(HookLocator, Bool)
+  }
+
+  public struct MutationFailure: Equatable, Error, Sendable {
+    public init(kind: Kind, message: String) {
+      self.kind = kind
+      self.message = message
+    }
+
+    public enum Kind: Equatable, Sendable {
+      case staleConfiguration
+      case writeFailed
+    }
+
+    public var kind: Kind
+    public var message: String
+  }
+
+  public struct Row: Equatable, Identifiable, Sendable {
+
+    // MARK: Lifecycle
+
+    public init(
+      id: UUID,
+      locator: HookLocator,
+      validationIssues: [HookValidationIssue],
+    ) {
+      self.id = id
+      self.locator = locator
+      self.validationIssues = validationIssues
+    }
+
+    // MARK: Public
+
+    public var id: UUID
+    public var locator: HookLocator
+    public var validationIssues: [HookValidationIssue]
+
+    public var definition: HookDefinition {
+      locator.expected
+    }
+
+    public var isValid: Bool {
+      validationIssues.isEmpty
+    }
+
+  }
+
+  @ObservableState
+  public struct State: Equatable {
+    public init() { }
+
+    @Shared(.tatamiConfig) public var config
+    public var rows = [Row]()
+    public var mutationInFlight: Mutation?
+    @Presents public var editor: HookEditorFeature.State?
+    @Presents public var alert: AlertState<Action.Alert>?
+  }
+
+  public enum Action {
+    case addButtonTapped
+    case alert(PresentationAction<Alert>)
+    case configurationChanged
+    case deleteButtonTapped(HookLocator)
+    case editButtonTapped(HookLocator)
+    case editor(PresentationAction<HookEditorFeature.Action>)
+    case enabledChanged(HookLocator, Bool)
+    case mutationResponse(Mutation, Result<Void, MutationFailure>)
+    case task
+
+    public enum Alert: Equatable {
+      case confirmDelete(HookLocator)
+      case dismiss
+    }
+  }
+
+  public var body: some ReducerOf<Self> {
+    Reduce { state, action in
+      switch action {
+      case .task:
+        reconcileRows(state: &state)
+        let sharedConfig = state.$config
+        return .run { send in
+          for await _ in Perceptions({ sharedConfig.wrappedValue.hooks }) {
+            await send(.configurationChanged)
+          }
+        }
+        .cancellable(id: CancelID.observation, cancelInFlight: true)
+
+      case .configurationChanged:
+        reconcileRows(state: &state)
+        return .none
+
+      case .addButtonTapped:
+        guard state.mutationInFlight == nil else { return .none }
+        let baseline = state.config
+        let hook = HookDefinition(
+          id: availableID(in: baseline.hooks),
+          event: .workspaceActivated,
+          command: [],
+        )
+        state.editor = HookEditorFeature.State(
+          mode: .add,
+          baseline: baseline,
+          hook: hook,
+          makeUUID: { uuid() },
+        )
+        return .none
+
+      case .editButtonTapped(let locator):
+        guard state.mutationInFlight == nil else { return .none }
+        guard isCurrent(locator, in: state.config) else {
+          presentStaleAlert(state: &state)
+          reconcileRows(state: &state)
+          return .none
+        }
+        state.editor = HookEditorFeature.State(
+          mode: .edit(locator),
+          baseline: state.config,
+          hook: locator.expected,
+          makeUUID: { uuid() },
+        )
+        return .none
+
+      case .deleteButtonTapped(let locator):
+        guard state.mutationInFlight == nil else { return .none }
+        guard isCurrent(locator, in: state.config) else {
+          presentStaleAlert(state: &state)
+          reconcileRows(state: &state)
+          return .none
+        }
+        state.alert = AlertState {
+          TextState("Delete hook \"\(locator.expected.id)\"?")
+        } actions: {
+          ButtonState(role: .destructive, action: .confirmDelete(locator)) {
+            TextState("Delete")
+          }
+          ButtonState(role: .cancel, action: .dismiss) {
+            TextState("Cancel")
+          }
+        } message: {
+          TextState("The hook will no longer run for future events.")
+        }
+        return .none
+
+      case .alert(.presented(.confirmDelete(let locator))):
+        guard state.mutationInFlight == nil else { return .none }
+        let baseline = state.config
+        guard isCurrent(locator, in: baseline) else {
+          presentStaleAlert(state: &state)
+          reconcileRows(state: &state)
+          return .none
+        }
+        var updated = baseline
+        updated.hooks.remove(at: locator.offset)
+        let mutation = Mutation.delete(locator)
+        state.alert = nil
+        state.mutationInFlight = mutation
+        return persist(updated, baseline: baseline, config: state.$config, mutation: mutation)
+
+      case .enabledChanged(let locator, let enabled):
+        guard state.mutationInFlight == nil else { return .none }
+        let baseline = state.config
+        guard isCurrent(locator, in: baseline) else {
+          presentStaleAlert(state: &state)
+          reconcileRows(state: &state)
+          return .none
+        }
+        guard locator.expected.enabled != enabled else { return .none }
+        var updated = baseline
+        updated.hooks[locator.offset].enabled = enabled
+        let mutation = Mutation.setEnabled(locator, enabled)
+        state.mutationInFlight = mutation
+        return persist(updated, baseline: baseline, config: state.$config, mutation: mutation)
+
+      case .editor(.presented(.delegate(.cancelRequested))):
+        state.editor = nil
+        return .none
+
+      case .editor(.presented(.delegate(.saveRequested(
+        mode: let mode,
+        baseline: let baseline,
+        definition: let definition,
+      )))):
+        guard state.mutationInFlight == nil else { return .none }
+        var updated = baseline
+        let targetIndex: Int
+        let mutation: Mutation
+        switch mode {
+        case .add:
+          targetIndex = updated.hooks.endIndex
+          updated.hooks.append(definition)
+          mutation = .add
+
+        case .edit(let locator):
+          guard isCurrent(locator, in: baseline) else {
+            presentStaleAlert(state: &state)
+            return .none
+          }
+          targetIndex = locator.offset
+          updated.hooks[targetIndex] = definition
+          mutation = .edit(locator)
+        }
+        let candidateIssues = HookDefinition.validate(updated.hooks).detailedIssues
+          .filter { $0.hookIndex == targetIndex }
+        guard candidateIssues.isEmpty else { return .none }
+
+        state.mutationInFlight = mutation
+        return persist(updated, baseline: baseline, config: state.$config, mutation: mutation)
+
+      case .mutationResponse(let mutation, .success):
+        guard state.mutationInFlight == mutation else { return .none }
+        state.mutationInFlight = nil
+        errorReporter.resolve("ConfigSave")
+        switch mutation {
+        case .add,
+             .edit:
+          state.editor = nil
+        case .delete,
+             .setEnabled:
+          break
+        }
+        reconcileRows(state: &state)
+        return .none
+
+      case .mutationResponse(let mutation, .failure(let failure)):
+        guard state.mutationInFlight == mutation else { return .none }
+        state.mutationInFlight = nil
+        errorReporter.report(
+          "ConfigSave",
+          String(localized: "config.toml could not be saved"),
+          failure.message,
+        )
+        switch mutation {
+        case .add,
+             .edit:
+          state.editor?.saveError = failure.message
+
+        case .delete,
+             .setEnabled:
+          if failure.kind == .staleConfiguration {
+            presentStaleAlert(state: &state)
+          } else {
+            presentSaveFailedAlert(failure.message, state: &state)
+          }
+        }
+        reconcileRows(state: &state)
+        return .none
+
+      case .alert,
+           .editor:
+        return .none
+      }
+    }
+    .ifLet(\.$editor, action: \.editor) {
+      HookEditorFeature()
+    }
+    .ifLet(\.$alert, action: \.alert)
+  }
+
+  // MARK: Internal
+
+  @Dependency(\.configPersistence) var configPersistence
+  @Dependency(\.errorReporter) var errorReporter
+  @Dependency(\.uuid) var uuid
+
+  // MARK: Private
+
+  private enum CancelID { case observation }
+
+  private static func mutationFailure(_ error: any Error) -> MutationFailure {
+    let kind: MutationFailure.Kind =
+      if let error = error as? ConfigPersistenceError {
+        switch error {
+        case .changedInMemory,
+             .changedOnDisk,
+             .transactionExpired:
+          .staleConfiguration
+        case .outcomeUnknown:
+          .writeFailed
+        }
+      } else {
+        .writeFailed
+      }
+    return MutationFailure(kind: kind, message: ErrorReportClient.describe(error))
+  }
+
+  private func availableID(in hooks: [HookDefinition]) -> String {
+    let ids = Set(hooks.map(\.id))
+    if !ids.contains("hook") { return "hook" }
+    var suffix = 2
+    while ids.contains("hook-\(suffix)") { suffix += 1 }
+    return "hook-\(suffix)"
+  }
+
+  private func isCurrent(_ locator: HookLocator, in config: AppConfig) -> Bool {
+    config.hooks.indices.contains(locator.offset)
+      && config.hooks[locator.offset] == locator.expected
+  }
+
+  private func persist(
+    _ updated: AppConfig,
+    baseline: AppConfig,
+    config: Shared<AppConfig>,
+    mutation: Mutation,
+  ) -> Effect<Action> {
+    .run { [configPersistence] send in
+      do {
+        let revision = try configPersistence.captureRevision(baseline)
+        try configPersistence.commit(
+          config,
+          baseline,
+          revision,
+          updated,
+          { true },
+        )
+        await send(.mutationResponse(mutation, .success(())))
+      } catch {
+        await send(.mutationResponse(
+          mutation,
+          .failure(Self.mutationFailure(error)),
+        ))
+      }
+    }
+  }
+
+  private func presentStaleAlert(state: inout State) {
+    state.alert = AlertState {
+      TextState("Configuration changed")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+    } message: {
+      TextState("The hook was not changed. Review the latest configuration and try again.")
+    }
+  }
+
+  private func presentSaveFailedAlert(_ message: String, state: inout State) {
+    state.alert = AlertState {
+      TextState("Hook could not be saved")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismiss) { TextState("OK") }
+    } message: {
+      TextState(message)
+    }
+  }
+
+  private func reconcileRows(state: inout State) {
+    let hooks = state.config.hooks
+    let validation = HookDefinition.validate(hooks)
+    var unusedRows = Array(state.rows.enumerated())
+    var rows = [Row]()
+    rows.reserveCapacity(hooks.count)
+
+    for (offset, definition) in hooks.enumerated() {
+      let matchIndex = unusedRows.firstIndex { $0.element.locator.expected == definition }
+        ?? unusedRows.firstIndex { $0.element.locator.offset == offset }
+      let rowID: UUID =
+        if let matchIndex {
+          unusedRows.remove(at: matchIndex).element.id
+        } else {
+          uuid()
+        }
+      rows.append(Row(
+        id: rowID,
+        locator: HookLocator(offset: offset, expected: definition),
+        validationIssues: validation.detailedIssues.filter { $0.hookIndex == offset },
+      ))
+    }
+    state.rows = rows
+  }
+
+}

--- a/TatamiKit/Sources/Features/Settings/SettingsFeature.swift
+++ b/TatamiKit/Sources/Features/Settings/SettingsFeature.swift
@@ -10,16 +10,24 @@ import Foundation
 /// only the logic that talks to the system (install, permission, relaunch).
 @Reducer
 public struct SettingsFeature {
+
+  // MARK: Lifecycle
+
+  public init() { }
+
+  // MARK: Public
+
   @ObservableState
   public struct State: Equatable {
+    public init() { }
+
     public var cli = CLIStatus()
+    public var hooks = HookSettingsFeature.State()
     /// Default `true` to avoid a "not granted" flash before the first read.
     public var hasAXPermission = true
     /// Same flash-avoidance default as `hasAXPermission`.
     public var hasScreenRecordingPermission = true
     @Presents public var alert: AlertState<Action.Alert>?
-
-    public init() {}
   }
 
   public enum Action {
@@ -27,6 +35,7 @@ public struct SettingsFeature {
     case task
     case refreshCLIStatus
     case installCLITapped
+    case hooks(HookSettingsFeature.Action)
     case uninstallCLITapped
     /// A trust-DB change (or app re-activation) — re-read permission status.
     case accessibilityChanged
@@ -40,10 +49,108 @@ public struct SettingsFeature {
     case shortcutRecordingChanged(Bool)
     case alert(PresentationAction<Alert>)
 
+    // MARK: Public
+
     public enum Alert: Equatable {
       case confirmUninstall
     }
   }
+
+  public var body: some ReducerOf<Self> {
+    CombineReducers {
+      Scope(state: \.hooks, action: \.hooks) {
+        HookSettingsFeature()
+      }
+      Reduce { state, action in
+        switch action {
+        case .task:
+          state.cli = cliInstaller.status()
+          state.hasAXPermission = accessibility.isTrusted()
+          state.hasScreenRecordingPermission = screenRecording.isGranted()
+          return .run { [accessibility] send in
+            // Trust-DB change / app re-activation → re-read permission
+            // status (the re-activation tick also covers coming back from
+            // the Screen Recording pane of System Settings).
+            for await _ in accessibility.changes() {
+              await send(.accessibilityChanged)
+            }
+          }
+
+        case .refreshCLIStatus:
+          state.cli = cliInstaller.status()
+          return .none
+
+        case .installCLITapped:
+          return .run { [cliInstaller] send in
+            await cliInstaller.install()
+            await send(.refreshCLIStatus)
+          }
+
+        case .uninstallCLITapped:
+          state.alert = AlertState {
+            TextState("Uninstall tatami CLI?")
+          } actions: {
+            ButtonState(role: .destructive, action: .confirmUninstall) {
+              TextState("Uninstall")
+            }
+            ButtonState(role: .cancel) {
+              TextState("Cancel")
+            }
+          } message: {
+            TextState("Removes the tatami symlink from /usr/local/bin. You can reinstall it anytime from here.")
+          }
+          return .none
+
+        case .alert(.presented(.confirmUninstall)):
+          return .run { [cliInstaller] send in
+            await cliInstaller.uninstall()
+            await send(.refreshCLIStatus)
+          }
+
+        case .alert:
+          return .none
+
+        case .accessibilityChanged:
+          state.hasAXPermission = accessibility.isTrusted()
+          state.hasScreenRecordingPermission = screenRecording.isGranted()
+          return .none
+
+        case .grantAccessibilityTapped:
+          return .run { [accessibility] _ in
+            await accessibility.requestAccess()
+            await accessibility.openSettings()
+          }
+
+        case .openAccessibilitySettingsTapped:
+          return .run { [accessibility] _ in await accessibility.openSettings() }
+
+        case .grantScreenRecordingTapped:
+          return .run { [screenRecording] _ in
+            await screenRecording.requestAccess()
+            await screenRecording.openSettings()
+          }
+
+        case .openScreenRecordingSettingsTapped:
+          return .run { [screenRecording] _ in await screenRecording.openSettings() }
+
+        case .relaunchTapped:
+          return .run { [accessibility] _ in await accessibility.relaunch() }
+
+        case .checkForUpdatesTapped:
+          return .run { [updater] _ in await updater.checkForUpdates() }
+
+        case .shortcutRecordingChanged(let recording):
+          return .run { [hotKeys] _ in await hotKeys.setRecording(recording) }
+
+        case .hooks:
+          return .none
+        }
+      }
+    }
+    .ifLet(\.$alert, action: \.alert)
+  }
+
+  // MARK: Internal
 
   @Dependency(\.cliInstaller) var cliInstaller
   @Dependency(\.accessibility) var accessibility
@@ -51,91 +158,4 @@ public struct SettingsFeature {
   @Dependency(\.updater) var updater
   @Dependency(\.hotKeys) var hotKeys
 
-  public init() {}
-
-  public var body: some ReducerOf<Self> {
-    Reduce { state, action in
-      switch action {
-      case .task:
-        state.cli = cliInstaller.status()
-        state.hasAXPermission = accessibility.isTrusted()
-        state.hasScreenRecordingPermission = screenRecording.isGranted()
-        return .run { [accessibility] send in
-          // Trust-DB change / app re-activation → re-read permission
-          // status (the re-activation tick also covers coming back from
-          // the Screen Recording pane of System Settings).
-          for await _ in accessibility.changes() {
-            await send(.accessibilityChanged)
-          }
-        }
-
-      case .refreshCLIStatus:
-        state.cli = cliInstaller.status()
-        return .none
-
-      case .installCLITapped:
-        return .run { [cliInstaller] send in
-          await cliInstaller.install()
-          await send(.refreshCLIStatus)
-        }
-
-      case .uninstallCLITapped:
-        state.alert = AlertState {
-          TextState("Uninstall tatami CLI?")
-        } actions: {
-          ButtonState(role: .destructive, action: .confirmUninstall) {
-            TextState("Uninstall")
-          }
-          ButtonState(role: .cancel) {
-            TextState("Cancel")
-          }
-        } message: {
-          TextState("Removes the tatami symlink from /usr/local/bin. You can reinstall it anytime from here.")
-        }
-        return .none
-
-      case .alert(.presented(.confirmUninstall)):
-        return .run { [cliInstaller] send in
-          await cliInstaller.uninstall()
-          await send(.refreshCLIStatus)
-        }
-
-      case .alert:
-        return .none
-
-      case .accessibilityChanged:
-        state.hasAXPermission = accessibility.isTrusted()
-        state.hasScreenRecordingPermission = screenRecording.isGranted()
-        return .none
-
-      case .grantAccessibilityTapped:
-        return .run { [accessibility] _ in
-          await accessibility.requestAccess()
-          await accessibility.openSettings()
-        }
-
-      case .openAccessibilitySettingsTapped:
-        return .run { [accessibility] _ in await accessibility.openSettings() }
-
-      case .grantScreenRecordingTapped:
-        return .run { [screenRecording] _ in
-          await screenRecording.requestAccess()
-          await screenRecording.openSettings()
-        }
-
-      case .openScreenRecordingSettingsTapped:
-        return .run { [screenRecording] _ in await screenRecording.openSettings() }
-
-      case .relaunchTapped:
-        return .run { [accessibility] _ in await accessibility.relaunch() }
-
-      case .checkForUpdatesTapped:
-        return .run { [updater] _ in await updater.checkForUpdates() }
-
-      case .shortcutRecordingChanged(let recording):
-        return .run { [hotKeys] _ in await hotKeys.setRecording(recording) }
-      }
-    }
-    .ifLet(\.$alert, action: \.alert)
-  }
 }

--- a/TatamiKit/Sources/Features/WorkspaceActivation/WorkspaceActivationFeature+Activate.swift
+++ b/TatamiKit/Sources/Features/WorkspaceActivation/WorkspaceActivationFeature+Activate.swift
@@ -277,11 +277,58 @@ extension WorkspaceActivationFeature {
     return displays.connected(hint) ?? displays.primary() ?? hint
   }
 
+  /// Shared deliberate-switch entry point for hotkeys/UI and CLI completion
+  /// tracking. The CLI wraps this returned effect so its response follows the
+  /// actual focus/layout tail instead of merely following action delivery.
+  func deliberateActivation(
+    workspaceId: Workspace.ID,
+    setFocus: Bool,
+    continuesCLIActivation: Bool = false,
+    state: inout State,
+  ) -> Effect<Action> {
+    // A deliberate switch supersedes any in-flight reconnect restore cascade.
+    // The user's action wins over the display-restore queue.
+    state.pendingDisplayRestores = []
+    // An already-active host that activation would leave exactly where it is
+    // is a display focus transfer. Re-activation would tear down its Borrow.
+    if
+      state.activeActivationGeneration == nil,
+      setFocus,
+      let display = state.activeWorkspacesByDisplay.first(where: {
+        $0.value == workspaceId
+      })?.key,
+      let workspace = state.config.activeProfile?.workspaces[id: workspaceId],
+      deliberateActivationDisplay(for: workspace, state: state)?.matches(display) ?? true,
+      // With no focus target, a transfer would silently swallow the switch;
+      // run a real activation so the workspace is raised again.
+      visibleFocusTarget(workspaceId, state: state) != nil
+    {
+      let superseded = continuesCLIActivation
+        ? Effect<Action>.none
+        : supersedePendingCLIActivation(state: &state)
+      return .merge(superseded, focusVisibleWorkspace(
+        workspaceId: workspaceId,
+        display: display,
+        state: &state,
+      ))
+    }
+    return performActivate(
+      workspaceId: workspaceId,
+      setFocus: setFocus,
+      continuesCLIActivation: continuesCLIActivation,
+      state: &state,
+    )
+  }
+
   func performActivate(
     workspaceId: Workspace.ID,
     setFocus: Bool,
     displayOverride: DisplayName? = nil,
     suppressSwitchHUD: Bool = false,
+    /// Planned profile restores and the originating workspace CLI command keep
+    /// ownership of the pending CLI request. Every other activation supersedes
+    /// that request instead of silently rebinding it to unrelated work.
+    continuesCLIActivation: Bool = false,
     // The cursor follows focus even though this activation does not set it.
     // `setFocus` answers "does Tatami pick the focused window", which is not
     // the same question as "did focus move" — an app the user activated from
@@ -297,6 +344,10 @@ extension WorkspaceActivationFeature {
     // (Switching to a borrowed workspace fully activates it — the composition
     // is dropped as the display re-tiles. Moving focus *into* a borrowed block
     // without switching is the directional-focus path, not activation.)
+    let superseded = continuesCLIActivation
+      ? Effect<Action>.none
+      : supersedePendingCLIActivation(state: &state)
+
     // A scratchpad is borrow-only: there's no "switch to" it. Redirect a
     // standalone activate into a borrow on the pointer display's host
     // (re-docks if it's already borrowed there).
@@ -305,16 +356,23 @@ extension WorkspaceActivationFeature {
       let resolved = workspace.borrowEdge ?? state.config.settings.switching.borrowDefaultEdge
       if let resolved {
         // A configured default edge → dock straight there.
-        return performBorrow(targetId: workspaceId, edge: resolved, state: &state)
+        return .merge(
+          superseded,
+          performBorrow(targetId: workspaceId, edge: resolved, state: &state),
+        )
       }
       if setFocus {
         // "Ask" via a deliberate shortcut (switch/borrow): open the direction
         // picker with nothing placed yet, like the borrow shortcut.
-        return .send(.beginBorrowDirection(workspaceId: workspaceId))
+        return .merge(
+          superseded,
+          .send(.beginBorrowDirection(workspaceId: workspaceId)),
+        )
       }
       // "Ask" via focusing the app: dock provisionally at the fallback edge so
       // the window never floats unplaced, then open the picker to re-steer it.
       return .merge(
+        superseded,
         performBorrow(targetId: workspaceId, edge: .right, state: &state),
         .send(.beginBorrowDirection(workspaceId: workspaceId)),
       )
@@ -362,6 +420,15 @@ extension WorkspaceActivationFeature {
     }
     state.isActivating = true
     state.activatingWorkspaceID = workspaceId
+    state.activationGeneration &+= 1
+    let activationGeneration = state.activationGeneration
+    state.activeActivationGeneration = activationGeneration
+    if continuesCLIActivation, let request = state.pendingCLIActivation {
+      state.pendingCLIActivationBinding = CLIActivationBinding(
+        requestID: request.id,
+        activationGeneration: activationGeneration,
+      )
+    }
     let isPaused = state.isTilingPaused
     debugLog.log(
       "Activate",
@@ -664,7 +731,7 @@ extension WorkspaceActivationFeature {
     // by `activationCompleted` on the normal path.
     let watchdog = Effect<Action>.run { [clock] send in
       try await clock.sleep(for: .seconds(10))
-      await send(.activationTimedOut)
+      await send(.activationTimedOut(generation: activationGeneration))
     }
     .cancellable(id: CancelID.activationWatchdog, cancelInFlight: true)
 
@@ -672,383 +739,403 @@ extension WorkspaceActivationFeature {
     // hotkey press. Under system load the default priority leaves our
     // main-actor hops queued behind everything else — exactly when the
     // switch already crawls on slow AX replies.
-    return .concatenate(
-      // Every frame writer targeting this display shares one cancellation
-      // domain. An activation is the authoritative writer, so retire an
-      // in-flight tree/composition flush before its show/hide + tile pass.
-      .cancel(id: CancelID.layout(targetDisplay)),
-      .cancel(id: CancelID.borrowFocus(targetDisplay)),
-      .cancel(id: CancelID.borrowRender(targetDisplay)),
-      .merge(
-        screenRecordingWarning,
-        watchdog,
-        crossMonitorHUD,
-        displacedCompositionReflow,
-        clearedCompositionMarkers,
-        // Arm tiled, floating, and unmanaged apps concurrently with activation.
-        // A first-time installation emits one observation-ready reconcile, so
-        // a state change racing this setup cannot fall through the cache gap.
-        .run { [observer = windowObserver, activationObservedBundleIds] send in
-          await observer.observe(activationObservedBundleIds)
-          await send(
-            .presentationObservationReady(
-              bundleIds: Set(activationObservedBundleIds)
+    return .merge(
+      superseded,
+      .concatenate(
+        // Every frame writer targeting this display shares one cancellation
+        // domain. An activation is the authoritative writer, so retire an
+        // in-flight tree/composition flush before its show/hide + tile pass.
+        .cancel(id: CancelID.layout(targetDisplay)),
+        .cancel(id: CancelID.borrowFocus(targetDisplay)),
+        .cancel(id: CancelID.borrowRender(targetDisplay)),
+        .merge(
+          screenRecordingWarning,
+          watchdog,
+          crossMonitorHUD,
+          displacedCompositionReflow,
+          clearedCompositionMarkers,
+          // Arm tiled, floating, and unmanaged apps concurrently with activation.
+          // A first-time installation emits one observation-ready reconcile, so
+          // a state change racing this setup cannot fall through the cache gap.
+          .run { [observer = windowObserver, activationObservedBundleIds] send in
+            await observer.observe(activationObservedBundleIds)
+            await send(
+              .presentationObservationReady(
+                bundleIds: Set(activationObservedBundleIds)
+              )
             )
-          )
-        },
-        .run(priority: .high) { [
-          mgr = workspaceManager,
-          tiler = windowTiler,
-          store = layoutStore,
-          hud = workspaceHUD,
-          mouse = mouse,
-          overlay = floatingOverlay,
-          snapshot = windowSnapshot,
-          displays = displays,
-          debugLog = debugLog,
-          focus = focusManager,
-          strandedBorrows,
-        ] send in
-          async let outgoingFocus: WindowKey? = {
-            guard let outgoingFrontmostApp else { return nil as WindowKey? }
-            return await snapshot.focusedWindowKeyOffMain(outgoingFrontmostApp)
-          }()
-          // Wall-clock per phase — AX round trips block on *other* apps' run
-          // loops, so when a switch crawls under load this names the phase
-          // (and thus the app set) that ate the time.
-          let timer = ContinuousClock()
-          var phaseStart = timer.now
-          var phases = [(String, Duration)]()
-          var coreCompletionSent = false
-          func mark(_ name: String) {
-            let now = timer.now
-            phases.append((name, now - phaseStart))
-            phaseStart = now
-          }
-          if showHUD {
-            await hud.showOnDisplay(hudName, hudIcon, hudSubtitle, hudDurationMs, hudDisplay)
-          }
-          guard !Task.isCancelled else { return }
-          // Tear down the outgoing workspace's mirrors in the same beat as the
-          // hide pass — leaving them to the post-tile `setFloating` made the
-          // floating windows visibly outlive the windows they mirror.
-          await overlay.retainOnly(Set(presentationFloatingBundleIds))
-          guard !Task.isCancelled else { return }
-          // Resolve the outgoing window before show/hide can focus a different
-          // window in the same process. Merely starting this child task first
-          // does not order its AX read ahead of `mgr.activate`.
-          let outgoingFocusedWindow = await outgoingFocus
-          guard !Task.isCancelled else { return }
-          await mgr.activate(request)
-          guard !Task.isCancelled else { return }
-          if let outgoingWorkspaceId, let outgoingFocusedWindow {
-            await send(.activationFocusSnapshotResolved(
-              workspaceId: outgoingWorkspaceId,
-              key: outgoingFocusedWindow,
-            ))
-          }
-          mark("showHide")
-          // Superseded by a newer switch: stop before the tile pass. `send`
-          // on a cancelled effect is already a no-op, but the AX work below
-          // is not — without these checks a superseded activation would keep
-          // writing the *old* workspace's frames interleaved with the new
-          // activation's main-actor hops.
-          guard !Task.isCancelled else { return }
-          if !isPaused {
-            // Layouts always persist now — restore the saved template whenever
-            // there's no in-memory tree yet (fresh launch / first activation).
-            let persistedSnapshot: LayoutSnapshot? =
-              sessionTree == nil ? await store.load(workspaceId) : nil
-            guard !Task.isCancelled else { return }
-            // Cache-first discovery: a warm `WindowKeyCache` entry costs zero
-            // AX round trips — AX scans block on each target app's run loop
-            // (measured 50 ms–1.2 s per switch), which is what made switching
-            // crawl under system load. Each process has its own serialized AX
-            // lane, so independent apps can resolve concurrently without one
-            // slow app adding its timeout to every following bundle. Preserve
-            // configured order when flattening so fresh-tree placement stays
-            // deterministic.
-            let discovered = await withTaskGroup(
-              of: (Int, [WindowKey]).self,
-              returning: [WindowKey].self,
-            ) { group in
-              for (index, bundleId) in bundleIds.enumerated() {
-                group.addTask {
-                  (index, await snapshot.stableCachedKeysOffMain([bundleId], true))
-                }
-              }
-              var results = [(Int, [WindowKey])]()
-              for await result in group { results.append(result) }
-              return results.sorted { $0.0 < $1.0 }.flatMap(\.1)
+          },
+          .run(priority: .high) { [
+            mgr = workspaceManager,
+            tiler = windowTiler,
+            store = layoutStore,
+            hud = workspaceHUD,
+            mouse = mouse,
+            overlay = floatingOverlay,
+            snapshot = windowSnapshot,
+            displays = displays,
+            debugLog = debugLog,
+            focus = focusManager,
+            strandedBorrows,
+          ] send in
+            async let outgoingFocus: WindowKey? = {
+              guard let outgoingFrontmostApp else { return nil as WindowKey? }
+              return await snapshot.focusedWindowKeyOffMain(outgoingFrontmostApp)
+            }()
+            // Wall-clock per phase. AX round trips block on *other* apps' run
+            // loops, so when a switch crawls under load this names the phase
+            // (and thus the app set) that ate the time.
+            let timer = ContinuousClock()
+            var phaseStart = timer.now
+            var phases = [(String, Duration)]()
+            var coreCompletionSent = false
+            func mark(_ name: String) {
+              let now = timer.now
+              phases.append((name, now - phaseStart))
+              phaseStart = now
+            }
+            if showHUD {
+              await hud.showOnDisplay(hudName, hudIcon, hudSubtitle, hudDurationMs, hudDisplay)
             }
             guard !Task.isCancelled else { return }
-            let onScreenFrames = snapshot.onScreenWindowFrames()
-            let keys = await MainActor.run {
-              Self.scopedWindowKeys(
-                discovered,
-                sharedTiledBundleIds: sharedTiledBundleIds,
-                existingTargetKeys: existingTargetKeys,
-                protectedKeys: protectedWindowKeys,
-                partitionSharedWindows: partitionsSharedWindows,
-                targetWorkArea: displays.workArea(targetDisplay),
-                windowFrame: { onScreenFrames[$0.windowID] },
-              )
-            }
-            mark("discover")
-            let (tree, frames, restoredZoom, unresolvedZoomSlots) = await MainActor.run {
-              () -> (
-                BSPNode<WindowKey>?,
-                [WindowKey: CGRect],
-                Set<WindowKey>,
-                Set<SlotID>
-              ) in
-              let workArea = displays.workArea(targetDisplay).insetBy(
-                dx: CGFloat(settings.layout.gapOuter),
-                dy: CGFloat(settings.layout.gapOuter),
-              )
-              var base = sessionTree
-              var persistedZoomSlots = [SlotID]()
-              if let snapshot = persistedSnapshot {
-                base = BSPNode.hydrate(template: snapshot.tree, keys: keys)
-                persistedZoomSlots = snapshot.fullscreenZoomedSlots
-              }
-              let restoredLayout = base != nil
-              let merged = Self.mergeTree(
-                existing: base,
-                target: keys,
-                focused: { outgoingFocusedWindow },
-                insertionPoint: insertionPoint,
-                workArea: workArea,
-                settings: settings,
-              )
-              let axis = settings.layout.autoBalance
-              // No resident tree and no persisted template (or a template with
-              // zero matching windows) means the old shape is genuinely gone.
-              // Initialize from the same contract as explicit Balance:
-              // Auto-balance axes when enabled, canonical BSP when Off.
-              let tree =
-                if restoredLayout {
-                  axis == .none ? merged : merged?.balanced(axis: axis)
-                } else {
-                  merged?.balancedForCommand(
-                    autoBalance: axis,
-                    in: workArea,
-                    gap: CGFloat(settings.layout.gapInner),
-                    splitAxis: settings.layout.splitType.bspSplitAxis(),
-                  )
-                }
-              let resolvedZoom: Set<WindowKey> = {
-                if !zoomed.isEmpty { return zoomed }
-                guard let tree else { return [] }
-                return Self.resolveFullscreenZoom(
-                  slots: persistedZoomSlots,
-                  keys: keys,
-                  among: tree.windows,
-                )
-              }()
-              let frames = Self.computeFrames(
-                tree: tree,
-                settings: settings,
-                targetDisplay: targetDisplay,
-                fullscreenZoomed: resolvedZoom,
-              )
-              let assignments = slotAssignment(keys)
-              let resolvedSlots = Set(resolvedZoom.compactMap { assignments[$0] })
-              let unresolvedZoomSlots =
-                Set(persistedZoomSlots).subtracting(resolvedSlots)
-              return (tree, frames, resolvedZoom, unresolvedZoomSlots)
-            }
-            mark("layout")
-            // Cancellation can arrive while the main actor computes a large tree.
-            // Do not publish or persist a superseded workspace's layout snapshot.
+            // Tear down the outgoing workspace's mirrors in the same beat as the
+            // hide pass. Leaving them to the post-tile `setFloating` made the
+            // floating windows visibly outlive the windows they mirror.
+            await overlay.retainOnly(Set(presentationFloatingBundleIds))
             guard !Task.isCancelled else { return }
-            await send(.tilingTreeUpdated(workspaceId: workspaceId, tree: tree))
-            if persistedSnapshot != nil, zoomed.isEmpty {
-              await send(.persistedFullscreenZoomRestored(
-                workspaceId: workspaceId,
-                keys: restoredZoom,
-                unresolvedSlots: unresolvedZoomSlots,
+            // Resolve the outgoing window before show/hide can focus a different
+            // window in the same process. Merely starting this child task first
+            // does not order its AX read ahead of `mgr.activate`.
+            let outgoingFocusedWindow = await outgoingFocus
+            guard !Task.isCancelled else { return }
+            await mgr.activate(request)
+            guard !Task.isCancelled else { return }
+            if let outgoingWorkspaceId, let outgoingFocusedWindow {
+              await send(.activationFocusSnapshotResolved(
+                workspaceId: outgoingWorkspaceId,
+                key: outgoingFocusedWindow,
               ))
             }
+            mark("showHide")
+            // Superseded by a newer switch: stop before the tile pass. `send`
+            // on a cancelled effect is already a no-op, but the AX work below
+            // is not. Without these checks a superseded activation would keep
+            // writing the *old* workspace's frames interleaved with the new
+            // activation's main-actor hops.
             guard !Task.isCancelled else { return }
-            if let tree {
-              let slots = slotAssignment(tree.windows)
-              await store.save(
-                workspaceId,
-                LayoutSnapshot(
-                  tree: tree.mapWindows { slots[$0]! },
-                  fullscreenZoomedSlots: Set(
-                    restoredZoom.compactMap { slots[$0] }
-                  )
-                  .union(unresolvedZoomSlots)
-                  .sorted { ($0.bundleId, $0.occurrence) < ($1.bundleId, $1.occurrence) },
-                ),
-              )
-            }
-            guard !Task.isCancelled else { return }
-            if !frames.isEmpty {
-              await tiler.apply(FrameApplication(windowFrames: frames))
-            }
-            mark("apply")
-            guard !Task.isCancelled else { return }
-            if !frames.isEmpty {
-              await send(
-                .presentationLayoutApplied(
-                  keys: Set(frames.keys),
-                  preservesPointer: false,
-                )
-              )
-            }
-            // Show/hide + the first authoritative tile pass is the visible
-            // switch. Publish it now; floating overlays, markers, focus
-            // validation, and pointer warp are cancellable best-effort
-            // post-layout work and must not hold the activation gate.
-            coreCompletionSent = true
-            await send(.activationCompleted(workspaceId: workspaceId, display: targetDisplay))
-            guard !Task.isCancelled else { return }
-            // Mirror floating windows onto always-on-top panels (the Topit /
-            // Floaty technique): a foreign window's level can't be raised without
-            // SIP, so instead of trying we paint a live mirror above the tiles.
-            // Passing the resolved set (possibly empty) also tears down mirrors
-            // for apps that were just un-floated or belong to another workspace.
-            // Same cache-first, per-bundle worker discovery as the tile pass
-            // above.
-            var floatingDiscovered = Set<WindowKey>()
-            for bundleId in presentationFloatingBundleIds {
+            if !isPaused {
+              // Layouts always persist now. Restore the saved template whenever
+              // there's no in-memory tree yet (fresh launch / first activation).
+              let persistedSnapshot: LayoutSnapshot? =
+                sessionTree == nil ? await store.load(workspaceId) : nil
               guard !Task.isCancelled else { return }
-              floatingDiscovered.formUnion(
-                await snapshot.cachedKeysOffMain([bundleId], false)
-              )
-            }
-            let floatingKeys = floatingDiscovered
-            mark("float")
-            guard !Task.isCancelled else { return }
-            await overlay.setFloating(floatingKeys)
-            guard !Task.isCancelled else { return }
-            // Markers ride the same discovery, but reducer state owns their
-            // categories. Re-derive after `activationCompleted` publishes the
-            // target workspace and cancel any composition-era marker refresh.
-            await send(.activationMarkerKeysResolved(Array(floatingKeys)))
-            guard !Task.isCancelled else { return }
-            if warpMouse {
-              var fallbackFrames = [WindowKey: CGRect]()
-              let liveWindowServerFrames = snapshot.onScreenWindowFrames()
-              if let mruWindow, frames[mruWindow] == nil {
-                if let frame = liveWindowServerFrames[mruWindow.windowID] {
-                  fallbackFrames[mruWindow] = frame
-                } else if let frame = await snapshot.windowFrameOffMain(mruWindow) {
-                  fallbackFrames[mruWindow] = frame
-                }
-              }
-              guard !Task.isCancelled else { return }
-              // Read focus after the potentially blocking MRU geometry lookup,
-              // so a user focus change during that IPC cannot leave a stale
-              // "still focused" proof for the eventual pointer warp.
-              var liveFocused = await snapshot.focusedWindowKeyOffMain()
-              guard !Task.isCancelled else { return }
-              if
-                let candidateFocus = liveFocused,
-                frames[candidateFocus] == nil,
-                fallbackFrames[candidateFocus] == nil
-              {
-                if let frame = liveWindowServerFrames[candidateFocus.windowID] {
-                  fallbackFrames[candidateFocus] = frame
-                } else {
-                  let frame = await snapshot.windowFrameOffMain(candidateFocus)
-                  guard !Task.isCancelled else { return }
-                  // Geometry is another suspension point. Validate focus again
-                  // and accept that frame only if the same window still owns it.
-                  let verifiedFocused = await snapshot.focusedWindowKeyOffMain()
-                  guard !Task.isCancelled else { return }
-                  if verifiedFocused == candidateFocus, let frame {
-                    fallbackFrames[candidateFocus] = frame
+              // Cache-first discovery: a warm `WindowKeyCache` entry costs zero
+              // AX round trips. AX scans block on each target app's run loop
+              // (measured 50 ms–1.2 s per switch), which is what made switching
+              // crawl under system load. Each process has its own serialized AX
+              // lane, so independent apps can resolve concurrently without one
+              // slow app adding its timeout to every following bundle. Preserve
+              // configured order when flattening so fresh-tree placement stays
+              // deterministic.
+              let discovered = await withTaskGroup(
+                of: (Int, [WindowKey]).self,
+                returning: [WindowKey].self,
+              ) { group in
+                for (index, bundleId) in bundleIds.enumerated() {
+                  group.addTask {
+                    (index, await snapshot.stableCachedKeysOffMain([bundleId], true))
                   }
-                  liveFocused = verifiedFocused
                 }
+                var results = [(Int, [WindowKey])]()
+                for await result in group { results.append(result) }
+                return results.sorted { $0.0 < $1.0 }.flatMap(\.1)
               }
               guard !Task.isCancelled else { return }
-              let warp: (key: WindowKey, rect: CGRect, live: WindowKey?)? = {
-                // Warp to the window this activation deliberately focused (the MRU
-                // target), not a live `focusedWindowKey()` read. That read races
-                // the async app activation and can return a *different* frontmost
-                // window (e.g. Siri keeping front while ChatGPT is the target),
-                // sending the cursor to the wrong tile — where focus-follows-mouse
-                // then grabs focus to it. Fall back to the live read only when this
-                // workspace has no MRU target (a pinned-app or empty workspace).
-                let live = liveFocused
-                // Unless focus arrived on its own: then the raised window is
-                // the answer and the MRU pick is a guess about it.
-                if
-                  prefersLiveFocusTarget,
-                  let live,
-                  live.bundleId == expectedFocusBundleId,
-                  let rect = frames[live] ?? fallbackFrames[live]
-                {
-                  return (live, rect, live)
-                }
-                if
-                  let mruWindow,
-                  let rect = frames[mruWindow] ?? fallbackFrames[mruWindow]
-                {
-                  return (mruWindow, rect, live)
-                }
-                // A stale MRU id is allowed to fall back to the app's live main
-                // window (the focus manager does the same). Gate by the expected
-                // bundle so a lagging frontmost read can never warp into the
-                // outgoing workspace. AX geometry also lets MFF follow an owned
-                // floating/unmanaged restore target, which has no tiled frame.
-                guard
-                  let live,
-                  live.bundleId == expectedFocusBundleId,
-                  let rect = frames[live] ?? fallbackFrames[live]
-                else { return nil }
-                return (live, rect, live)
-              }()
-              guard !Task.isCancelled else { return }
-              if let warp {
-                let center = CGPoint(x: warp.rect.midX, y: warp.rect.midY)
-                debugLog.log(
-                  "Warp",
-                  "activate target=\(warp.key.bundleId)#\(warp.key.windowID) "
-                    + "live=\(warp.live.map { "\($0.bundleId)#\($0.windowID)" } ?? "nil") "
-                    + "→ (\(Int(center.x)),\(Int(center.y)))",
+              let onScreenFrames = snapshot.onScreenWindowFrames()
+              let keys = await MainActor.run {
+                Self.scopedWindowKeys(
+                  discovered,
+                  sharedTiledBundleIds: sharedTiledBundleIds,
+                  existingTargetKeys: existingTargetKeys,
+                  protectedKeys: protectedWindowKeys,
+                  partitionSharedWindows: partitionsSharedWindows,
+                  targetWorkArea: displays.workArea(targetDisplay),
+                  windowFrame: { onScreenFrames[$0.windowID] },
                 )
-                // The deliberate activation focus can be stolen mid-switch — an app
-                // like Siri grabs frontmost as it unhides — leaving the keyboard
-                // focus on the wrong tile while the cursor warps to the intended
-                // one, so directional focus then anchors on the wrong window. When
-                // the live frontmost differs from the window we're warping to,
-                // re-assert the intended focus now that the layout has settled.
-                if warp.live != warp.key {
-                  await focus.focusWindow(warp.key)
+              }
+              mark("discover")
+              let (tree, frames, restoredZoom, unresolvedZoomSlots) = await MainActor.run {
+                () -> (
+                  BSPNode<WindowKey>?,
+                  [WindowKey: CGRect],
+                  Set<WindowKey>,
+                  Set<SlotID>
+                ) in
+                let workArea = displays.workArea(targetDisplay).insetBy(
+                  dx: CGFloat(settings.layout.gapOuter),
+                  dy: CGFloat(settings.layout.gapOuter),
+                )
+                var base = sessionTree
+                var persistedZoomSlots = [SlotID]()
+                if let snapshot = persistedSnapshot {
+                  base = BSPNode.hydrate(template: snapshot.tree, keys: keys)
+                  persistedZoomSlots = snapshot.fullscreenZoomedSlots
+                }
+                let restoredLayout = base != nil
+                let merged = Self.mergeTree(
+                  existing: base,
+                  target: keys,
+                  focused: { outgoingFocusedWindow },
+                  insertionPoint: insertionPoint,
+                  workArea: workArea,
+                  settings: settings,
+                )
+                let axis = settings.layout.autoBalance
+                // No resident tree and no persisted template (or a template with
+                // zero matching windows) means the old shape is genuinely gone.
+                // Initialize from the same contract as explicit Balance:
+                // Auto-balance axes when enabled, canonical BSP when Off.
+                let tree =
+                  if restoredLayout {
+                    axis == .none ? merged : merged?.balanced(axis: axis)
+                  } else {
+                    merged?.balancedForCommand(
+                      autoBalance: axis,
+                      in: workArea,
+                      gap: CGFloat(settings.layout.gapInner),
+                      splitAxis: settings.layout.splitType.bspSplitAxis(),
+                    )
+                  }
+                let resolvedZoom: Set<WindowKey> = {
+                  if !zoomed.isEmpty { return zoomed }
+                  guard let tree else { return [] }
+                  return Self.resolveFullscreenZoom(
+                    slots: persistedZoomSlots,
+                    keys: keys,
+                    among: tree.windows,
+                  )
+                }()
+                let frames = Self.computeFrames(
+                  tree: tree,
+                  settings: settings,
+                  targetDisplay: targetDisplay,
+                  fullscreenZoomed: resolvedZoom,
+                )
+                let assignments = slotAssignment(keys)
+                let resolvedSlots = Set(resolvedZoom.compactMap { assignments[$0] })
+                let unresolvedZoomSlots =
+                  Set(persistedZoomSlots).subtracting(resolvedSlots)
+                return (tree, frames, resolvedZoom, unresolvedZoomSlots)
+              }
+              mark("layout")
+              // Cancellation can arrive while the main actor computes a large tree.
+              // Do not publish or persist a superseded workspace's layout snapshot.
+              guard !Task.isCancelled else { return }
+              await send(.tilingTreeUpdated(workspaceId: workspaceId, tree: tree))
+              if persistedSnapshot != nil, zoomed.isEmpty {
+                await send(.persistedFullscreenZoomRestored(
+                  workspaceId: workspaceId,
+                  keys: restoredZoom,
+                  unresolvedSlots: unresolvedZoomSlots,
+                ))
+              }
+              guard !Task.isCancelled else { return }
+              if let tree {
+                let slots = slotAssignment(tree.windows)
+                await store.save(
+                  workspaceId,
+                  LayoutSnapshot(
+                    tree: tree.mapWindows { slots[$0]! },
+                    fullscreenZoomedSlots: Set(
+                      restoredZoom.compactMap { slots[$0] }
+                    )
+                    .union(unresolvedZoomSlots)
+                    .sorted { ($0.bundleId, $0.occurrence) < ($1.bundleId, $1.occurrence) },
+                  ),
+                )
+              }
+              guard !Task.isCancelled else { return }
+              if !frames.isEmpty {
+                await tiler.apply(FrameApplication(windowFrames: frames))
+              }
+              mark("apply")
+              guard !Task.isCancelled else { return }
+              if !frames.isEmpty {
+                await send(
+                  .presentationLayoutApplied(
+                    keys: Set(frames.keys),
+                    preservesPointer: false,
+                  )
+                )
+              }
+              // Show/hide + the first authoritative tile pass is the visible
+              // switch. Publish it now; floating overlays, markers, focus
+              // validation, and pointer warp are cancellable best-effort
+              // post-layout work and must not hold the activation gate.
+              coreCompletionSent = true
+              await send(.activationCompleted(
+                workspaceId: workspaceId,
+                display: targetDisplay,
+                generation: activationGeneration,
+              ))
+              guard !Task.isCancelled else { return }
+              // Mirror floating windows onto always-on-top panels (the Topit /
+              // Floaty technique): a foreign window's level can't be raised without
+              // SIP, so instead of trying we paint a live mirror above the tiles.
+              // Passing the resolved set (possibly empty) also tears down mirrors
+              // for apps that were just un-floated or belong to another workspace.
+              // Same cache-first, per-bundle worker discovery as the tile pass
+              // above.
+              var floatingDiscovered = Set<WindowKey>()
+              for bundleId in presentationFloatingBundleIds {
+                guard !Task.isCancelled else { return }
+                floatingDiscovered.formUnion(
+                  await snapshot.cachedKeysOffMain([bundleId], false)
+                )
+              }
+              let floatingKeys = floatingDiscovered
+              mark("float")
+              guard !Task.isCancelled else { return }
+              await overlay.setFloating(floatingKeys)
+              guard !Task.isCancelled else { return }
+              // Markers ride the same discovery, but reducer state owns their
+              // categories. Re-derive after `activationCompleted` publishes the
+              // target workspace and cancel any composition-era marker refresh.
+              await send(.activationMarkerKeysResolved(Array(floatingKeys)))
+              guard !Task.isCancelled else { return }
+              if warpMouse {
+                var fallbackFrames = [WindowKey: CGRect]()
+                let liveWindowServerFrames = snapshot.onScreenWindowFrames()
+                if let mruWindow, frames[mruWindow] == nil {
+                  if let frame = liveWindowServerFrames[mruWindow.windowID] {
+                    fallbackFrames[mruWindow] = frame
+                  } else if let frame = await snapshot.windowFrameOffMain(mruWindow) {
+                    fallbackFrames[mruWindow] = frame
+                  }
                 }
                 guard !Task.isCancelled else { return }
-                mouse.warp(center)
+                // Read focus after the potentially blocking MRU geometry lookup,
+                // so a user focus change during that IPC cannot leave a stale
+                // "still focused" proof for the eventual pointer warp.
+                var liveFocused = await snapshot.focusedWindowKeyOffMain()
+                guard !Task.isCancelled else { return }
+                if
+                  let candidateFocus = liveFocused,
+                  frames[candidateFocus] == nil,
+                  fallbackFrames[candidateFocus] == nil
+                {
+                  if let frame = liveWindowServerFrames[candidateFocus.windowID] {
+                    fallbackFrames[candidateFocus] = frame
+                  } else {
+                    let frame = await snapshot.windowFrameOffMain(candidateFocus)
+                    guard !Task.isCancelled else { return }
+                    // Geometry is another suspension point. Validate focus again
+                    // and accept that frame only if the same window still owns it.
+                    let verifiedFocused = await snapshot.focusedWindowKeyOffMain()
+                    guard !Task.isCancelled else { return }
+                    if verifiedFocused == candidateFocus, let frame {
+                      fallbackFrames[candidateFocus] = frame
+                    }
+                    liveFocused = verifiedFocused
+                  }
+                }
+                guard !Task.isCancelled else { return }
+                let warp: (key: WindowKey, rect: CGRect, live: WindowKey?)? = {
+                  // Warp to the window this activation deliberately focused (the MRU
+                  // target), not a live `focusedWindowKey()` read. That read races
+                  // the async app activation and can return a *different* frontmost
+                  // window (e.g. Siri keeping front while ChatGPT is the target),
+                  // sending the cursor to the wrong tile, where focus-follows-mouse
+                  // then grabs focus to it. Fall back to the live read only when this
+                  // workspace has no MRU target (a pinned-app or empty workspace).
+                  let live = liveFocused
+                  // Unless focus arrived on its own: then the raised window is
+                  // the answer and the MRU pick is a guess about it.
+                  if
+                    prefersLiveFocusTarget,
+                    let live,
+                    live.bundleId == expectedFocusBundleId,
+                    let rect = frames[live] ?? fallbackFrames[live]
+                  {
+                    return (live, rect, live)
+                  }
+                  if
+                    let mruWindow,
+                    let rect = frames[mruWindow] ?? fallbackFrames[mruWindow]
+                  {
+                    return (mruWindow, rect, live)
+                  }
+                  // A stale MRU id is allowed to fall back to the app's live main
+                  // window (the focus manager does the same). Gate by the expected
+                  // bundle so a lagging frontmost read can never warp into the
+                  // outgoing workspace. AX geometry also lets MFF follow an owned
+                  // floating/unmanaged restore target, which has no tiled frame.
+                  guard
+                    let live,
+                    live.bundleId == expectedFocusBundleId,
+                    let rect = frames[live] ?? fallbackFrames[live]
+                  else { return nil }
+                  return (live, rect, live)
+                }()
+                guard !Task.isCancelled else { return }
+                if let warp {
+                  let center = CGPoint(x: warp.rect.midX, y: warp.rect.midY)
+                  debugLog.log(
+                    "Warp",
+                    "activate target=\(warp.key.bundleId)#\(warp.key.windowID) "
+                      + "live=\(warp.live.map { "\($0.bundleId)#\($0.windowID)" } ?? "nil") "
+                      + "→ (\(Int(center.x)),\(Int(center.y)))",
+                  )
+                  // The deliberate activation focus can be stolen mid-switch. An app
+                  // like Siri grabs frontmost as it unhides, leaving the keyboard
+                  // focus on the wrong tile while the cursor warps to the intended
+                  // one, so directional focus then anchors on the wrong window. When
+                  // the live frontmost differs from the window we're warping to,
+                  // re-assert the intended focus now that the layout has settled.
+                  if warp.live != warp.key {
+                    await focus.focusWindow(warp.key)
+                  }
+                  guard !Task.isCancelled else { return }
+                  mouse.warp(center)
+                }
               }
             }
+            debugLog.log(
+              "Activate",
+              "phases " + phases.map { "\($0.0)=\(ms($0.1))ms" }.joined(separator: " "),
+            )
+            if !coreCompletionSent {
+              await send(.activationCompleted(
+                workspaceId: workspaceId,
+                display: targetDisplay,
+                generation: activationGeneration,
+              ))
+            }
+            // Take down blocks borrowed into a display this host just left. Runs
+            // after the tile pass so the host's own windows already count as
+            // living on their new display and aren't hidden along with them.
+            for stranded in strandedBorrows {
+              await mgr.returnBorrowed(stranded.bundleIds, stranded.display)
+            }
+            // The tail survived to the end. Only now is it safe for a queued
+            // display restore to start its own activation, which would cancel
+            // this effect. A cancelled tail never gets here, but cancellation
+            // only happens when another activation is already taking over.
+            await send(.activationTailFinished(generation: activationGeneration))
           }
-          debugLog.log(
-            "Activate",
-            "phases " + phases.map { "\($0.0)=\(ms($0.1))ms" }.joined(separator: " "),
-          )
-          if !coreCompletionSent {
-            await send(.activationCompleted(workspaceId: workspaceId, display: targetDisplay))
-          }
-          // Take down blocks borrowed into a display this host just left. Runs
-          // after the tile pass so the host's own windows already count as
-          // living on their new display and aren't hidden along with them.
-          for stranded in strandedBorrows {
-            await mgr.returnBorrowed(stranded.bundleIds, stranded.display)
-          }
-          // The tail survived to the end. Only now is it safe for a queued
-          // display restore to start its own activation, which would cancel
-          // this effect. A cancelled tail never gets here, but cancellation
-          // only happens when another activation is already taking over.
-          await send(.activationTailFinished)
-        }
-        .cancellable(id: CancelID.activation, cancelInFlight: true),
+          .cancellable(id: CancelID.activation, cancelInFlight: true),
+        ),
       ),
     )
+  }
+
+  func supersedePendingCLIActivation(state: inout State) -> Effect<Action> {
+    guard let request = state.pendingCLIActivation else { return .none }
+    state.pendingCLIActivation = nil
+    state.pendingCLIActivationBinding = nil
+    return .run { _ in
+      request.complete("Activation was superseded by a newer user action")
+    }
   }
 
   func cycle(by direction: Int, state: inout State) -> Effect<Action> {
@@ -1253,14 +1340,15 @@ extension WorkspaceActivationFeature {
         )
         return hf.merging(bf) { current, _ in current }
       }
-      // A Borrow's focus must not ride this writer's cancellation. Superseding
-      // layout writes are routine — a sync folding the borrowed window into the
-      // tree starts one — and they change where the block lands, not whether it
-      // gets focus. Dropping the notification here left the block summoned but
-      // unfocused, with the cursor still on the host. The reducer re-validates
-      // generation, pending completion and composition identity, so a genuinely
-      // stale one is rejected there rather than silently lost here.
-      @Sendable func publishBorrowPhase() async {
+      /// A Borrow's focus must not ride this writer's cancellation. Superseding
+      /// layout writes are routine. A sync folding the borrowed window into the
+      /// tree starts one, and they change where the block lands, not whether it
+      /// gets focus. Dropping the notification here left the block summoned but
+      /// unfocused, with the cursor still on the host. The reducer re-validates
+      /// generation, pending completion and composition identity, so a genuinely
+      /// stale one is rejected there rather than silently lost here.
+      @Sendable
+      func publishBorrowPhase() async {
         guard let phase = borrowPhaseCompletion else { return }
         await send(
           .borrowCompositionLayoutCompleted(

--- a/TatamiKit/Sources/Features/WorkspaceActivation/WorkspaceActivationFeature.swift
+++ b/TatamiKit/Sources/Features/WorkspaceActivation/WorkspaceActivationFeature.swift
@@ -24,6 +24,42 @@ public struct WorkspaceActivationFeature {
 
   // MARK: Public
 
+  public struct CLIActivationRequest: Equatable, Sendable {
+
+    // MARK: Lifecycle
+
+    public init(
+      id: UUID = UUID(),
+      target: Target,
+      complete: @escaping @Sendable (_ error: String?) -> Void,
+    ) {
+      self.id = id
+      self.target = target
+      self.complete = complete
+    }
+
+    // MARK: Public
+
+    public enum Target: Equatable, Sendable {
+      case profile(Profile.ID)
+      case workspace(Workspace.ID)
+    }
+
+    public let id: UUID
+    public let target: Target
+    public let complete: @Sendable (_ error: String?) -> Void
+
+    public static func ==(lhs: Self, rhs: Self) -> Bool {
+      lhs.id == rhs.id && lhs.target == rhs.target
+    }
+
+  }
+
+  public struct CLIActivationBinding: Equatable, Sendable {
+    public let requestID: UUID
+    public let activationGeneration: UInt64
+  }
+
   @ObservableState
   public struct State: Equatable {
 
@@ -108,7 +144,7 @@ public struct WorkspaceActivationFeature {
       case systemSleep
     }
 
-    @Shared(.tatamiConfig) public var config = AppConfig()
+    @Shared(.tatamiConfig) public var config
     public var activeWorkspacesByDisplay = [DisplayName: Workspace.ID]()
     /// Per-display "most recent" workspace, for switch-to-recent on the
     /// display the user is currently on (multi-monitor aware).
@@ -141,6 +177,12 @@ public struct WorkspaceActivationFeature {
     /// authoritative interaction context.
     public var focusedDisplay: DisplayName?
     public var isActivating = false
+    public var activationGeneration: UInt64 = 0
+    public var activeActivationGeneration: UInt64?
+    /// CLI activation replies are completed only after the activation tail (and
+    /// every profile display restore) finishes.
+    public var pendingCLIActivation: CLIActivationRequest?
+    public var pendingCLIActivationBinding: CLIActivationBinding?
     /// A work-area change that arrived during activation. The activation owns
     /// its target display's writer, so the global reflow is committed once that
     /// transaction completes instead of polling or racing it.
@@ -641,10 +683,14 @@ public struct WorkspaceActivationFeature {
     /// targets a specific workspace lands on it after the per-display retile,
     /// with no race against the restore cascade.
     case reactivateActiveProfile(focus: Workspace.ID?)
+    case trackCLIActivation(CLIActivationRequest, joinCurrentActivation: Bool)
+    case failCLIActivation(requestID: UUID, error: String)
     /// Startup permission gate: prompt for any missing permission, surfacing
     /// Accessibility + Screen Recording together when both are absent.
     case surfaceMissingPermissions
     case activate(workspaceId: Workspace.ID, setFocus: Bool)
+    case activateFromCLI(workspaceId: Workspace.ID, requestID: UUID)
+    case cliActivationEffectFinished(workspaceId: Workspace.ID, requestID: UUID)
     case activateNext
     case activatePrevious
     case activateRecent
@@ -872,18 +918,22 @@ public struct WorkspaceActivationFeature {
     /// landing on a workspace with two windows of that app otherwise gives no
     /// clue which one was raised.
     case activateFollowingAppFocus(workspaceId: Workspace.ID)
-    case activationCompleted(workspaceId: Workspace.ID, display: DisplayName?)
+    case activationCompleted(
+      workspaceId: Workspace.ID,
+      display: DisplayName?,
+      generation: UInt64,
+    )
     /// The whole activation effect ran out, post-layout tail included.
     /// `activationCompleted` fires early — as soon as the *visible* switch is
     /// published — so anything that starts another activation must wait for
     /// this instead, or it cancels the tail (floating mirrors, markers, the
     /// pointer warp) of the activation that just completed.
-    case activationTailFinished
+    case activationTailFinished(generation: UInt64)
     /// `performActivate` did not report completion within the watchdog
     /// window — release the `isActivating` gate so one wedged activation
     /// (an app stuck past every AX timeout) can't refuse all future
     /// activations and syncs for the rest of the session.
-    case activationTimedOut
+    case activationTimedOut(generation: UInt64)
     /// Bubbled to AppFeature, which owns the profile-switch side effects
     /// (hotkey rebind, session-store save, HUD) the activation feature can't do.
     case delegate(Delegate)
@@ -896,7 +946,7 @@ public struct WorkspaceActivationFeature {
       case profileSwitchRequested(Profile.ID, focus: Workspace.ID?)
       /// A display rule matched and this feature already retiled for it —
       /// AppFeature runs the remaining switch side effects.
-      case profileAutoActivated(Profile.ID)
+      case profileAutoActivated(previous: Profile.ID?, current: Profile.ID)
       /// Startup rejected a missing or condition-mismatched last profile and
       /// resolved another one. AppFeature persists the corrected session id.
       case startupProfileResolved(Profile.ID)
@@ -1070,7 +1120,10 @@ public struct WorkspaceActivationFeature {
           restoreActive = [:]
           restoreNewlyConnected = connected
           didAutoSwitch = true
-          autoSwitch = .send(.delegate(.profileAutoActivated(matched)))
+          autoSwitch = .send(.delegate(.profileAutoActivated(
+            previous: currentActiveProfile,
+            current: matched,
+          )))
           debugLog.log(
             "Profile",
             "auto-activate \(state.config.activeProfile?.name ?? "?") for \(names.map(\.name))",
@@ -1954,17 +2007,69 @@ public struct WorkspaceActivationFeature {
         else { return .none }
         return .send(.delegate(.startupProfileResolved(startupProfileId)))
 
+      case .trackCLIActivation(let request, let joinCurrentActivation):
+        let previous = state.pendingCLIActivation
+        state.pendingCLIActivation = request
+        state.pendingCLIActivationBinding =
+          if
+            joinCurrentActivation,
+            let generation = state.activeActivationGeneration
+          {
+            CLIActivationBinding(
+              requestID: request.id,
+              activationGeneration: generation,
+            )
+          } else {
+            nil
+          }
+        guard let previous else { return .none }
+        return .run { _ in
+          previous.complete("Activation was superseded by a newer CLI command")
+        }
+
+      case .failCLIActivation(let requestID, let error):
+        guard state.pendingCLIActivation?.id == requestID else { return .none }
+        return completeCLIActivation(error: error, state: &state)
+
       case .reactivateActiveProfile(let focus):
-        guard let profile = state.config.activeProfile else { return .none }
+        // A profile switch is authoritative over every workspace activation
+        // from the outgoing profile, even when the new profile has no normal
+        // workspace to start a replacement generation. Invalidate reducer
+        // state synchronously so an already-enqueued completion is stale, and
+        // cancel both effects before starting the new restore cascade.
+        state.isActivating = false
+        state.activatingWorkspaceID = nil
+        state.activeActivationGeneration = nil
+        state.activeWorkspacesByDisplay = [:]
+        state.pendingDisplayRestores = []
+        state.focusWorkspaceOnRestore = nil
+        let cancelOutgoingActivation = Effect<Action>.merge(
+          .cancel(id: CancelID.activation),
+          .cancel(id: CancelID.activationWatchdog),
+        )
+        guard let profile = state.config.activeProfile else {
+          return .concatenate(
+            cancelOutgoingActivation,
+            completeCLIActivation(
+              error: "The requested profile no longer exists",
+              state: &state,
+            ),
+          )
+        }
         let connected = displays.all()
-        guard !connected.isEmpty else { return .send(.activateInitial) }
+        guard !connected.isEmpty else {
+          return .concatenate(
+            cancelOutgoingActivation,
+            .merge(
+              .send(.activateInitial),
+              completeCLIActivationIfSettled(state: &state),
+            ),
+          )
+        }
         // The prior per-display assignments point at the *old* profile's
         // workspace ids (independent per profile), so start fresh and re-fill
         // every display from the new profile — its pinned workspaces land on
         // their monitors, dynamics fill the rest (reuses the reconnect planner).
-        state.activeWorkspacesByDisplay = [:]
-        state.pendingDisplayRestores = []
-        state.focusWorkspaceOnRestore = nil
         var plan = Self.planDisplayRestore(
           connected: connected,
           newlyConnected: Set(connected),
@@ -1997,8 +2102,13 @@ public struct WorkspaceActivationFeature {
         // Empty profile (nothing pinnable) → nothing to tile. Still honor an
         // explicit focus target so the Activate button isn't a no-op.
         guard !plan.isEmpty else {
-          if let focus { return .send(.activate(workspaceId: focus, setFocus: true)) }
-          return .none
+          let completion =
+            if let focus {
+              Effect<Action>.send(.activate(workspaceId: focus, setFocus: true))
+            } else {
+              completeCLIActivationIfSettled(state: &state)
+            }
+          return .concatenate(cancelOutgoingActivation, completion)
         }
         state.pendingDisplayRestores = plan
         let hudEffect = profileSwitchHUDs(
@@ -2007,7 +2117,10 @@ public struct WorkspaceActivationFeature {
           show: state.config.settings.hud.shows(\.profileSwitch),
           durationMs: state.config.settings.hud.durationMs,
         )
-        return .merge(hudEffect, .send(.processDisplayRestores))
+        return .concatenate(
+          cancelOutgoingActivation,
+          .merge(hudEffect, .send(.processDisplayRestores)),
+        )
 
       case .delegate:
         return .none
@@ -2115,44 +2228,32 @@ public struct WorkspaceActivationFeature {
         }
 
       case .activate(let workspaceId, let setFocus):
-        // A deliberate switch supersedes any in-flight reconnect restore cascade
-        // — the user's action wins over the display-restore queue.
-        state.pendingDisplayRestores = []
-        // An already-active host that activation would leave exactly where it
-        // is does not need activation: it is a display focus transfer.
-        // Re-activating it would deliberately tear down that display's Borrow
-        // composition, returning a borrowed workspace merely because the user
-        // visited another monitor and came back. Borrow dismissal remains
-        // explicit through `.dismissBorrow`.
-        //
-        // The comparison against `deliberateActivationDisplay` is what keeps a
-        // dynamic workspace dynamic: it is already visible on *some* monitor
-        // almost always, so shortcutting on visibility alone pinned it to
-        // whichever monitor it last landed on and "follows mouse" stopped
-        // moving anything.
-        if
-          setFocus,
-          let display = state.activeWorkspacesByDisplay.first(where: {
-            $0.value == workspaceId
-          })?.key,
-          let workspace = state.config.activeProfile?.workspaces[id: workspaceId],
-          deliberateActivationDisplay(for: workspace, state: state)?.matches(display) ?? true,
-          // Nothing to focus means the transfer would swallow the switch
-          // whole: no app activation, no hide pass, no HUD. Fall through to a
-          // real activation, which is what raises the workspace back up.
-          visibleFocusTarget(workspaceId, state: state) != nil
-        {
-          return focusVisibleWorkspace(
-            workspaceId: workspaceId,
-            display: display,
-            state: &state,
-          )
-        }
-        return performActivate(
+        return deliberateActivation(
           workspaceId: workspaceId,
           setFocus: setFocus,
           state: &state,
         )
+
+      case .activateFromCLI(let workspaceId, let requestID):
+        return .concatenate(
+          deliberateActivation(
+            workspaceId: workspaceId,
+            setFocus: true,
+            continuesCLIActivation: true,
+            state: &state,
+          ),
+          .send(.cliActivationEffectFinished(
+            workspaceId: workspaceId,
+            requestID: requestID,
+          )),
+        )
+
+      case .cliActivationEffectFinished(let workspaceId, let requestID):
+        guard
+          state.pendingCLIActivation?.id == requestID,
+          state.pendingCLIActivation?.target == .workspace(workspaceId)
+        else { return .none }
+        return completeCLIActivationIfSettled(state: &state)
 
       case .activateFollowingAppFocus(let workspaceId):
         // A deliberate user action, so it outranks any queued display restore
@@ -2170,6 +2271,29 @@ public struct WorkspaceActivationFeature {
         // focus so the profile switch lands on the clicked workspace.
         let takesFocus = state.focusWorkspaceOnRestore == workspaceId
         if takesFocus { state.focusWorkspaceOnRestore = nil }
+        guard state.config.activeProfile?.workspaces[id: workspaceId] != nil else {
+          let completion: Effect<Action>
+          if let request = state.pendingCLIActivation {
+            let error =
+              switch request.target {
+              case .profile(let id) where !state.config.profiles.contains(where: { $0.id == id }):
+                "The requested profile no longer exists"
+
+              case .workspace(let id) where state.config.profileId(owning: id) == nil:
+                "The requested workspace no longer exists"
+
+              default:
+                "Configuration changed while activation was in progress"
+              }
+            completion = completeCLIActivation(error: error, state: &state)
+          } else {
+            completion = .none
+          }
+          let drain = state.pendingDisplayRestores.isEmpty
+            ? Effect<Action>.none
+            : .send(.processDisplayRestores)
+          return .concatenate(completion, drain)
+        }
         return performActivate(
           workspaceId: workspaceId,
           setFocus: takesFocus,
@@ -2177,6 +2301,7 @@ public struct WorkspaceActivationFeature {
           // The profile-switch HUD already announces this workspace as its
           // subtitle; don't let the focused restore raise a second HUD over it.
           suppressSwitchHUD: takesFocus,
+          continuesCLIActivation: true,
           state: &state,
         )
 
@@ -2447,10 +2572,13 @@ public struct WorkspaceActivationFeature {
         // dynamic workspace through the cursor and return its borrowed block.
         state.pendingDisplayRestores = []
         if let display = state.displayShowing(recent) {
-          return focusVisibleWorkspace(
-            workspaceId: recent,
-            display: display,
-            state: &state,
+          return .merge(
+            supersedePendingCLIActivation(state: &state),
+            focusVisibleWorkspace(
+              workspaceId: recent,
+              display: display,
+              state: &state,
+            ),
           )
         }
         return performActivate(
@@ -3109,7 +3237,8 @@ public struct WorkspaceActivationFeature {
           trailing,
         )
 
-      case .activationCompleted(let id, let display):
+      case .activationCompleted(let id, let display, let generation):
+        guard state.activeActivationGeneration == generation else { return .none }
         state.isActivating = false
         state.activatingWorkspaceID = nil
         let reflowDisplayGeometry = state.pendingDisplayGeometryReflow
@@ -3241,17 +3370,32 @@ public struct WorkspaceActivationFeature {
             ),
         )
 
-      case .activationTailFinished:
+      case .activationTailFinished(let generation):
+        guard state.activeActivationGeneration == generation else { return .none }
+        state.activeActivationGeneration = nil
         // Drain the display-restore queue: the activation effect is fully
         // done, so the next display's restore can take the slot without
         // cancelling anyone's post-layout work.
-        guard !state.pendingDisplayRestores.isEmpty else { return .none }
+        guard !state.pendingDisplayRestores.isEmpty else {
+          guard
+            let request = state.pendingCLIActivation,
+            state.pendingCLIActivationBinding == CLIActivationBinding(
+              requestID: request.id,
+              activationGeneration: generation,
+            )
+          else { return .none }
+          return completeCLIActivationIfSettled(state: &state)
+        }
         return .send(.processDisplayRestores)
 
-      case .activationTimedOut:
-        guard state.isActivating else { return .none }
+      case .activationTimedOut(let generation):
+        guard
+          state.isActivating,
+          state.activeActivationGeneration == generation
+        else { return .none }
         state.isActivating = false
         state.activatingWorkspaceID = nil
+        state.activeActivationGeneration = nil
         let reflowDisplayGeometry = state.pendingDisplayGeometryReflow
         state.pendingDisplayGeometryReflow = false
         let pendingWindowSyncBundleIds = state.pendingWindowSyncBundleIds
@@ -3270,6 +3414,7 @@ public struct WorkspaceActivationFeature {
           // The cancelled effect will never report its tail, so drain the
           // restore queue here or a wedged activation strands it for good.
           state.pendingDisplayRestores.isEmpty ? .none : .send(.processDisplayRestores),
+          completeCLIActivation(error: "Workspace activation timed out", state: &state),
         )
       }
     }
@@ -3931,6 +4076,46 @@ public struct WorkspaceActivationFeature {
         cycle.display,
       )
     }
+  }
+
+  private func completeCLIActivation(
+    error: String?,
+    state: inout State,
+  ) -> Effect<Action> {
+    guard let request = state.pendingCLIActivation else { return .none }
+    state.pendingCLIActivation = nil
+    state.pendingCLIActivationBinding = nil
+    return .run { _ in request.complete(error) }
+  }
+
+  private func completeCLIActivationIfSettled(state: inout State) -> Effect<Action> {
+    guard
+      let request = state.pendingCLIActivation,
+      !state.isActivating,
+      state.pendingDisplayRestores.isEmpty
+    else { return .none }
+
+    let error: String? =
+      switch request.target {
+      case .profile(let id):
+        if !state.config.profiles.contains(where: { $0.id == id }) {
+          "The requested profile no longer exists"
+        } else if state.config.activeProfile?.id == id {
+          nil
+        } else {
+          "Profile activation completed on a different profile"
+        }
+
+      case .workspace(let id):
+        if state.config.profileId(owning: id) == nil {
+          "The requested workspace no longer exists"
+        } else if state.activeWorkspacesByDisplay.values.contains(id) {
+          nil
+        } else {
+          "Workspace activation finished without making the workspace active"
+        }
+      }
+    return completeCLIActivation(error: error, state: &state)
   }
 
   private func windowSwitcherIndicators(

--- a/TatamiKit/Sources/Features/WorkspaceDetail/ProfileDetailFeature.swift
+++ b/TatamiKit/Sources/Features/WorkspaceDetail/ProfileDetailFeature.swift
@@ -11,11 +11,12 @@ import Foundation
 public struct ProfileDetailFeature {
   @ObservableState
   public struct State: Equatable {
-    @Shared(.tatamiConfig) public var config = AppConfig()
+    @Shared(.tatamiConfig) public var config
     public var profileId: Profile.ID
     /// Displays offered in the auto-activation editor: currently connected plus
     /// any referenced by a workspace's `displayHint`. Loaded on appear.
     public var availableDisplays: [DisplayName] = []
+    @Presents public var alert: AlertState<Action.Alert>?
 
     public init(profileId: Profile.ID) {
       self.profileId = profileId
@@ -30,7 +31,10 @@ public struct ProfileDetailFeature {
 
     /// Conflict title for the profile switch shortcut (this profile excluded).
     public func shortcutConflict(for candidate: HotKey) -> String? {
-      config.shortcutConflict(for: candidate, excluding: .activateProfile(profileId))
+      config.shortcutConflictAcrossProfiles(
+        for: candidate,
+        excluding: .activateProfile(profileId)
+      )
     }
 
     /// How this profile's auto-activation rule overlaps the other profiles'.
@@ -51,12 +55,21 @@ public struct ProfileDetailFeature {
     /// maps carry the app bundle ids / field ids the user unchecked, per
     /// target workspace.
     case applyProfileSync(
+      target: Profile.ID,
       source: Profile.ID,
+      baseline: AppConfig,
       excludedApps: [Workspace.ID: Set<String>],
       excludedFields: [Workspace.ID: Set<String>]
     )
     case binding(BindingAction<State>)
     case delegate(Delegate)
+    case alert(PresentationAction<Alert>)
+
+    public enum Alert: Equatable {
+      case dismissConfigurationChanged
+      case dismissCopyFailure
+      case dismissShortcutConflicts
+    }
 
     public enum Delegate: Equatable {
       case activateProfile(Profile.ID)
@@ -67,64 +80,148 @@ public struct ProfileDetailFeature {
 
   @Dependency(\.hotKeys) var hotKeys
   @Dependency(\.displays) var displays
+  @Dependency(\.configPersistence) var configPersistence
 
   public init() {}
 
   public var body: some ReducerOf<Self> {
-    BindingReducer()
-    Reduce { state, action in
-      switch action {
-      case .onAppear:
-        // Connected displays + any pinned-to by a workspace, de-duplicated.
-        var seen = Set<DisplayName>()
-        var out: [DisplayName] = []
-        func add(_ d: DisplayName) { if seen.insert(d).inserted { out.append(d) } }
-        displays.all().forEach(add)
-        for profile in state.config.profiles {
-          for ws in profile.workspaces { if let hint = ws.displayHint { add(hint) } }
+    CombineReducers {
+      BindingReducer()
+      Reduce { state, action in
+        switch action {
+        case .onAppear:
+          // Connected displays + any pinned-to by a workspace, de-duplicated.
+          var seen = Set<DisplayName>()
+          var out: [DisplayName] = []
+          func add(_ d: DisplayName) { if seen.insert(d).inserted { out.append(d) } }
+          displays.all().forEach(add)
+          for profile in state.config.profiles {
+            for ws in profile.workspaces { if let hint = ws.displayHint { add(hint) } }
+          }
+          state.availableDisplays = out
+          return .none
+
+        case .nameChanged(let name):
+          let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
+          guard !trimmed.isEmpty else { return .none }
+          mutate(state) { $0.name = trimmed }
+          return .send(.delegate(.profilesChanged))
+
+        case .symbolIconChanged(let symbol):
+          // Cosmetic: the @Shared write re-renders the sidebar / menu bar; no
+          // hotkey rebind needed.
+          mutate(state) { $0.symbolIconName = symbol }
+          return .none
+
+        case .shortcutChanged(let hotKey):
+          mutate(state) { $0.shortcut = hotKey }
+          return .send(.delegate(.profilesChanged))
+
+        case .shortcutRecordingChanged(let recording):
+          return .run { [hotKeys] _ in await hotKeys.setRecording(recording) }
+
+        case .autoActivationChanged(let rule):
+          mutate(state) { $0.autoActivation = rule }
+          return .send(.delegate(.profilesChanged))
+
+        case .activateTapped:
+          return .send(.delegate(.activateProfile(state.profileId)))
+
+        case let .applyProfileSync(target, source, baseline, excludedApps, excludedFields):
+          guard
+            state.profileId == target,
+            let projection = baseline.profileSyncProjection(
+              into: target,
+              from: source,
+              excludedAppsByWorkspace: excludedApps,
+              excludedFieldsByWorkspace: excludedFields
+            )
+          else {
+            state.alert = configurationChangedAlert()
+            return .none
+          }
+          guard projection.conflicts.isEmpty else {
+            state.alert = shortcutConflictAlert(projection.conflicts)
+            return .none
+          }
+
+          do {
+            let revision = try configPersistence.captureRevision(baseline)
+            try configPersistence.commit(
+              state.$config,
+              baseline,
+              revision,
+              projection.config,
+              { true }
+            )
+            return .send(.delegate(.profilesChanged))
+          } catch {
+            state.alert = isStaleReview(error)
+              ? configurationChangedAlert()
+              : copyFailedAlert(error)
+            return .none
+          }
+
+        case .alert, .binding, .delegate:
+          return .none
         }
-        state.availableDisplays = out
-        return .none
-
-      case .nameChanged(let name):
-        let trimmed = name.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return .none }
-        mutate(state) { $0.name = trimmed }
-        return .send(.delegate(.profilesChanged))
-
-      case .symbolIconChanged(let symbol):
-        // Cosmetic: the @Shared write re-renders the sidebar / menu bar; no
-        // hotkey rebind needed.
-        mutate(state) { $0.symbolIconName = symbol }
-        return .none
-
-      case .shortcutChanged(let hotKey):
-        mutate(state) { $0.shortcut = hotKey }
-        return .send(.delegate(.profilesChanged))
-
-      case .shortcutRecordingChanged(let recording):
-        return .run { [hotKeys] _ in await hotKeys.setRecording(recording) }
-
-      case .autoActivationChanged(let rule):
-        mutate(state) { $0.autoActivation = rule }
-        return .send(.delegate(.profilesChanged))
-
-      case .activateTapped:
-        return .send(.delegate(.activateProfile(state.profileId)))
-
-      case let .applyProfileSync(source, excludedApps, excludedFields):
-        state.$config.withLock {
-          $0.applyProfileSync(
-            into: state.profileId, from: source,
-            excludedAppsByWorkspace: excludedApps,
-            excludedFieldsByWorkspace: excludedFields
-          )
-        }
-        return .send(.delegate(.profilesChanged))
-
-      case .binding, .delegate:
-        return .none
       }
+    }
+    .ifLet(\.$alert, action: \.alert)
+  }
+
+  private func configurationChangedAlert() -> AlertState<Action.Alert> {
+    AlertState {
+      TextState("Configuration changed")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismissConfigurationChanged) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(
+        "Nothing was copied because the configuration changed while the review was open. Reopen Copy and review the latest changes."
+      )
+    }
+  }
+
+  private func copyFailedAlert(_ error: any Error) -> AlertState<Action.Alert> {
+    AlertState {
+      TextState("Copy failed")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismissCopyFailure) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(ErrorReportClient.describe(error))
+    }
+  }
+
+  private func isStaleReview(_ error: any Error) -> Bool {
+    guard let error = error as? ConfigPersistenceError else { return false }
+    return switch error {
+    case .changedInMemory, .changedOnDisk, .transactionExpired:
+      true
+    case .outcomeUnknown:
+      false
+    }
+  }
+
+  private func shortcutConflictAlert(
+    _ conflicts: [WorkspaceShortcutConflict]
+  ) -> AlertState<Action.Alert> {
+    let descriptions = Set(conflicts.map { "\($0.hotKey.symbols): \($0.owner)" })
+      .sorted()
+      .formatted()
+    return AlertState {
+      TextState("Shortcut conflicts")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismissShortcutConflicts) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(
+        "Nothing was copied. Deselect the conflicting shortcut changes and try again: \(descriptions)"
+      )
     }
   }
 

--- a/TatamiKit/Sources/Features/WorkspaceDetail/WorkspaceDetailFeature.swift
+++ b/TatamiKit/Sources/Features/WorkspaceDetail/WorkspaceDetailFeature.swift
@@ -13,7 +13,7 @@ import Sharing
 public struct WorkspaceDetailFeature {
   @ObservableState
   public struct State: Equatable {
-    @Shared(.tatamiConfig) public var config = AppConfig()
+    @Shared(.tatamiConfig) public var config
     public var workspaceId: Workspace.ID
     public var isAppPickerPresented = false
     public var availableRunningApps: [MacApp] = []
@@ -49,19 +49,27 @@ public struct WorkspaceDetailFeature {
     /// — for the activate-shortcut recorder's conflict message. Lives here
     /// (not the view) so the config read stays in the reducer's state.
     public func activateShortcutConflict(for candidate: HotKey) -> String? {
-      config.shortcutConflict(for: candidate, excluding: .activateWorkspace(workspaceId))
+      shortcutConflict(for: candidate, excluding: .activateWorkspace(workspaceId))
     }
 
     /// Same, for the assign-app-shortcut recorder.
     public func assignShortcutConflict(for candidate: HotKey) -> String? {
-      config.shortcutConflict(
+      shortcutConflict(
         for: candidate, excluding: .assignFocusedAppToWorkspace(workspaceId)
       )
     }
 
     /// Same, for the borrow-shortcut recorder.
     public func borrowShortcutConflict(for candidate: HotKey) -> String? {
-      config.shortcutConflict(for: candidate, excluding: .borrowWorkspace(workspaceId))
+      shortcutConflict(for: candidate, excluding: .borrowWorkspace(workspaceId))
+    }
+
+    private func shortcutConflict(
+      for candidate: HotKey,
+      excluding action: HotKeyAction
+    ) -> String? {
+      guard let profileId = config.profileId(owning: workspaceId) else { return nil }
+      return config.shortcutConflict(for: candidate, excluding: action, in: profileId)
     }
   }
 
@@ -101,16 +109,26 @@ public struct WorkspaceDetailFeature {
     /// Pull a reviewed set of apps / settings from another profile's workspace
     /// into this one; the excluded sets carry what the user unchecked.
     case importWorkspace(
+      targetWorkspace: Workspace.ID,
       sourceProfile: Profile.ID,
       sourceWorkspace: Workspace.ID,
+      baseline: AppConfig,
       excludingApps: Set<String>,
       excludingFields: Set<String>
     )
     case layout(WorkspaceLayoutFeature.Action)
     case alert(PresentationAction<Alert>)
+    case delegate(Delegate)
 
     public enum Alert: Equatable {
       case confirmAppRemoval(bundleIdentifier: String)
+      case dismissConfigurationChanged
+      case dismissCopyFailure
+      case dismissShortcutConflicts
+    }
+
+    public enum Delegate: Equatable {
+      case importApplied(Workspace.ID)
     }
   }
 
@@ -118,6 +136,7 @@ public struct WorkspaceDetailFeature {
   @Dependency(\.displays) var displays
   @Dependency(\.hotKeys) var hotKeys
   @Dependency(\.appChooser) var appChooser
+  @Dependency(\.configPersistence) var configPersistence
 
   public init() {}
 
@@ -127,6 +146,9 @@ public struct WorkspaceDetailFeature {
     Reduce { state, action in
       switch action {
       case .binding:
+        return .none
+
+      case .delegate:
         return .none
 
       case .onAppear:
@@ -326,21 +348,105 @@ public struct WorkspaceDetailFeature {
       case .activateTapped:
         return .none
 
-      case let .importWorkspace(sourceProfile, sourceWorkspace, excludingApps, excludingFields):
-        state.$config.withLock {
-          $0.importWorkspace(
-            into: state.workspaceId,
+      case let .importWorkspace(
+        targetWorkspace,
+        sourceProfile,
+        sourceWorkspace,
+        baseline,
+        excludingApps,
+        excludingFields
+      ):
+        guard
+          state.workspaceId == targetWorkspace,
+          let projection = baseline.workspaceImportProjection(
+            into: targetWorkspace,
             from: sourceProfile,
             sourceWorkspace: sourceWorkspace,
             excludingApps: excludingApps,
             excludingFields: excludingFields
           )
+        else {
+          state.alert = configurationChangedAlert()
+          return .none
         }
-        // AppFeature intercepts to rebind hotkeys (key may have changed) and
-        // re-tile if this is the active workspace (apps may have changed).
-        return .none
+        guard projection.conflicts.isEmpty else {
+          state.alert = shortcutConflictAlert(projection.conflicts)
+          return .none
+        }
+
+        do {
+          let revision = try configPersistence.captureRevision(baseline)
+          try configPersistence.commit(
+            state.$config,
+            baseline,
+            revision,
+            projection.config,
+            { true }
+          )
+          return .send(.delegate(.importApplied(targetWorkspace)))
+        } catch {
+          state.alert = isStaleReview(error)
+            ? configurationChangedAlert()
+            : copyFailedAlert(error)
+          return .none
+        }
       }
     }
     .ifLet(\.$alert, action: \.alert)
+  }
+
+  private func configurationChangedAlert() -> AlertState<Action.Alert> {
+    AlertState {
+      TextState("Configuration changed")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismissConfigurationChanged) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(
+        "Nothing was copied because the configuration changed while the review was open. Reopen Copy and review the latest changes."
+      )
+    }
+  }
+
+  private func copyFailedAlert(_ error: any Error) -> AlertState<Action.Alert> {
+    AlertState {
+      TextState("Copy failed")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismissCopyFailure) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(ErrorReportClient.describe(error))
+    }
+  }
+
+  private func isStaleReview(_ error: any Error) -> Bool {
+    guard let error = error as? ConfigPersistenceError else { return false }
+    return switch error {
+    case .changedInMemory, .changedOnDisk, .transactionExpired:
+      true
+    case .outcomeUnknown:
+      false
+    }
+  }
+
+  private func shortcutConflictAlert(
+    _ conflicts: [WorkspaceShortcutConflict]
+  ) -> AlertState<Action.Alert> {
+    let descriptions = Set(conflicts.map { "\($0.hotKey.symbols): \($0.owner)" })
+      .sorted()
+      .formatted()
+    return AlertState {
+      TextState("Shortcut conflicts")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismissShortcutConflicts) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(
+        "Nothing was copied. Deselect the conflicting shortcut changes and try again: \(descriptions)"
+      )
+    }
   }
 }

--- a/TatamiKit/Sources/Features/WorkspaceDetail/WorkspaceLayoutFeature.swift
+++ b/TatamiKit/Sources/Features/WorkspaceDetail/WorkspaceLayoutFeature.swift
@@ -69,7 +69,7 @@ public struct WorkspaceLayoutFeature {
 
     // MARK: Public
 
-    @Shared(.tatamiConfig) public var config = AppConfig()
+    @Shared(.tatamiConfig) public var config
     public var workspaceId: Workspace.ID
 
     /// Persisted layout template, loaded on appear; drives the preview when the

--- a/TatamiKit/Sources/Features/WorkspaceList/SharedAppsFeature.swift
+++ b/TatamiKit/Sources/Features/WorkspaceList/SharedAppsFeature.swift
@@ -16,7 +16,7 @@ import Sharing
 public struct SharedAppsFeature {
   @ObservableState
   public struct State: Equatable {
-    @Shared(.tatamiConfig) public var config = AppConfig()
+    @Shared(.tatamiConfig) public var config
     public var isAppPickerPresented = false
     public var availableRunningApps: [MacApp] = []
     @Presents public var alert: AlertState<Action.Alert>?

--- a/TatamiKit/Sources/Features/WorkspaceList/WorkspaceListFeature.swift
+++ b/TatamiKit/Sources/Features/WorkspaceList/WorkspaceListFeature.swift
@@ -3,6 +3,7 @@
 
 import ComposableArchitecture
 import Foundation
+import IdentifiedCollections
 import Sharing
 
 /// Sidebar listing of the active profile's workspaces, plus the "Shared"
@@ -11,6 +12,108 @@ import Sharing
 /// `WorkspaceDetailFeature` or `SharedAppsFeature` child.
 @Reducer
 public struct WorkspaceListFeature {
+
+  // MARK: Lifecycle
+
+  public init() { }
+
+  // MARK: Public
+
+  public enum NameTarget: Equatable, Hashable, Sendable {
+    case profile(Profile.ID)
+    case workspace(Workspace.ID)
+  }
+
+  public struct RenameSession: Equatable, Sendable {
+    public init(target: NameTarget, draft: String) {
+      self.target = target
+      self.draft = draft
+    }
+
+    public var draft: String
+    public var target: NameTarget
+  }
+
+  /// Immutable source data shown by the duplicate chooser. Keeping the
+  /// snapshot in reducer state means the eventual clone matches the options
+  /// the user reviewed even if config.toml changes while the sheet is open.
+  public struct DuplicationReview: Equatable, Identifiable, Sendable {
+    public enum Source: Equatable, Sendable {
+      case profile(Profile)
+      case workspace(Workspace)
+    }
+
+    public init(source: Source, baseline: AppConfig) {
+      self.source = source
+      self.baseline = baseline
+    }
+
+    public let baseline: AppConfig
+    public let source: Source
+
+    public var id: NameTarget {
+      switch source {
+      case .profile(let profile): .profile(profile.id)
+      case .workspace(let workspace): .workspace(workspace.id)
+      }
+    }
+  }
+
+  /// Stable ids shared by the reducer's selective-copy logic and the
+  /// `SyncPreviewSheet` rows in the app target.
+  public enum DuplicationOptionID {
+    public static let profileIcon = "profile:icon"
+
+    public static func includeWorkspace(_ id: Workspace.ID) -> String {
+      "\(id.uuidString):workspace"
+    }
+
+    public static func app(_ bundleIdentifier: String, in workspaceID: Workspace.ID) -> String {
+      "\(workspaceID.uuidString):app:\(bundleIdentifier)"
+    }
+
+    public static func field(_ fieldID: String, in workspaceID: Workspace.ID) -> String {
+      "\(workspaceID.uuidString):field:\(fieldID)"
+    }
+
+    public static func layout(_ workspaceID: Workspace.ID) -> String {
+      "\(workspaceID.uuidString):layout"
+    }
+  }
+
+  /// Validate a duplicate chooser's entire effective selection and map every
+  /// collision back to the source row id shown by `SyncPreviewSheet`.
+  public static func duplicationShortcutConflicts(
+    review: DuplicationReview,
+    excluding excludedItemIDs: Set<String>
+  ) -> [String: [WorkspaceShortcutConflict]] {
+    guard let pending = prepareDuplication(
+      review: review,
+      excluding: excludedItemIDs,
+      selectionRevision: 0
+    ) else { return [:] }
+    var result = [String: [WorkspaceShortcutConflict]]()
+    for conflict in pending.updated.shortcutCopyConflicts(
+      for: pending.shortcutSelections,
+      comparedTo: pending.baseline
+    ) {
+      guard let itemID = pending.shortcutItemIDs[conflict.selection] else { continue }
+      result[itemID, default: []].append(conflict)
+    }
+    return result
+  }
+
+  public struct DuplicationPreparation: Equatable, Sendable {
+    var baseline: AppConfig
+    var configRevision: Data?
+    var updated: AppConfig
+    var target: NameTarget
+    var newWorkspaceIDs: [Workspace.ID]
+    var selectionRevision: UInt64
+    var layoutCopied: Bool
+    var shortcutSelections = Set<WorkspaceShortcutSelection>()
+  }
+
   /// What the sidebar column (col 1) can select: a profile (whose contents fill
   /// col 2), or the global Shared Apps entry (profile-independent, so it lives
   /// in col 1 rather than under any one profile).
@@ -28,7 +131,14 @@ public struct WorkspaceListFeature {
 
   @ObservableState
   public struct State: Equatable {
-    @Shared(.tatamiConfig) public var config = AppConfig()
+
+    // MARK: Lifecycle
+
+    public init() { }
+
+    // MARK: Public
+
+    @Shared(.tatamiConfig) public var config
     /// The sidebar (col 1) selection — a profile being viewed/edited, or the
     /// global Shared Apps. Independent of the *active* (running) profile, so a
     /// non-active profile can be inspected and edited without switching to it.
@@ -37,13 +147,15 @@ public struct WorkspaceListFeature {
     public var selection: SidebarItem?
     public var isAddSheetPresented = false
     public var draftName = ""
+    /// A sidebar rename is persisted only on Return or blur. Escape discards it.
+    public var renameSession: RenameSession?
+    /// Source snapshot currently being reviewed before a duplicate is queued.
+    public var duplicationReview: DuplicationReview?
     public var detail: WorkspaceDetailFeature.State?
     public var shared: SharedAppsFeature.State?
     /// Profile settings shown in the detail pane (like `detail` for a workspace).
     public var profileDetail: ProfileDetailFeature.State?
     @Presents public var alert: AlertState<Action.Alert>?
-
-    public init() {}
 
     /// The profile selected in col 1, or nil when Shared Apps (or nothing) is.
     public var selectedProfileId: Profile.ID? {
@@ -52,7 +164,9 @@ public struct WorkspaceListFeature {
     }
 
     /// Whether col 1's global Shared Apps entry is selected.
-    public var isViewingShared: Bool { topSelection == .shared }
+    public var isViewingShared: Bool {
+      topSelection == .shared
+    }
 
     /// The profile whose contents col 2 lists — the selected one, falling back
     /// to the active/first when nothing is selected yet.
@@ -78,6 +192,19 @@ public struct WorkspaceListFeature {
     public var scratchpadWorkspaces: [Workspace] {
       workspaces.filter { $0.kind == .scratchpad }
     }
+
+    // MARK: Internal
+
+    /// Invalidates delayed duplicate-selection completions after any newer
+    /// selection intent, so background layout I/O cannot steal navigation.
+    var selectionRevision: UInt64 = 0
+    var pendingDuplications = [PendingDuplication]()
+    var isDuplicationInFlight = false
+    /// Includes every confirmed in-flight/queued clone, letting another
+    /// chooser opened during layout I/O snapshot the exact baseline it will
+    /// follow instead of racing the not-yet-published shared config.
+    var projectedDuplicationConfig: AppConfig?
+
   }
 
   public enum Action: BindableAction {
@@ -89,7 +216,7 @@ public struct WorkspaceListFeature {
       draggedId: Workspace.ID,
       kind: WorkspaceKind,
       relativeTo: Workspace.ID?,
-      after: Bool
+      after: Bool,
     )
     case sidebarSelected(SidebarItem?)
     /// First render: highlight the active profile in col 1 without opening its
@@ -100,8 +227,16 @@ public struct WorkspaceListFeature {
     case topSelected(SidebarTop?)
     case newProfileButtonTapped
     case duplicateProfileTapped(Profile.ID)
+    case duplicateWorkspaceTapped(Workspace.ID)
+    case duplicationReviewConfirmed(excluding: Set<String>)
+    case duplicationPrepared(DuplicationPreparation)
+    case selectDuplicateIfUnchanged(NameTarget, selectionRevision: UInt64)
     case deleteProfileRequested(Profile.ID)
     case profilesReordered(IndexSet, Int)
+    case renameCancelled
+    case renameDraftChanged(String)
+    case renameRequested(NameTarget)
+    case renameSubmitted
     case detail(WorkspaceDetailFeature.Action)
     case shared(SharedAppsFeature.Action)
     case profileDetail(ProfileDetailFeature.Action)
@@ -109,9 +244,12 @@ public struct WorkspaceListFeature {
     case binding(BindingAction<State>)
     case delegate(Delegate)
 
+    // MARK: Public
+
     public enum Alert: Equatable {
       case confirmDeletion(Workspace.ID)
       case confirmProfileDeletion(Profile.ID)
+      case dismissShortcutConflicts
     }
 
     /// Profile side effects the parent (AppFeature) owns: switching drives
@@ -119,14 +257,10 @@ public struct WorkspaceListFeature {
     /// hotkeys.
     public enum Delegate: Equatable {
       case activateProfile(Profile.ID)
+      case activateProfileAfterDeletion(Profile.ID, previousProfile: Profile)
       case profilesChanged
     }
   }
-
-  @Dependency(\.displays) var displays
-  @Dependency(\.layoutStore) var layoutStore
-
-  public init() {}
 
   public var body: some ReducerOf<Self> {
     BindingReducer()
@@ -191,7 +325,9 @@ public struct WorkspaceListFeature {
       case .alert(.presented(.confirmProfileDeletion(let id))):
         // Clear the deleted profile's workspace layouts, then remove it. If it
         // was the active one, switch to the new first profile.
-        let wsIds = state.config.profiles.first(where: { $0.id == id })?.workspaces.map(\.id) ?? []
+        guard let deletedProfile = state.config.profiles.first(where: { $0.id == id })
+        else { return .none }
+        let wsIds = deletedProfile.workspaces.map(\.id)
         let wasActive = (state.config.activeProfileId ?? state.config.profiles.first?.id) == id
         state.$config.withLock { $0.profiles.removeAll { $0.id == id } }
         // If the viewed profile was the one deleted, move the sidebar selection
@@ -205,20 +341,25 @@ public struct WorkspaceListFeature {
           state.shared = nil
         }
         let switchAway: Effect<Action> = wasActive
-          ? (state.config.profiles.first.map { .send(.delegate(.activateProfile($0.id))) }
+          ? (state.config.profiles.first.map {
+            .send(.delegate(.activateProfileAfterDeletion(
+              $0.id,
+              previousProfile: deletedProfile,
+            )))
+          }
             ?? .send(.delegate(.profilesChanged)))
           : .send(.delegate(.profilesChanged))
         return .merge(
           .run { [layoutStore] _ in
             for wsId in wsIds { await layoutStore.clear(wsId) }
           },
-          switchAway
+          switchAway,
         )
 
       case .alert:
         return .none
 
-      case let .workspaceDropped(draggedId, kind, target, after):
+      case .workspaceDropped(let draggedId, let kind, let target, let after):
         let profileId = state.selectedProfileResolvedId
         state.$config.withLock { config in
           config.placeWorkspace(draggedId, kind: kind, relativeTo: target, after: after, in: profileId)
@@ -232,12 +373,14 @@ public struct WorkspaceListFeature {
         return .none
 
       case .topSelected(let top):
+        state.selectionRevision &+= 1
         state.topSelection = top
         switch top {
         case .profile:
           // Switching the viewed profile resets col 2 to that profile's
           // settings; it does *not* activate the profile.
           return .send(.sidebarSelected(.profileSettings))
+
         case .shared:
           // Shared Apps is global — open its editor in the detail column and
           // clear the profile-scoped col 2 selection.
@@ -246,6 +389,7 @@ public struct WorkspaceListFeature {
           state.profileDetail = nil
           state.shared = SharedAppsFeature.State()
           return .none
+
         case nil:
           state.selection = nil
           state.detail = nil
@@ -255,6 +399,7 @@ public struct WorkspaceListFeature {
         }
 
       case .sidebarSelected(let item):
+        state.selectionRevision &+= 1
         state.selection = item
         switch item {
         case .profileSettings:
@@ -262,10 +407,12 @@ public struct WorkspaceListFeature {
             .map { ProfileDetailFeature.State(profileId: $0) }
           state.detail = nil
           state.shared = nil
+
         case .workspace(let id):
           state.detail = WorkspaceDetailFeature.State(workspaceId: id)
           state.shared = nil
           state.profileDetail = nil
+
         case nil:
           state.detail = nil
           state.shared = nil
@@ -274,20 +421,104 @@ public struct WorkspaceListFeature {
         return .none
 
       case .duplicateProfileTapped(let id):
-        let remap = state.$config.withLock { $0.duplicateProfile(id) }
-        guard !remap.isEmpty else { return .none }
-        return .merge(
-          .send(.delegate(.profilesChanged)),
-          // Copy each source workspace's saved layout onto its fresh id so the
-          // clone opens identical (layouts are keyed by workspace id).
-          .run { [layoutStore] _ in
-            for (old, new) in remap {
-              if let snapshot = await layoutStore.load(old) {
-                await layoutStore.save(new, snapshot)
-              }
-            }
-          }
+        let baseline = state.projectedDuplicationConfig ?? state.config
+        guard let profile = baseline.profiles.first(where: { $0.id == id })
+        else { return .none }
+        state.duplicationReview = DuplicationReview(source: .profile(profile), baseline: baseline)
+        return .none
+
+      case .duplicateWorkspaceTapped(let id):
+        let baseline = state.projectedDuplicationConfig ?? state.config
+        guard let workspace = baseline.workspace(id: id) else { return .none }
+        state.duplicationReview = DuplicationReview(source: .workspace(workspace), baseline: baseline)
+
+        return .none
+
+      case .duplicationReviewConfirmed(let excludedItemIDs):
+        guard
+          let review = state.duplicationReview,
+          let pending = Self.prepareDuplication(
+            review: review,
+            excluding: excludedItemIDs,
+            selectionRevision: state.selectionRevision,
+          )
+        else { return .none }
+        let conflicts = pending.updated.shortcutCopyConflicts(
+          for: pending.shortcutSelections,
+          comparedTo: pending.baseline
         )
+        guard conflicts.isEmpty else {
+          state.alert = shortcutConflictAlert(conflicts)
+          return .none
+        }
+        state.duplicationReview = nil
+        state.projectedDuplicationConfig = pending.updated
+        state.pendingDuplications.append(pending)
+        return startNextDuplication(state: &state)
+
+      case .duplicationPrepared(let preparation):
+        state.isDuplicationInFlight = false
+        guard preparation.layoutCopied else {
+          state.pendingDuplications.removeAll()
+          state.projectedDuplicationConfig = nil
+          state.duplicationReview = nil
+          return .none
+        }
+        let conflicts = preparation.updated.shortcutCopyConflicts(
+          for: preparation.shortcutSelections,
+          comparedTo: preparation.baseline
+        )
+        guard conflicts.isEmpty else {
+          state.alert = shortcutConflictAlert(conflicts)
+          state.pendingDuplications.removeAll()
+          state.projectedDuplicationConfig = nil
+          state.duplicationReview = nil
+          return clearLayouts(preparation.newWorkspaceIDs)
+        }
+        do {
+          try configPersistence.commit(
+            state.$config,
+            preparation.baseline,
+            preparation.configRevision,
+            preparation.updated,
+            { true },
+          )
+        } catch {
+          errorReporter.report(
+            "Duplication",
+            String(localized: "Configuration changed before duplication finished"),
+            ErrorReportClient.describe(error),
+          )
+          state.pendingDuplications.removeAll()
+          state.projectedDuplicationConfig = nil
+          state.duplicationReview = nil
+          if case ConfigPersistenceError.outcomeUnknown = error {
+            return .none
+          }
+          return clearLayouts(preparation.newWorkspaceIDs)
+        }
+        errorReporter.resolve("Duplication")
+        let nextDuplication = startNextDuplication(state: &state)
+        return .concatenate(
+          .send(.delegate(.profilesChanged)),
+          .send(.selectDuplicateIfUnchanged(
+            preparation.target,
+            selectionRevision: preparation.selectionRevision,
+          )),
+          nextDuplication,
+        )
+
+      case .selectDuplicateIfUnchanged(let target, let selectionRevision):
+        guard
+          state.selectionRevision == selectionRevision,
+          name(for: target, in: state.config) != nil
+        else { return .none }
+        let revision = state.selectionRevision
+        select(target, state: &state)
+        // Programmatic selection of one completed duplicate must not invalidate
+        // another duplicate the user already queued at the same revision.
+        state.selectionRevision = revision
+        return .none
 
       case .newProfileButtonTapped:
         // Create an empty profile and open its detail so it's named + configured
@@ -296,23 +527,45 @@ public struct WorkspaceListFeature {
         state.$config.withLock { $0.profiles.append(profile) }
         return .send(.topSelected(.profile(profile.id)))
 
-      case let .profilesReordered(source, destination):
+      case .profilesReordered(let source, let destination):
         // Order matters: `activeProfile` falls back to the first, and an
         // auto-activation tie breaks toward the earlier profile.
         state.$config.withLock { $0.profiles.move(fromOffsets: source, toOffset: destination) }
+        return .none
+
+      case .renameCancelled:
+        state.renameSession = nil
+        return .none
+
+      case .renameDraftChanged(let draft):
+        state.renameSession?.draft = draft
+        return .none
+
+      case .renameRequested(let target):
+        if state.renameSession?.target == target { return .none }
+        commitRename(state: &state)
+        guard let name = name(for: target, in: state.config) else { return .none }
+        select(target, state: &state)
+        state.renameSession = RenameSession(target: target, draft: name)
+        return .none
+
+      case .renameSubmitted:
+        commitRename(state: &state)
         return .none
 
       // Profile detail bubbles its side-effecting ops up (switch → AppFeature,
       // delete → the confirm alert here, edits → hotkey rebind).
       case .profileDetail(.delegate(.activateProfile(let id))):
         return .send(.delegate(.activateProfile(id)))
+
       case .profileDetail(.delegate(.profilesChanged)):
         return .send(.delegate(.profilesChanged))
 
       case .deleteProfileRequested(let id):
         // Keep at least one profile; the delete option is hidden past that too.
-        guard state.config.profiles.count > 1,
-              let name = state.config.profiles.first(where: { $0.id == id })?.name
+        guard
+          state.config.profiles.count > 1,
+          let name = state.config.profiles.first(where: { $0.id == id })?.name
         else { return .none }
         state.alert = AlertState {
           TextState("Delete profile \"\(name)\"?")
@@ -326,7 +579,11 @@ public struct WorkspaceListFeature {
         }
         return .none
 
-      case .detail, .shared, .binding, .delegate, .profileDetail:
+      case .detail,
+           .shared,
+           .binding,
+           .delegate,
+           .profileDetail:
         return .none
       }
     }
@@ -341,4 +598,313 @@ public struct WorkspaceListFeature {
     }
     .ifLet(\.$alert, action: \.alert)
   }
+
+  // MARK: Internal
+
+  struct PendingDuplication: Equatable, Sendable {
+    var baseline: AppConfig
+    var updated: AppConfig
+    var target: NameTarget
+    var layoutMapping: [Workspace.ID: Workspace.ID]
+    var selectionRevision: UInt64
+    var shortcutSelections = Set<WorkspaceShortcutSelection>()
+    var shortcutItemIDs = [WorkspaceShortcutSelection: String]()
+  }
+
+  @Dependency(\.displays) var displays
+  @Dependency(\.configPersistence) var configPersistence
+  @Dependency(\.errorReporter) var errorReporter
+  @Dependency(\.layoutStore) var layoutStore
+
+  // MARK: Private
+
+  private func startNextDuplication(state: inout State) -> Effect<Action> {
+    guard !state.isDuplicationInFlight else { return .none }
+    guard !state.pendingDuplications.isEmpty else {
+      state.projectedDuplicationConfig = nil
+      return .none
+    }
+
+    let request = state.pendingDuplications.removeFirst()
+    let configRevision: Data?
+    do {
+      configRevision = try configPersistence.captureRevision(request.baseline)
+    } catch {
+      errorReporter.report(
+        "Duplication",
+        String(localized: "Configuration changed before duplication started"),
+        ErrorReportClient.describe(error),
+      )
+      state.pendingDuplications.removeAll()
+      state.projectedDuplicationConfig = nil
+      state.duplicationReview = nil
+      return .none
+    }
+    state.isDuplicationInFlight = true
+    // Prepare external layout state first. The clone is published to the
+    // shared config only after that atomic copy succeeds, so opening it can
+    // never race a nil first load.
+    return .run { [layoutStore] send in
+      let copied: Bool
+      if request.layoutMapping.isEmpty {
+        copied = true
+      } else {
+        copied = await layoutStore.copyLayouts(request.layoutMapping)
+      }
+      await send(.duplicationPrepared(DuplicationPreparation(
+        baseline: request.baseline,
+        configRevision: configRevision,
+        updated: request.updated,
+        target: request.target,
+        newWorkspaceIDs: Array(request.layoutMapping.values),
+        selectionRevision: request.selectionRevision,
+        layoutCopied: copied,
+        shortcutSelections: request.shortcutSelections,
+      )))
+    }
+  }
+
+  private static func prepareDuplication(
+    review: DuplicationReview,
+    excluding excludedItemIDs: Set<String>,
+    selectionRevision: UInt64
+  ) -> PendingDuplication? {
+    let baseline = review.baseline
+    var updated = baseline
+    let target: NameTarget
+    let layoutMapping: [Workspace.ID: Workspace.ID]
+    var shortcutSelections = Set<WorkspaceShortcutSelection>()
+    var shortcutItemIDs = [WorkspaceShortcutSelection: String]()
+
+    switch review.source {
+    case .profile(let source):
+      guard let result = updated.duplicateProfile(source.id) else { return nil }
+      target = .profile(result.profileId)
+      var selectedWorkspaces = [Workspace]()
+      var selectedLayouts: [Workspace.ID: Workspace.ID] = [:]
+      for workspace in source.workspaces {
+        guard
+          !excludedItemIDs.contains(DuplicationOptionID.includeWorkspace(workspace.id)),
+          let clonedID = result.workspaceIdMap[workspace.id],
+          let clonedName = updated.workspace(id: clonedID)?.name
+        else { continue }
+        let selectiveCopy = selectiveWorkspaceCopy(
+          of: workspace,
+          id: clonedID,
+          name: clonedName,
+          excluding: excludedItemIDs,
+          includeShortcuts: true,
+        )
+        selectedWorkspaces.append(selectiveCopy.workspace)
+        shortcutSelections.formUnion(selectiveCopy.shortcutSelections)
+        for selection in selectiveCopy.shortcutSelections {
+          shortcutItemIDs[selection] = DuplicationOptionID.field(
+            selection.field.rawValue,
+            in: workspace.id
+          )
+        }
+        if !excludedItemIDs.contains(DuplicationOptionID.layout(workspace.id)) {
+          selectedLayouts[workspace.id] = clonedID
+        }
+      }
+      updated.mutateProfile(result.profileId) { clone in
+        if excludedItemIDs.contains(DuplicationOptionID.profileIcon) {
+          clone.symbolIconName = nil
+        }
+        clone.workspaces = IdentifiedArray(uniqueElements: selectedWorkspaces)
+      }
+      layoutMapping = selectedLayouts
+
+    case .workspace(let source):
+      guard
+        let duplicateID = updated.duplicateWorkspace(source.id),
+        let duplicateName = updated.workspace(id: duplicateID)?.name
+      else { return nil }
+      let selectiveCopy = selectiveWorkspaceCopy(
+        of: source,
+        id: duplicateID,
+        name: duplicateName,
+        excluding: excludedItemIDs,
+        includeShortcuts: false,
+      )
+      updated.mutateWorkspace(duplicateID) { $0 = selectiveCopy.workspace }
+      target = .workspace(duplicateID)
+      layoutMapping = excludedItemIDs.contains(DuplicationOptionID.layout(source.id))
+        ? [:]
+        : [source.id: duplicateID]
+    }
+
+    return PendingDuplication(
+      baseline: baseline,
+      updated: updated,
+      target: target,
+      layoutMapping: layoutMapping,
+      selectionRevision: selectionRevision,
+      shortcutSelections: shortcutSelections,
+      shortcutItemIDs: shortcutItemIDs,
+    )
+  }
+
+  /// Builds the reviewed contents onto a clean workspace shell. Starting from
+  /// defaults makes every unchecked option mean "do not copy" instead of
+  /// needing to reverse fields after a full clone. Identity and Finder-style
+  /// naming still come from AppConfig's duplicate helpers.
+  private struct SelectiveWorkspaceCopy {
+    var shortcutSelections: Set<WorkspaceShortcutSelection>
+    var workspace: Workspace
+  }
+
+  private static func selectiveWorkspaceCopy(
+    of source: Workspace,
+    id: Workspace.ID,
+    name: String,
+    excluding excludedItemIDs: Set<String>,
+    includeShortcuts: Bool
+  ) -> SelectiveWorkspaceCopy {
+    var copy = Workspace(id: id, name: name)
+
+    let appChanges = WorkspaceSync.appChanges(from: source.apps, to: copy.apps)
+    let excludedApps = Set(appChanges.compactMap { change in
+      excludedItemIDs.contains(DuplicationOptionID.app(change.bundleId, in: source.id))
+        ? change.bundleId
+        : nil
+    })
+    copy.apps = WorkspaceSync.apply(appChanges, to: copy.apps, excluding: excludedApps)
+
+    let fieldChanges = WorkspaceSync.fieldChanges(from: source, to: copy)
+    let excludedFields = Set(fieldChanges.compactMap { change in
+      if !includeShortcuts, isShortcutIdentity(change) { return change.id }
+      return excludedItemIDs.contains(DuplicationOptionID.field(change.id, in: source.id))
+        ? change.id
+        : nil
+    })
+    WorkspaceSync.apply(fieldChanges, to: &copy, excluding: excludedFields)
+
+    var shortcutSelections = Set<WorkspaceShortcutSelection>()
+    if includeShortcuts {
+      for change in fieldChanges where !excludedFields.contains(change.id) {
+        if let field = change.shortcutField {
+          shortcutSelections.insert(.init(workspaceId: id, field: field))
+        }
+      }
+    }
+
+    if !includeShortcuts {
+      // Same-profile workspace duplicates must never register the source's
+      // direct or derived shortcuts. Workspaces copied as part of a new
+      // profile remain independently scoped and may retain selected shortcuts.
+      copy.keyEquivalent = nil
+      copy.activateShortcut = nil
+      copy.assignAppShortcut = nil
+      copy.borrowShortcut = nil
+    }
+
+    if
+      let focusBundleID = copy.appToFocusBundleId,
+      !copy.apps.contains(where: { $0.bundleIdentifier == focusBundleID })
+    {
+      copy.appToFocusBundleId = nil
+    }
+    return SelectiveWorkspaceCopy(
+      shortcutSelections: shortcutSelections,
+      workspace: copy
+    )
+  }
+
+  private static func isShortcutIdentity(_ change: WorkspaceFieldChange) -> Bool {
+    switch change {
+    case .keyEquivalent, .activateShortcut, .assignAppShortcut, .borrowShortcut:
+      true
+    case .icon, .kind, .appToFocus, .displayHint, .borrowEdge, .borrowFraction:
+      false
+    }
+  }
+
+  private func shortcutConflictAlert(
+    _ conflicts: [WorkspaceShortcutConflict]
+  ) -> AlertState<Action.Alert> {
+    let descriptions = Set(conflicts.map { "\($0.hotKey.symbols): \($0.owner)" })
+      .sorted()
+      .formatted()
+    return AlertState {
+      TextState("Shortcut conflicts")
+    } actions: {
+      ButtonState(role: .cancel, action: .dismissShortcutConflicts) {
+        TextState("OK")
+      }
+    } message: {
+      TextState(
+        "Nothing was duplicated. Deselect the conflicting shortcut changes and try again: \(descriptions)"
+      )
+    }
+  }
+
+  private func clearLayouts(_ workspaceIDs: [Workspace.ID]) -> Effect<Action> {
+    .run { [layoutStore, errorReporter] _ in
+      guard await layoutStore.removeLayouts(workspaceIDs) else {
+        errorReporter.report(
+          "Duplication",
+          String(localized: "Incomplete duplicate layout cleanup"),
+          String(localized: "The duplicate was not added to the configuration."),
+        )
+        return
+      }
+    }
+  }
+
+  private func commitRename(state: inout State) {
+    guard let session = state.renameSession else { return }
+    state.renameSession = nil
+    let name = session.draft.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !name.isEmpty else { return }
+    state.$config.withLock { config in
+      switch session.target {
+      case .profile(let id):
+        config.mutateProfile(id) { $0.name = name }
+      case .workspace(let id):
+        config.mutateWorkspace(id) { $0.name = name }
+      }
+    }
+  }
+
+  private func name(for target: NameTarget, in config: AppConfig) -> String? {
+    switch target {
+    case .profile(let id):
+      config.profiles.first(where: { $0.id == id })?.name
+    case .workspace(let id):
+      config.workspace(id: id)?.name
+    }
+  }
+
+  private func select(_ target: NameTarget, state: inout State) {
+    switch target {
+    case .profile(let id):
+      let selectionChanged = state.topSelection != .profile(id)
+        || state.selection != .profileSettings
+      if selectionChanged { state.selectionRevision &+= 1 }
+      state.topSelection = .profile(id)
+      state.selection = .profileSettings
+      if state.profileDetail?.profileId != id {
+        state.profileDetail = ProfileDetailFeature.State(profileId: id)
+      }
+      state.detail = nil
+      state.shared = nil
+
+    case .workspace(let id):
+      let owner = state.config.profileId(owning: id)
+      let selectionChanged = state.topSelection != owner.map { .profile($0) }
+        || state.selection != .workspace(id)
+      if selectionChanged { state.selectionRevision &+= 1 }
+      if let profileId = state.config.profileId(owning: id) {
+        state.topSelection = .profile(profileId)
+      }
+      state.selection = .workspace(id)
+      if state.detail?.workspaceId != id {
+        state.detail = WorkspaceDetailFeature.State(workspaceId: id)
+      }
+      state.profileDetail = nil
+      state.shared = nil
+    }
+  }
+
 }

--- a/TatamiKit/Sources/Persistence/TatamiConfigKey.swift
+++ b/TatamiKit/Sources/Persistence/TatamiConfigKey.swift
@@ -6,66 +6,148 @@ import Foundation
 import Sharing
 import TOML
 
-extension SharedReaderKey where Self == FileStorageKey<AppConfig>.Default {
+// MARK: - TatamiConfigKey
+
+/// FileStorage-backed key that keeps every mutation synchronous and routes it
+/// through Tatami's configuration transaction coordinator. The stock
+/// FileStorage key coalesces successive writes for one second, which is useful
+/// for generic values but makes config-file compare-and-swap ambiguous.
+public struct TatamiConfigKey: SharedKey {
+
+  // MARK: Public
+
+  public var id: FileStorageKeyID {
+    base.id
+  }
+
+  public func load(
+    context: LoadContext<AppConfig>,
+    continuation: LoadContinuation<AppConfig>,
+  ) {
+    base.load(context: context, continuation: continuation)
+  }
+
+  public func subscribe(
+    context: LoadContext<AppConfig>,
+    subscriber: SharedSubscriber<AppConfig>,
+  ) -> SharedSubscription {
+    base.subscribe(
+      context: context,
+      subscriber: SharedSubscriber(
+        callback: { result in
+          if case .success(.some(let decoded)) = result {
+            let value = TatamiConfigTransactionCoordinator.shared
+              .preservingSessionProfile(in: decoded)
+            if TatamiConfigTransactionCoordinator.shared.shouldSuppressFileEcho(value) {
+              return
+            }
+            subscriber.yield(value)
+          } else {
+            subscriber.yield(with: result)
+          }
+        },
+        onLoading: { subscriber.yieldLoading($0) },
+      ),
+    )
+  }
+
+  public func save(
+    _ value: AppConfig,
+    context: SaveContext,
+    continuation: SaveContinuation,
+  ) {
+    if
+      context == .didSet,
+      TatamiConfigTransactionCoordinator.shared.consumeSuppressedDidSet(value)
+    {
+      continuation.resume()
+      return
+    }
+    // A user-initiated FileStorage save is immediate and cancels any old
+    // coalesced work inherited from a previous app version. Record its echo
+    // only after storage confirms success.
+    base.save(
+      value,
+      context: .userInitiated,
+      continuation: SaveContinuation { result in
+        switch result {
+        case .success:
+          TatamiConfigTransactionCoordinator.shared.recordSelfWrite(value)
+          continuation.resume()
+
+        case .failure(let error):
+          continuation.resume(throwing: error)
+        }
+      },
+    )
+  }
+
+  // MARK: Internal
+
+  let base: FileStorageKey<AppConfig>
+
+}
+
+extension SharedReaderKey where Self == TatamiConfigKey.Default {
   /// `@Shared(.tatamiConfig)` reads and writes the user's config TOML at
   /// `$XDG_CONFIG_HOME/tatami/config.toml`, falling back to a seeded default
   /// `AppConfig` (a `Default` profile + the recommended starter shortcuts)
   /// when the file is missing — so a fresh install is usable out of the box.
-  /// The seed only fills a missing file; an existing config decodes as-is
-  /// (`Shortcuts.recommended` is deliberately not a per-field decode fallback).
-  ///
-  /// The directory is created on first access; serialization uses TOMLKit so
-  /// existing dotfiles-style edits made outside the app are preserved.
+  /// The seed only fills a missing file; an existing config decodes as-is.
   public static var tatamiConfig: Self {
-    Self[
-      .fileStorage(
-        ConfigLocation.fileURL,
-        decode: { data in
-          let toml = String(decoding: data, as: UTF8.self)
-          @Dependency(\.errorReporter) var reporter
-          // "Shortcuts" reports fire from inside HotKey's decode and
-          // "Settings" from the field-tolerant decode helper; the pass
-          // confirms a still-broken value quietly and resolves a fixed one.
-          reporter.beginPass(["Shortcuts", "Settings"])
-          do {
-            let decoder = TOMLDecoder()
-            let config = try decoder.decode(AppConfig.self, from: toml)
-            reporter.commitPass(["Shortcuts", "Settings"])
-            reporter.resolve("Config")
-            return config
-          } catch {
-            // Decode failed wholesale — shortcut/typo state is unknown, keep it.
-            reporter.abortPass(["Shortcuts", "Settings"])
-            reporter.report(
-              "Config",
-              String(localized: "config.toml could not be parsed — keeping previous settings"),
-              ErrorReportClient.describe(error)
-            )
-            FileHandle.standardError.write(
-              Data("[Tatami] config.toml decode failed: \(error)\n".utf8)
-            )
-            throw error
-          }
-        },
-        encode: { config in
-          @Dependency(\.errorReporter) var reporter
-          do {
-            let encoder = TOMLEncoder()
-            encoder.outputFormatting = [.sortedKeys]
-            let data = try encoder.encode(config)
-            reporter.resolve("ConfigSave")
-            return data
-          } catch {
-            reporter.report(
-              "ConfigSave",
-              String(localized: "config.toml could not be saved"),
-              ErrorReportClient.describe(error)
-            )
-            throw error
-          }
-        }
-      ),
-      default: AppConfig(settings: AppSettings(shortcuts: .recommended))
+    let storage = FileStorageKey<AppConfig>.fileStorage(
+      ConfigLocation.fileURL,
+      decode: decodeTatamiConfig,
+      encode: encodeTatamiConfig,
+    )
+    return Self[
+      TatamiConfigKey(base: storage),
+      default: AppConfig(settings: AppSettings(shortcuts: .recommended)),
     ]
+  }
+}
+
+// MARK: - Serialization
+
+func decodeTatamiConfig(_ data: Data) throws -> AppConfig {
+  let toml = String(decoding: data, as: UTF8.self)
+  @Dependency(\.errorReporter) var reporter
+  // "Shortcuts" reports fire from inside HotKey's decode and "Settings"
+  // from the field-tolerant decode helper.
+  reporter.beginPass(["Shortcuts", "Settings"])
+  do {
+    let config = try TOMLDecoder().decode(AppConfig.self, from: toml)
+    reporter.commitPass(["Shortcuts", "Settings"])
+    reporter.resolve("Config")
+    return config
+  } catch {
+    reporter.abortPass(["Shortcuts", "Settings"])
+    reporter.report(
+      "Config",
+      String(localized: "config.toml could not be parsed. Keeping previous settings"),
+      ErrorReportClient.describe(error),
+    )
+    FileHandle.standardError.write(
+      Data("[Tatami] config.toml decode failed: \(error)\n".utf8)
+    )
+    throw error
+  }
+}
+
+func encodeTatamiConfig(_ config: AppConfig) throws -> Data {
+  @Dependency(\.errorReporter) var reporter
+  do {
+    let encoder = TOMLEncoder()
+    encoder.outputFormatting = [.sortedKeys]
+    let data = try encoder.encode(config)
+    reporter.resolve("ConfigSave")
+    return data
+  } catch {
+    reporter.report(
+      "ConfigSave",
+      String(localized: "config.toml could not be saved"),
+      ErrorReportClient.describe(error),
+    )
+    throw error
   }
 }

--- a/TatamiTests/Sources/AppFeatureTests.swift
+++ b/TatamiTests/Sources/AppFeatureTests.swift
@@ -6,10 +6,12 @@ import Foundation
 import Testing
 @testable import TatamiKit
 
+// MARK: - WorkspaceListFeatureTests
+
 @MainActor
 struct WorkspaceListFeatureTests {
   @Test
-  func addingWorkspaceAppendsToActiveProfile() async throws {
+  func `adding workspace appends to active profile`() async {
     let store = TestStore(initialState: WorkspaceListFeature.State()) {
       WorkspaceListFeature()
     }
@@ -26,17 +28,754 @@ struct WorkspaceListFeatureTests {
 
     #expect(store.state.workspaces.contains(where: { $0.name == "Focus" }))
   }
+
+  @Test
+  func `duplicating workspace copies layout selects clone and clears shortcuts`() async throws {
+    let shortcut = try #require(HotKey(parsing: "ctrl + alt - f"))
+    let workspace = Workspace(
+      name: "Focus",
+      activateShortcut: shortcut,
+      assignAppShortcut: shortcut,
+      keyEquivalent: "f",
+      borrowShortcut: shortcut,
+    )
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let snapshot = LayoutSnapshot(
+      tree: .leaf(BSPLeaf(windowList: [SlotID(bundleId: "com.example.App", occurrence: 0)]))
+    )
+    let saved = LockIsolated<[Workspace.ID: LayoutSnapshot]>([:])
+    var state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile], activeProfileId: profile.id))
+    state.topSelection = .profile(profile.id)
+    state.selection = .workspace(workspace.id)
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { mapping in
+        for (source, destination) in mapping where source == workspace.id {
+          saved.withValue { $0[destination] = snapshot }
+        }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicateWorkspaceTapped(workspace.id))
+    #expect(store.state.duplicationReview?.id == .workspace(workspace.id))
+    #expect(store.state.config.profiles[0].workspaces.count == 1)
+    await store.send(.duplicationReviewConfirmed(excluding: []))
+    let duplicateID = LockIsolated<Workspace.ID?>(nil)
+    await store.receive {
+      guard
+        case .duplicationPrepared(let preparation) = $0,
+        case .workspace(let receivedID) = preparation.target
+      else { return false }
+      duplicateID.setValue(receivedID)
+      return preparation.selectionRevision == 0 && preparation.layoutCopied
+    }
+    await store.receive {
+      guard case .delegate(.profilesChanged) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard
+        case .selectDuplicateIfUnchanged(
+          .workspace(let receivedID),
+          selectionRevision: 0,
+        ) = $0
+      else { return false }
+      return receivedID == duplicateID.value
+    }
+    await store.finish()
+
+    let duplicateId = try #require(duplicateID.value)
+    #expect(store.state.selection == .workspace(duplicateId))
+    let duplicate = try #require(store.state.config.workspace(id: duplicateId))
+    #expect(duplicate.name == "Focus copy")
+    #expect(duplicate.keyEquivalent == nil)
+    #expect(duplicate.activateShortcut == nil)
+    #expect(duplicate.assignAppShortcut == nil)
+    #expect(duplicate.borrowShortcut == nil)
+    #expect(saved.value[duplicateId] == snapshot)
+  }
+
+  @Test
+  func `workspace duplicate applies chooser exclusions and never offers shortcut identity`() async throws {
+    let shortcut = try #require(HotKey(parsing: "ctrl + alt - f"))
+    let keptApp = AppAssignment(bundleIdentifier: "com.example.Kept", name: "Kept")
+    let skippedApp = AppAssignment(bundleIdentifier: "com.example.Skipped", name: "Skipped")
+    let workspace = Workspace(
+      name: "Focus",
+      displayHint: DisplayName("Studio Display"),
+      activateShortcut: shortcut,
+      assignAppShortcut: shortcut,
+      symbolIconName: "hammer",
+      keyEquivalent: "f",
+      borrowShortcut: shortcut,
+      borrowEdge: .left,
+      apps: [keptApp, skippedApp],
+    )
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let layoutCopyCount = LockIsolated(0)
+    let state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile]))
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in
+        layoutCopyCount.withValue { $0 += 1 }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicateWorkspaceTapped(workspace.id))
+    await store.send(.duplicationReviewConfirmed(excluding: [
+      WorkspaceListFeature.DuplicationOptionID.app(skippedApp.bundleIdentifier, in: workspace.id),
+      WorkspaceListFeature.DuplicationOptionID.field("displayHint", in: workspace.id),
+      WorkspaceListFeature.DuplicationOptionID.layout(workspace.id),
+    ]))
+    let duplicateID = LockIsolated<Workspace.ID?>(nil)
+    await store.receive {
+      guard
+        case .duplicationPrepared(let preparation) = $0,
+        case .workspace(let id) = preparation.target
+      else { return false }
+      duplicateID.setValue(id)
+      return preparation.layoutCopied && preparation.newWorkspaceIDs.isEmpty
+    }
+    await store.receive {
+      guard case .delegate(.profilesChanged) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .selectDuplicateIfUnchanged = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    let id = try #require(duplicateID.value)
+    let duplicate = try #require(store.state.config.workspace(id: id))
+    #expect(duplicate.apps.map(\.bundleIdentifier) == [keptApp.bundleIdentifier])
+    #expect(duplicate.displayHint == nil)
+    #expect(duplicate.symbolIconName == workspace.symbolIconName)
+    #expect(duplicate.borrowEdge == workspace.borrowEdge)
+    #expect(duplicate.keyEquivalent == nil)
+    #expect(duplicate.activateShortcut == nil)
+    #expect(duplicate.assignAppShortcut == nil)
+    #expect(duplicate.borrowShortcut == nil)
+    #expect(layoutCopyCount.value == 0)
+  }
+
+  @Test
+  func `profile duplicate selects workspaces content and layout while retaining workspace shortcuts`() async throws {
+    let activateShortcut = try #require(HotKey(parsing: "cmd - 1"))
+    let assignShortcut = try #require(HotKey(parsing: "cmd - 2"))
+    let borrowShortcut = try #require(HotKey(parsing: "cmd - 3"))
+    let profileShortcut = try #require(HotKey(parsing: "cmd - p"))
+    let app = AppAssignment(bundleIdentifier: "com.example.App", name: "Example")
+    let included = Workspace(
+      name: "Focus",
+      activateShortcut: activateShortcut,
+      assignAppShortcut: assignShortcut,
+      keyEquivalent: "f",
+      borrowShortcut: borrowShortcut,
+      apps: [app],
+    )
+    let excluded = Workspace(name: "Browse")
+    let profile = Profile(
+      name: "Default",
+      symbolIconName: "rectangle.stack.fill",
+      shortcut: profileShortcut,
+      autoActivation: ProfileActivation(),
+      workspaces: [included, excluded],
+    )
+    let layoutCopyCount = LockIsolated(0)
+    let state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile]))
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in
+        layoutCopyCount.withValue { $0 += 1 }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicateProfileTapped(profile.id))
+    await store.send(.duplicationReviewConfirmed(excluding: [
+      WorkspaceListFeature.DuplicationOptionID.app(app.bundleIdentifier, in: included.id),
+      WorkspaceListFeature.DuplicationOptionID.layout(included.id),
+      WorkspaceListFeature.DuplicationOptionID.includeWorkspace(excluded.id),
+    ]))
+    let duplicateID = LockIsolated<Profile.ID?>(nil)
+    await store.receive {
+      guard
+        case .duplicationPrepared(let preparation) = $0,
+        case .profile(let id) = preparation.target
+      else { return false }
+      duplicateID.setValue(id)
+      return preparation.layoutCopied && preparation.newWorkspaceIDs.isEmpty
+    }
+    await store.receive {
+      guard case .delegate(.profilesChanged) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .selectDuplicateIfUnchanged = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    let clone = try #require(store.state.config.profiles.first { $0.id == duplicateID.value })
+    let clonedWorkspace = try #require(clone.workspaces.first)
+    #expect(clone.workspaces.count == 1)
+    #expect(clonedWorkspace.name == included.name)
+    #expect(clonedWorkspace.apps.isEmpty)
+    #expect(clonedWorkspace.keyEquivalent == included.keyEquivalent)
+    #expect(clonedWorkspace.activateShortcut == included.activateShortcut)
+    #expect(clonedWorkspace.assignAppShortcut == included.assignAppShortcut)
+    #expect(clonedWorkspace.borrowShortcut == included.borrowShortcut)
+    #expect(clone.symbolIconName == profile.symbolIconName)
+    #expect(clone.shortcut == nil)
+    #expect(clone.autoActivation == nil)
+    #expect(layoutCopyCount.value == 0)
+  }
+
+  @Test
+  func `profile duplicate chooser exposes selective shortcut conflict and refuses confirmation`() async throws {
+    let explicit = try #require(HotKey(parsing: "cmd - x"))
+    let derived = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let workspace = Workspace(
+      name: "Focus",
+      activateShortcut: explicit,
+      keyEquivalent: "a"
+    )
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    settings.shortcuts.focusLeft = derived
+    let state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile], settings: settings))
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    }
+    store.exhaustivity = .off
+    let excluded: Set<String> = [
+      WorkspaceListFeature.DuplicationOptionID.field(
+        WorkspaceShortcutField.activateShortcut.rawValue,
+        in: workspace.id
+      ),
+    ]
+
+    await store.send(.duplicateProfileTapped(profile.id))
+    let review = try #require(store.state.duplicationReview)
+    let conflictMap = WorkspaceListFeature.duplicationShortcutConflicts(
+      review: review,
+      excluding: excluded
+    )
+    let keyItemID = WorkspaceListFeature.DuplicationOptionID.field(
+      WorkspaceShortcutField.keyEquivalent.rawValue,
+      in: workspace.id
+    )
+    #expect(conflictMap[keyItemID]?.map(\.hotKey) == [derived])
+
+    await store.send(.duplicationReviewConfirmed(excluding: excluded))
+
+    #expect(store.state.config.profiles.count == 1)
+    #expect(store.state.pendingDuplications.isEmpty)
+    #expect(store.state.alert != nil)
+  }
+
+  @Test
+  func `duplicate revalidates shortcuts immediately before config commit`() async throws {
+    let explicit = try #require(HotKey(parsing: "cmd - x"))
+    let derived = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let workspace = Workspace(
+      name: "Focus",
+      activateShortcut: explicit,
+      keyEquivalent: "a"
+    )
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    settings.shortcuts.focusLeft = derived
+    let baseline = AppConfig(profiles: [profile], settings: settings)
+    var updated = baseline
+    let duplicationResult = updated.duplicateProfile(profile.id)
+    let result = try #require(duplicationResult)
+    let clonedWorkspaceID = try #require(result.workspaceIdMap[workspace.id])
+    updated.mutateWorkspace(clonedWorkspaceID) { $0.activateShortcut = nil }
+    var state = WorkspaceListFeature.State()
+    state.$config = Shared(value: baseline)
+    state.isDuplicationInFlight = true
+    state.projectedDuplicationConfig = updated
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicationPrepared(.init(
+      baseline: baseline,
+      configRevision: nil,
+      updated: updated,
+      target: .profile(result.profileId),
+      newWorkspaceIDs: [],
+      selectionRevision: 0,
+      layoutCopied: true,
+      shortcutSelections: [
+        .init(workspaceId: clonedWorkspaceID, field: .keyEquivalent),
+      ]
+    )))
+
+    #expect(store.state.config == baseline)
+    #expect(store.state.alert != nil)
+    #expect(store.state.projectedDuplicationConfig == nil)
+  }
+
+  @Test
+  func `duplicating an empty profile still publishes and selects the clone`() async throws {
+    let profile = Profile(name: "Empty")
+    var state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile], activeProfileId: profile.id))
+    state.topSelection = .profile(profile.id)
+    state.selection = .profileSettings
+    state.profileDetail = ProfileDetailFeature.State(profileId: profile.id)
+    let copiedMappings = LockIsolated<[[Workspace.ID: Workspace.ID]]>([])
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { mapping in
+        copiedMappings.withValue { $0.append(mapping) }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+    let cloneID = LockIsolated<Profile.ID?>(nil)
+
+    await store.send(.duplicateProfileTapped(profile.id))
+    #expect(store.state.duplicationReview?.id == .profile(profile.id))
+    #expect(store.state.config.profiles.count == 1)
+    await store.send(.duplicationReviewConfirmed(excluding: []))
+    await store.receive {
+      guard
+        case .duplicationPrepared(let preparation) = $0,
+        case .profile(let id) = preparation.target
+      else { return false }
+      cloneID.setValue(id)
+      return preparation.layoutCopied
+    }
+    await store.receive {
+      guard case .delegate(.profilesChanged) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .selectDuplicateIfUnchanged(.profile(let id), selectionRevision: 0) = $0
+      else { return false }
+      return id == cloneID.value
+    }
+    await store.finish()
+
+    let id = try #require(cloneID.value)
+    #expect(copiedMappings.value.isEmpty)
+    #expect(store.state.config.profiles.first(where: { $0.id == id })?.name == "Empty copy")
+    #expect(store.state.topSelection == .profile(id))
+    #expect(store.state.profileDetail?.profileId == id)
+  }
+
+  @Test
+  func `rename draft commits trimmed and escape keeps original`() async {
+    let workspace = Workspace(name: "Focus")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile], activeProfileId: profile.id))
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.renameRequested(.workspace(workspace.id)))
+    await store.send(.renameDraftChanged("  Build  "))
+    #expect(store.state.config.workspace(id: workspace.id)?.name == "Focus")
+    await store.send(.renameSubmitted)
+    #expect(store.state.config.workspace(id: workspace.id)?.name == "Build")
+
+    await store.send(.renameRequested(.profile(profile.id)))
+    await store.send(.renameDraftChanged("Discarded"))
+    await store.send(.renameCancelled)
+    #expect(store.state.config.profiles.first?.name == "Default")
+    #expect(store.state.renameSession == nil)
+  }
+
+  @Test
+  func `renaming the selected item preserves loaded detail state`() async {
+    let workspace = Workspace(name: "Focus")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    var state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile], activeProfileId: profile.id))
+    state.topSelection = .profile(profile.id)
+    state.selection = .workspace(workspace.id)
+    state.detail = WorkspaceDetailFeature.State(workspaceId: workspace.id)
+    state.detail?.layout.snapshotLoadedFor = workspace.id
+    state.detail?.layout.windowInfoLoadedFor = workspace.id
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.renameRequested(.workspace(workspace.id)))
+
+    #expect(store.state.detail?.layout.snapshotLoadedFor == workspace.id)
+    #expect(store.state.detail?.layout.windowInfoLoadedFor == workspace.id)
+  }
+
+  @Test
+  func `delayed duplicate selection does not override newer navigation`() async {
+    let workspace = Workspace(name: "Focus")
+    let first = Profile(name: "Default", workspaces: [workspace])
+    let second = Profile(name: "Dual")
+    var state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [first, second],
+      activeProfileId: first.id,
+    ))
+    state.topSelection = .profile(first.id)
+    state.selection = .workspace(workspace.id)
+    state.detail = WorkspaceDetailFeature.State(workspaceId: workspace.id)
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in
+        try? await Task.sleep(for: .milliseconds(50))
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicateWorkspaceTapped(workspace.id))
+    await store.send(.duplicationReviewConfirmed(excluding: []))
+    await store.send(.topSelected(.profile(second.id)))
+    await store.receive {
+      guard case .sidebarSelected(.profileSettings) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .duplicationPrepared(let preparation) = $0 else { return false }
+      return preparation.selectionRevision == 0 && preparation.layoutCopied
+    }
+    await store.receive {
+      guard case .delegate(.profilesChanged) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .selectDuplicateIfUnchanged(_, selectionRevision: 0) = $0
+      else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.topSelection == .profile(second.id))
+    #expect(store.state.selection == .profileSettings)
+    #expect(store.state.profileDetail?.profileId == second.id)
+    #expect(store.state.detail == nil)
+  }
+
+  @Test
+  func `duplicate review rejects configuration changes after the chooser opened`() async {
+    let workspace = Workspace(name: "Focus")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let shared = Shared(value: AppConfig(profiles: [profile]))
+    let state = WorkspaceListFeature.State()
+    state.$config = shared
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicateWorkspaceTapped(workspace.id))
+    shared.withLock { $0.mutateWorkspace(workspace.id) { $0.name = "Changed elsewhere" } }
+    await store.send(.duplicationReviewConfirmed(excluding: [
+      WorkspaceListFeature.DuplicationOptionID.layout(workspace.id),
+    ]))
+    await store.receive {
+      guard case .duplicationPrepared(let preparation) = $0 else { return false }
+      return preparation.layoutCopied
+    }
+    await store.finish()
+
+    #expect(store.state.config.profiles[0].workspaces.count == 1)
+    #expect(store.state.config.workspace(id: workspace.id)?.name == "Changed elsewhere")
+    #expect(store.state.projectedDuplicationConfig == nil)
+  }
+
+  @Test
+  func `failed duplicate chain closes a later chooser and drops dependent work`() async throws {
+    let workspace = Workspace(name: "Focus")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let baseline = AppConfig(profiles: [profile])
+    var updated = baseline
+    let duplicateCandidate = updated.duplicateWorkspace(workspace.id)
+    let duplicateID = try #require(duplicateCandidate)
+    var state = WorkspaceListFeature.State()
+    state.$config = Shared(value: baseline)
+    state.isDuplicationInFlight = true
+    state.pendingDuplications = [WorkspaceListFeature.PendingDuplication(
+      baseline: updated,
+      updated: updated,
+      target: .workspace(duplicateID),
+      layoutMapping: [:],
+      selectionRevision: 0,
+    )]
+    state.projectedDuplicationConfig = updated
+    state.duplicationReview = WorkspaceListFeature.DuplicationReview(
+      source: .workspace(workspace),
+      baseline: baseline,
+    )
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicationPrepared(WorkspaceListFeature.DuplicationPreparation(
+      baseline: baseline,
+      configRevision: nil,
+      updated: updated,
+      target: .workspace(duplicateID),
+      newWorkspaceIDs: [duplicateID],
+      selectionRevision: 0,
+      layoutCopied: false,
+    )))
+
+    #expect(store.state.isDuplicationInFlight == false)
+    #expect(store.state.pendingDuplications.isEmpty)
+    #expect(store.state.projectedDuplicationConfig == nil)
+    #expect(store.state.duplicationReview == nil)
+  }
+
+  @Test
+  func `rapid duplicate requests are serialized and both commit`() async {
+    let workspace = Workspace(name: "Focus")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    var state = WorkspaceListFeature.State()
+    state.$config = Shared(value: AppConfig(profiles: [profile], activeProfileId: profile.id))
+    state.topSelection = .profile(profile.id)
+    state.selection = .workspace(workspace.id)
+    state.detail = WorkspaceDetailFeature.State(workspaceId: workspace.id)
+    let copyCount = LockIsolated(0)
+    let store = TestStore(initialState: state) {
+      WorkspaceListFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in
+        let call = copyCount.withValue { count -> Int in
+          count += 1
+          return count
+        }
+        if call == 1 { try? await Task.sleep(for: .milliseconds(50)) }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.duplicateWorkspaceTapped(workspace.id))
+    await store.send(.duplicationReviewConfirmed(excluding: []))
+    await store.send(.duplicateWorkspaceTapped(workspace.id))
+    await store.send(.duplicationReviewConfirmed(excluding: []))
+    for _ in 0 ..< 2 {
+      await store.receive {
+        guard case .duplicationPrepared = $0 else { return false }
+        return true
+      }
+      await store.receive {
+        guard case .delegate(.profilesChanged) = $0 else { return false }
+        return true
+      }
+      await store.receive {
+        guard case .selectDuplicateIfUnchanged = $0 else { return false }
+        return true
+      }
+    }
+    await store.finish()
+
+    #expect(copyCount.value == 2)
+    #expect(store.state.config.activeProfile?.workspaces.map(\.name) == [
+      "Focus",
+      "Focus copy 2",
+      "Focus copy",
+    ])
+    guard case .workspace(let selectedID) = store.state.selection else {
+      Issue.record("Expected the last duplicate to remain selected")
+      return
+    }
+    #expect(store.state.config.workspace(id: selectedID)?.name == "Focus copy 2")
+  }
 }
+
+// MARK: - AppConfigDuplicationTests
+
+struct AppConfigDuplicationTests {
+  @Test
+  func `workspace copies use unique finder names and fresh I ds`() throws {
+    let shortcut = try #require(HotKey(parsing: "ctrl + alt - f"))
+    let app = AppAssignment(
+      bundleIdentifier: "com.example.App",
+      name: "Example",
+      autoOpen: true,
+      layout: .floating,
+    )
+    let source = Workspace(
+      name: "Focus",
+      displayHint: DisplayName("Studio Display"),
+      activateShortcut: shortcut,
+      assignAppShortcut: shortcut,
+      symbolIconName: "hammer",
+      appToFocusBundleId: app.bundleIdentifier,
+      kind: .scratchpad,
+      keyEquivalent: "f",
+      borrowShortcut: shortcut,
+      borrowEdge: .left,
+      borrowFraction: 0.3,
+      apps: [app],
+    )
+    var config = AppConfig(profiles: [Profile(name: "Default", workspaces: [source])])
+
+    let firstCandidate = config.duplicateWorkspace(source.id)
+    let firstId = try #require(firstCandidate)
+    let secondCandidate = config.duplicateWorkspace(source.id)
+    let secondId = try #require(secondCandidate)
+    let first = try #require(config.workspace(id: firstId))
+    let second = try #require(config.workspace(id: secondId))
+
+    #expect(first.id != source.id)
+    #expect(second.id != source.id)
+    #expect(first.id != second.id)
+    #expect(first.name == "Focus copy")
+    #expect(second.name == "Focus copy 2")
+    #expect(first.displayHint == source.displayHint)
+    #expect(first.symbolIconName == source.symbolIconName)
+    #expect(first.appToFocusBundleId == source.appToFocusBundleId)
+    #expect(first.kind == source.kind)
+    #expect(first.borrowEdge == source.borrowEdge)
+    #expect(first.borrowFraction == source.borrowFraction)
+    #expect(first.apps == source.apps)
+    #expect(first.keyEquivalent == nil)
+    #expect(first.activateShortcut == nil)
+    #expect(first.assignAppShortcut == nil)
+    #expect(first.borrowShortcut == nil)
+  }
+
+  @Test
+  func `profile duplicate deep copies I ds and select metadata for empty profiles`() throws {
+    let workspace = Workspace(name: "Focus")
+    let populated = Profile(name: "Default", workspaces: [workspace])
+    let empty = Profile(name: "Empty")
+    var config = AppConfig(profiles: [populated, empty])
+
+    let populatedCandidate = config.duplicateProfile(populated.id)
+    let populatedResult = try #require(populatedCandidate)
+    let populatedClone = try #require(
+      config.profiles.first(where: { $0.id == populatedResult.profileId })
+    )
+    let clonedWorkspace = try #require(populatedClone.workspaces.first)
+    #expect(populatedClone.name == "Default copy")
+    #expect(populatedClone.id != populated.id)
+    #expect(clonedWorkspace.id != workspace.id)
+    #expect(populatedResult.workspaceIdMap[workspace.id] == clonedWorkspace.id)
+
+    let emptyCandidate = config.duplicateProfile(empty.id)
+    let emptyResult = try #require(emptyCandidate)
+    #expect(emptyResult.workspaceIdMap.isEmpty)
+    #expect(config.profiles.contains(where: { $0.id == emptyResult.profileId }))
+  }
+}
+
+// MARK: - ProfileCopyTransactionTests
+
+@MainActor
+struct ProfileCopyTransactionTests {
+  @Test
+  func `external writer after revision capture rejects profile copy`() async {
+    let sourceWorkspace = Workspace(name: "Browser", symbolIconName: "star")
+    let targetWorkspace = Workspace(name: "Browser", symbolIconName: "bolt")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    let baseline = AppConfig(profiles: [target, source])
+    let commitAttempts = LockIsolated(0)
+    let state = ProfileDetailFeature.State(profileId: target.id)
+    state.$config = Shared(value: baseline)
+    let store = TestStore(initialState: state) {
+      ProfileDetailFeature()
+    } withDependencies: {
+      $0.configPersistence.captureRevision = { expected in
+        #expect(expected == baseline)
+        return Data("reviewed-revision".utf8)
+      }
+      $0.configPersistence.commit = { _, _, _, _, _ in
+        commitAttempts.withValue { $0 += 1 }
+        throw ConfigPersistenceError.changedOnDisk
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.applyProfileSync(
+      target: target.id,
+      source: source.id,
+      baseline: baseline,
+      excludedApps: [:],
+      excludedFields: [:]
+    ))
+    await store.finish()
+
+    #expect(commitAttempts.value == 1)
+    #expect(store.state.config == baseline)
+    #expect(store.state.config.workspace(id: targetWorkspace.id)?.symbolIconName == "bolt")
+    #expect(store.state.alert != nil)
+  }
+
+  @Test
+  func `profile copy rejects source changes after review opens`() async {
+    let sourceWorkspace = Workspace(name: "Browser", symbolIconName: "star")
+    let targetWorkspace = Workspace(name: "Browser", symbolIconName: "bolt")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    let baseline = AppConfig(profiles: [target, source])
+    var changed = baseline
+    changed.mutateWorkspace(sourceWorkspace.id) { $0.symbolIconName = "heart" }
+    let state = ProfileDetailFeature.State(profileId: target.id)
+    state.$config = Shared(value: changed)
+    let store = TestStore(initialState: state) {
+      ProfileDetailFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.applyProfileSync(
+      target: target.id,
+      source: source.id,
+      baseline: baseline,
+      excludedApps: [:],
+      excludedFields: [:]
+    ))
+    await store.finish()
+
+    #expect(store.state.config == changed)
+    #expect(store.state.config.workspace(id: targetWorkspace.id)?.symbolIconName == "bolt")
+    #expect(store.state.alert != nil)
+  }
+}
+
+// MARK: - GestureRoutingTests
 
 @MainActor
 struct GestureRoutingTests {
   @Test
-  func configuredGestureRoutesThroughTheSharedTatamiCommandPath() async {
+  func `configured gesture routes through the shared tatami command path`() async {
     let state = AppFeature.State()
     state.$config.withLock {
       $0.settings.gestures = AppSettings.Gestures(
         enabled: true,
-        fourFinger: .init(up: .toggleFullscreen)
+        fourFinger: .init(up: .toggleFullscreen),
       )
     }
     let store = TestStore(initialState: state) {
@@ -52,7 +791,7 @@ struct GestureRoutingTests {
   }
 
   @Test
-  func onboardingRoutesTheRealRecognizerIntoTheSafePreview() async {
+  func `onboarding routes the real recognizer into the safe preview`() async {
     let first = Workspace(name: "Focus")
     let second = Workspace(name: "Browse")
     let profile = Profile(name: "Default", workspaces: [first, second])
@@ -78,14 +817,15 @@ struct GestureRoutingTests {
     #expect(store.state.onboarding.demoLastGesture == gesture)
     #expect(store.state.onboarding.demoActiveWorkspaceID == second.id)
   }
-
 }
+
+// MARK: - WindowCycleShortcutRoutingTests
 
 @MainActor
 @Suite(.serialized)
 struct WindowCycleShortcutRoutingTests {
   @Test
-  func hotKeyPreservesItsHoldModifierForTheCycleSession() async throws {
+  func `hot key preserves its hold modifier for the cycle session`() async {
     let state = AppFeature.State()
     state.$config.withLock {
       $0.settings.shortcuts.cycleNextWindow = HotKey(parsing: "alt - tab")
@@ -105,7 +845,7 @@ struct WindowCycleShortcutRoutingTests {
   }
 
   @Test
-  func workspaceGestureSwitchesToTheOwningProfile() async {
+  func `workspace gesture switches to the owning profile`() async {
     let currentWorkspace = Workspace(name: "Current")
     let targetWorkspace = Workspace(name: "Target")
     let currentProfile = Profile(name: "Default", workspaces: [currentWorkspace])
@@ -116,7 +856,7 @@ struct WindowCycleShortcutRoutingTests {
       $0.activeProfileId = currentProfile.id
       $0.settings.gestures = AppSettings.Gestures(
         enabled: true,
-        fourFinger: .init(up: .activateWorkspace(targetWorkspace.id))
+        fourFinger: .init(up: .activateWorkspace(targetWorkspace.id)),
       )
     }
     let store = TestStore(initialState: state) {
@@ -134,5 +874,472 @@ struct WindowCycleShortcutRoutingTests {
       return id == targetProfile.id && focus == targetWorkspace.id
     }
     #expect(store.state.config.activeProfileId == targetProfile.id)
+  }
+}
+
+// MARK: - CLIActionRoutingTests
+
+@MainActor
+struct CLIDomainCommandRoutingTests {
+  @Test
+  func `CLI domain command reuses the gesture and hotkey dispatcher before acknowledging`() async {
+    let completions = LockIsolated<[String?]>([])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cli(.delegate(.dispatchDomainCommandRequested(
+      .focusLeft,
+      complete: { error in completions.withValue { $0.append(error) } },
+    ))))
+    await store.receive {
+      guard case .activation(.bspFocus(.west)) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(completions.value == [nil])
+  }
+
+  @Test
+  func `CLI targeted domain command is revalidated immediately before dispatch`() async {
+    let completions = LockIsolated<[String?]>([])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cli(.delegate(.dispatchDomainCommandRequested(
+      .activateWorkspace(UUID()),
+      complete: { error in completions.withValue { $0.append(error) } },
+    ))))
+    await store.finish()
+
+    #expect(completions.value == ["The requested workspace no longer exists"])
+  }
+}
+
+// MARK: - CLIActivationRoutingTests
+
+@MainActor
+@Suite("CLI activation routing", .serialized)
+struct CLIActivationRoutingTests {
+  @Test
+  func `deleted profile request fails without entering activation tracking`() async {
+    let missingProfileID = UUID()
+    let completions = LockIsolated<[String?]>([])
+    let store = TestStore(initialState: AppFeature.State()) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cli(.delegate(.activateProfileRequested(
+      missingProfileID,
+      complete: { error in completions.withValue { $0.append(error) } },
+    ))))
+    await store.finish()
+
+    #expect(completions.value == ["The requested profile no longer exists"])
+    #expect(store.state.activation.pendingCLIActivation == nil)
+  }
+
+  @Test
+  func `profile removed after tracking completes the pending request exactly once`() async {
+    let removedProfileID = UUID()
+    let completions = LockIsolated<[String?]>([])
+    let request = WorkspaceActivationFeature.CLIActivationRequest(
+      target: .profile(removedProfileID),
+      complete: { error in completions.withValue { $0.append(error) } },
+    )
+    var state = AppFeature.State()
+    state.activation.pendingCLIActivation = request
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.activateProfile(removedProfileID, focus: nil))
+    await store.finish()
+    await store.send(.activateProfile(removedProfileID, focus: nil))
+    await store.finish()
+
+    #expect(completions.value == ["The requested profile no longer exists"])
+    #expect(store.state.activation.pendingCLIActivation == nil)
+  }
+
+  @Test
+  func `same profile request joins the in flight activation tail`() async {
+    let display = DisplayName("Main")
+    let workspace = Workspace(name: "Work")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let sharedConfig = Shared(value: AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+    var state = AppFeature.State()
+    state.$config = sharedConfig
+    state.activation.$config = sharedConfig
+    state.activation.isActivating = true
+    state.activation.activationGeneration = 1
+    state.activation.activeActivationGeneration = 1
+    let completions = LockIsolated<[String?]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cli(.delegate(.activateProfileRequested(
+      profile.id,
+      complete: { error in completions.withValue { $0.append(error) } },
+    ))))
+    #expect(completions.value.isEmpty)
+
+    await store.send(.activation(.activationCompleted(
+      workspaceId: workspace.id,
+      display: display,
+      generation: 1,
+    )))
+    #expect(completions.value.isEmpty)
+    await store.send(.activation(.activationTailFinished(generation: 1)))
+    await store.finish()
+
+    #expect(completions.value == [nil])
+  }
+
+  @Test
+  func `same profile request joins the core completion to tail gap`() async {
+    let workspace = Workspace(name: "Work")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let sharedConfig = Shared(value: AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+    var state = AppFeature.State()
+    state.$config = sharedConfig
+    state.activation.$config = sharedConfig
+    state.activation.activationGeneration = 1
+    state.activation.activeActivationGeneration = 1
+    let completions = LockIsolated<[String?]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cli(.delegate(.activateProfileRequested(
+      profile.id,
+      complete: { error in completions.withValue { $0.append(error) } },
+    ))))
+    #expect(completions.value.isEmpty)
+
+    await store.send(.activation(.activationTailFinished(generation: 1)))
+    await store.finish()
+
+    #expect(completions.value == [nil])
+  }
+
+  @Test
+  func `stale core completion neither mutates activation nor emits workspace hook`() async {
+    let display = DisplayName("Main")
+    let current = Workspace(name: "Current")
+    let stale = Workspace(name: "Stale")
+    let profile = Profile(name: "Default", workspaces: [current, stale])
+    let hook = HookDefinition(
+      id: "workspace",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    let sharedConfig = Shared(value: AppConfig(
+      profiles: [profile],
+      hooks: [hook],
+      activeProfileId: profile.id,
+    ))
+    var state = AppFeature.State()
+    state.$config = sharedConfig
+    state.activation.$config = sharedConfig
+    state.hooks.$config = sharedConfig
+    state.activation.isActivating = true
+    state.activation.activationGeneration = 2
+    state.activation.activeActivationGeneration = 2
+    state.activation.activeWorkspacesByDisplay[display] = current.id
+    let hookRuns = LockIsolated(0)
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.hookRunner.run = { _, _ in
+        hookRuns.withValue { $0 += 1 }
+        return .success(stdout: "", stderr: "")
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.activation(.activationCompleted(
+      workspaceId: stale.id,
+      display: display,
+      generation: 1,
+    )))
+    await store.finish()
+
+    #expect(store.state.activation.isActivating)
+    #expect(store.state.activation.activeActivationGeneration == 2)
+    #expect(store.state.activation.activeWorkspacesByDisplay[display] == current.id)
+    #expect(hookRuns.value == 0)
+  }
+
+  @Test
+  func `workspace reply waits for the focus effect to finish`() async {
+    let display = DisplayName("Main")
+    let workspace = Workspace(name: "CLI")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let window = WindowKey(pid: 1, windowID: 101, bundleId: "app.cli")
+    var state = AppFeature.State()
+    let sharedConfig = Shared(value: AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+    state.$config = sharedConfig
+    state.activation.$config = sharedConfig
+    state.activation.activeWorkspacesByDisplay[display] = workspace.id
+    state.activation.focusedDisplay = display
+    state.activation.tilingTrees[workspace.id] = .leaf(window)
+    let completions = LockIsolated<[String?]>([])
+    let (focusGate, focusGateContinuation) = AsyncStream<Void>.makeStream()
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.displays.current = { display }
+      $0.focusManager.focusWindow = { _ in
+        for await _ in focusGate { break }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cli(.delegate(.activateWorkspaceRequested(
+      workspace.id,
+      complete: { error in completions.withValue { $0.append(error) } },
+    ))))
+    #expect(completions.value.isEmpty)
+
+    focusGateContinuation.yield(())
+    focusGateContinuation.finish()
+    await store.finish()
+
+    #expect(completions.value == [nil])
+  }
+}
+
+// MARK: - HotKeyRegistrationRefreshTests
+
+@MainActor
+@Suite("Hot key registration refresh", .serialized)
+struct HotKeyRegistrationRefreshTests {
+  @Test
+  func `external writer after revision capture rejects workspace copy`() async {
+    let sourceWorkspace = Workspace(name: "Source", symbolIconName: "star")
+    let targetWorkspace = Workspace(name: "Target", symbolIconName: "bolt")
+    let sourceProfile = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let targetProfile = Profile(name: "Target", workspaces: [targetWorkspace])
+    let baseline = AppConfig(profiles: [targetProfile, sourceProfile])
+    let registrations = LockIsolated<[[HotKeyBinding]]>([])
+    let commitAttempts = LockIsolated(0)
+    var state = AppFeature.State()
+    state.$config.withLock { $0 = baseline }
+    state.workspaceList.detail = WorkspaceDetailFeature.State(
+      workspaceId: targetWorkspace.id
+    )
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.configPersistence.captureRevision = { expected in
+        #expect(expected == baseline)
+        return Data("reviewed-revision".utf8)
+      }
+      $0.configPersistence.commit = { _, _, _, _, _ in
+        commitAttempts.withValue { $0 += 1 }
+        throw ConfigPersistenceError.changedOnDisk
+      }
+      $0.hotKeys.register = { bindings in
+        registrations.withValue { $0.append(bindings) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaceList(.detail(.importWorkspace(
+      targetWorkspace: targetWorkspace.id,
+      sourceProfile: sourceProfile.id,
+      sourceWorkspace: sourceWorkspace.id,
+      baseline: baseline,
+      excludingApps: [],
+      excludingFields: []
+    ))))
+    await store.finish()
+
+    #expect(commitAttempts.value == 1)
+    #expect(registrations.value.isEmpty)
+    #expect(store.state.config == baseline)
+    #expect(store.state.workspaceList.detail?.alert != nil)
+  }
+
+  @Test
+  func `rejected workspace copy does not refresh or reactivate`() async {
+    let copiedApp = AppAssignment(bundleIdentifier: "copied", name: "Copied")
+    let sourceWorkspace = Workspace(name: "Source", apps: [copiedApp])
+    let targetWorkspace = Workspace(name: "Target")
+    let profile = Profile(name: "Default", workspaces: [targetWorkspace, sourceWorkspace])
+    let baseline = AppConfig(profiles: [profile], activeProfileId: profile.id)
+    var changed = baseline
+    changed.mutateWorkspace(sourceWorkspace.id) { $0.symbolIconName = "star" }
+    let registrations = LockIsolated<[[HotKeyBinding]]>([])
+    var state = AppFeature.State()
+    state.$config.withLock { $0 = changed }
+    state.workspaceList.detail = WorkspaceDetailFeature.State(
+      workspaceId: targetWorkspace.id
+    )
+    state.activation.activeWorkspacesByDisplay["Built-in"] = targetWorkspace.id
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.hotKeys.register = { bindings in
+        registrations.withValue { $0.append(bindings) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaceList(.detail(.importWorkspace(
+      targetWorkspace: targetWorkspace.id,
+      sourceProfile: profile.id,
+      sourceWorkspace: sourceWorkspace.id,
+      baseline: baseline,
+      excludingApps: [],
+      excludingFields: []
+    ))))
+    await store.finish()
+
+    #expect(registrations.value.isEmpty)
+    #expect(store.state.activation.activeActivationGeneration == nil)
+    #expect(store.state.config == changed)
+    #expect(store.state.workspaceList.detail?.alert != nil)
+  }
+
+  @Test
+  func `successful workspace copy delegates one hot key refresh`() async {
+    let sourceWorkspace = Workspace(name: "Source", keyEquivalent: "a")
+    let targetWorkspace = Workspace(name: "Target", keyEquivalent: "b")
+    let targetProfile = Profile(name: "Default", workspaces: [targetWorkspace])
+    let sourceProfile = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let baseline = AppConfig(
+      profiles: [targetProfile, sourceProfile],
+      activeProfileId: targetProfile.id
+    )
+    var current = baseline
+    current.activeProfileId = sourceProfile.id
+    let registrations = LockIsolated<[[HotKeyBinding]]>([])
+    var state = AppFeature.State()
+    state.$config.withLock { $0 = current }
+    state.workspaceList.detail = WorkspaceDetailFeature.State(
+      workspaceId: targetWorkspace.id
+    )
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.hotKeys.register = { bindings in
+        registrations.withValue { $0.append(bindings) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaceList(.detail(.importWorkspace(
+      targetWorkspace: targetWorkspace.id,
+      sourceProfile: sourceProfile.id,
+      sourceWorkspace: sourceWorkspace.id,
+      baseline: baseline,
+      excludingApps: [],
+      excludingFields: []
+    ))))
+    await store.finish()
+
+    #expect(registrations.value.count == 1)
+    #expect(store.state.config.workspace(id: targetWorkspace.id)?.keyEquivalent == "a")
+    #expect(store.state.config.activeProfileId == sourceProfile.id)
+  }
+
+  @Test
+  func `key equivalent and borrow shortcut changes refresh the registered bindings`() async throws {
+    let workspace = Workspace(name: "Focus")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let switchKey = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let borrowKey = try #require(HotKey(parsing: "ctrl + alt + cmd - b"))
+    let registrations = LockIsolated<[[HotKeyBinding]]>([])
+    var state = AppFeature.State()
+    state.$config.withLock {
+      $0 = AppConfig(profiles: [profile], activeProfileId: profile.id)
+    }
+    state.workspaceList.detail = WorkspaceDetailFeature.State(workspaceId: workspace.id)
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.hotKeys.register = { bindings in
+        registrations.withValue { $0.append(bindings) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaceList(.detail(.keyEquivalentChanged("a"))))
+    await store.finish()
+    #expect(registrations.value.count == 1)
+    #expect(
+      registrations.value.last?.contains {
+        $0.action == .activateWorkspace(workspace.id)
+          && $0.hotKey == switchKey
+      } == true
+    )
+
+    await store.send(.workspaceList(.detail(.borrowShortcutChanged(borrowKey))))
+    await store.finish()
+    #expect(registrations.value.count == 2)
+    #expect(
+      registrations.value.last?.contains {
+        $0.action == .borrowWorkspace(workspace.id) && $0.hotKey == borrowKey
+      } == true
+    )
+  }
+
+  @Test
+  func `confirmed workspace deletion refreshes without the deleted binding`() async throws {
+    let key = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let workspace = Workspace(name: "Focus", activateShortcut: key)
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let registrations = LockIsolated<[[HotKeyBinding]]>([])
+    var state = AppFeature.State()
+    state.$config.withLock {
+      $0 = AppConfig(profiles: [profile], activeProfileId: profile.id)
+    }
+    state.workspaceList.detail = WorkspaceDetailFeature.State(workspaceId: workspace.id)
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.hotKeys.register = { bindings in
+        registrations.withValue { $0.append(bindings) }
+      }
+      $0.layoutStore.clear = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.workspaceList(.workspaceDeleteRequested(workspace.id)))
+    #expect(registrations.value.isEmpty)
+
+    await store.send(
+      .workspaceList(.alert(.presented(.confirmDeletion(workspace.id))))
+    )
+    await store.finish()
+
+    #expect(registrations.value.count == 1)
+    let bindings = try #require(registrations.value.first)
+    #expect(
+      bindings.contains { $0.action == .activateWorkspace(workspace.id) } == false
+    )
   }
 }

--- a/TatamiTests/Sources/CLITests.swift
+++ b/TatamiTests/Sources/CLITests.swift
@@ -1,0 +1,866 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Foundation
+import Sharing
+import TatamiCLIProtocol
+import Testing
+@testable import TatamiKit
+
+// MARK: - CLIProtocolTests
+
+struct CLIProtocolTests {
+  @Test
+  func `empty revision is valid only for the recommended fresh seed`() throws {
+    let seed = AppConfig(settings: AppSettings(shortcuts: .recommended))
+    try validateConfigRevision(Data(), expected: seed)
+    try validateConfigRevision(nil, expected: seed)
+
+    let configured = AppConfig(profiles: [Profile(name: "Configured")])
+    #expect(throws: (any Error).self) {
+      try validateConfigRevision(Data(), expected: configured)
+    }
+    #expect(throws: (any Error).self) {
+      try validateConfigRevision(nil, expected: configured)
+    }
+  }
+
+  @Test
+  func `shared config uses the key's recommended fresh install seed`() {
+    withDependencies {
+      $0.defaultFileStorage = .inMemory
+    } operation: {
+      let state = CLIServerFeature.State()
+      #expect(state.config.settings.shortcuts == .recommended)
+    }
+  }
+
+  @Test
+  func `legacy request defaults additive fields`() throws {
+    let data = Data(#"{"command":"list-workspaces","arguments":[]}"#.utf8)
+
+    let request = try JSONDecoder().decode(CLIMessage.Request.self, from: data)
+
+    #expect(request.command == .listWorkspaces)
+    #expect(request.arguments.isEmpty)
+    #expect(request.options.isEmpty)
+    #expect(request.outputFormat == .plain)
+  }
+
+  @Test
+  func `legacy response is explicitly distinguishable from JSON capability`() throws {
+    let data = Data(#"{"success":true,"output":"Browser"}"#.utf8)
+
+    let response = try JSONDecoder().decode(CLIMessage.Response.self, from: data)
+
+    #expect(response.outputFormat == .plain)
+  }
+
+  @Test
+  func `new request round trips`() throws {
+    let request = CLIMessage.Request(
+      command: .duplicateWorkspace,
+      arguments: ["Work"],
+      options: [
+        CLIMessage.Option.profile.rawValue: "Dual",
+        CLIMessage.Option.name.rawValue: "Work copy",
+      ],
+      outputFormat: .json,
+    )
+
+    let decoded = try JSONDecoder().decode(
+      CLIMessage.Request.self,
+      from: JSONEncoder().encode(request),
+    )
+
+    #expect(decoded == request)
+  }
+}
+
+// MARK: - CLIQueryTests
+
+struct CLIQueryTests {
+  @Test
+  func `profile list JSON is structured and marks active profile`() throws {
+    let first = Profile(
+      id: try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001")),
+      name: "Default",
+    )
+    let second = Profile(
+      id: try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002")),
+      name: "Dual",
+    )
+    let config = AppConfig(profiles: [first, second], activeProfileId: second.id)
+
+    let response = CLIServerFeature.handle(
+      request: .init(command: .listProfiles, outputFormat: .json),
+      config: config,
+    )
+
+    #expect(response.success)
+    let output = try #require(response.output)
+    let values = try JSONDecoder().decode([CLIMessage.ProfileInfo].self, from: Data(output.utf8))
+    #expect(values.map(\.name) == ["Default", "Dual"])
+    #expect(values.map(\.isActive) == [false, true])
+  }
+
+  @Test
+  func `workspace and app queries can target an inactive profile`() throws {
+    let browser = Workspace(
+      id: try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000010")),
+      name: "Browser",
+      apps: [
+        AppAssignment(
+          bundleIdentifier: "company.thebrowser.Browser",
+          name: "Browser",
+          autoOpen: true,
+          layout: .tiled,
+        )
+      ],
+    )
+    let first = Profile(name: "Default")
+    let second = Profile(name: "Dual", workspaces: [browser])
+    let config = AppConfig(profiles: [first, second], activeProfileId: first.id)
+    let options = [CLIMessage.Option.profile.rawValue: second.id.uuidString]
+
+    let workspaces = CLIServerFeature.handle(
+      request: .init(
+        command: .listWorkspaces,
+        options: options,
+        outputFormat: .json,
+      ),
+      config: config,
+    )
+    let apps = CLIServerFeature.handle(
+      request: .init(
+        command: .listApps,
+        arguments: [browser.id.uuidString],
+        options: options,
+        outputFormat: .json,
+      ),
+      config: config,
+    )
+
+    let workspaceOutput = try #require(workspaces.output)
+    let workspaceValues = try JSONDecoder().decode(
+      [CLIMessage.WorkspaceInfo].self,
+      from: Data(workspaceOutput.utf8),
+    )
+    let appOutput = try #require(apps.output)
+    let appValues = try JSONDecoder().decode(
+      [CLIMessage.AppInfo].self,
+      from: Data(appOutput.utf8),
+    )
+    #expect(workspaceValues.map(\.name) == ["Browser"])
+    #expect(appValues.map(\.bundleIdentifier) == ["company.thebrowser.Browser"])
+    #expect(appValues.first?.autoOpen == true)
+  }
+
+  @Test
+  func `legacy plain queries keep their original line output`() {
+    let workspace = Workspace(
+      name: "Work",
+      apps: [AppAssignment(bundleIdentifier: "com.apple.Terminal", name: "Terminal")],
+    )
+    let config = AppConfig(profiles: [Profile(name: "Default", workspaces: [workspace])])
+
+    let workspaces = CLIServerFeature.handle(
+      request: .init(command: .listWorkspaces),
+      config: config,
+    )
+    let apps = CLIServerFeature.handle(
+      request: .init(command: .listApps, arguments: ["Work"]),
+      config: config,
+    )
+
+    #expect(workspaces.output == "Work")
+    #expect(apps.output == "com.apple.Terminal")
+  }
+
+  @Test
+  func `hook list reports semantic validity`() throws {
+    let valid = HookDefinition(
+      id: "valid",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let invalid = HookDefinition(
+      id: "invalid id",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    let config = AppConfig(hooks: [valid, invalid])
+
+    let response = CLIServerFeature.handle(
+      request: .init(command: .listHooks, outputFormat: .json),
+      config: config,
+    )
+
+    let output = try #require(response.output)
+    let hooks = try JSONDecoder().decode([CLIMessage.HookInfo].self, from: Data(output.utf8))
+    #expect(hooks.map(\.valid) == [true, false])
+  }
+}
+
+// MARK: - ConfigPersistenceTests
+
+@Suite(.serialized)
+struct ConfigPersistenceTests {
+  @Test @MainActor
+  func `filesystem self write echo preserves the active profile session`() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("tatami-config-echo-\(UUID().uuidString)")
+    let url = directory.appendingPathComponent("config.toml")
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let first = Profile(name: "First")
+    let second = Profile(name: "Second")
+    let initial = AppConfig(profiles: [first, second])
+    try encodeTatamiConfig(initial).write(to: url, options: .atomic)
+    let storage = FileStorageKey<AppConfig>.fileStorage(
+      url,
+      decode: decodeTatamiConfig,
+      encode: encodeTatamiConfig,
+    )
+    let shared = Shared(wrappedValue: initial, TatamiConfigKey(base: storage))
+
+    shared.withLock { $0.activeProfileId = second.id }
+    shared.withLock { $0.mutateProfile(first.id) { $0.name = "Renamed" } }
+    try await Task.sleep(for: .milliseconds(300))
+
+    #expect(shared.wrappedValue.activeProfileId == second.id)
+    #expect(shared.wrappedValue.profiles.first?.name == "Renamed")
+  }
+
+  @Test
+  func `revision mismatch preserves the external edit and matching revision commits`() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("tatami-config-transaction-\(UUID().uuidString)")
+    let url = directory.appendingPathComponent("config.toml")
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let baseline = AppConfig(profiles: [Profile(name: "Baseline")])
+    let external = AppConfig(profiles: [Profile(name: "External")])
+    let updated = AppConfig(profiles: [Profile(name: "Updated")])
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try encodeTatamiConfig(baseline).write(to: url, options: .atomic)
+    let revision = try TatamiConfigTransactionCoordinator.shared.captureRevision(
+      expected: baseline,
+      at: url,
+    )
+
+    let externalData = try encodeTatamiConfig(external)
+    try externalData.write(to: url, options: .atomic)
+    let externalInode = try fileInode(at: url)
+    let exchangeCalled = LockIsolated(false)
+    let rejectedBeforeExchange = LockIsolated(false)
+    do {
+      try TatamiConfigTransactionCoordinator.shared.replace(
+        revision: revision,
+        with: updated,
+        at: url,
+        afterInitialExchange: { exchangeCalled.setValue(true) },
+      )
+      Issue.record("Expected the stale revision to be rejected")
+    } catch ConfigPersistenceError.changedOnDisk {
+      rejectedBeforeExchange.setValue(true)
+    } catch {
+      Issue.record("Expected changedOnDisk, got \(error)")
+    }
+    let preservedData = try Data(contentsOf: url)
+    let preserved = try decodeTatamiConfig(preservedData)
+    #expect(rejectedBeforeExchange.value)
+    #expect(!exchangeCalled.value)
+    #expect(preservedData == externalData)
+    #expect(try fileInode(at: url) == externalInode)
+    #expect(preserved.hasSamePersistedContent(as: external))
+
+    let externalRevision = try Data(contentsOf: url)
+    try TatamiConfigTransactionCoordinator.shared.replace(
+      revision: externalRevision,
+      with: updated,
+      at: url,
+    )
+    let committed = try decodeTatamiConfig(Data(contentsOf: url))
+    #expect(committed.hasSamePersistedContent(as: updated))
+    #expect(TatamiConfigTransactionCoordinator.shared.consumeSuppressedDidSet(updated))
+
+    let committedRevision = try Data(contentsOf: url)
+    let expiredUpdate = AppConfig(profiles: [Profile(name: "Expired")])
+    #expect(throws: (any Error).self) {
+      try TatamiConfigTransactionCoordinator.shared.replace(
+        revision: committedRevision,
+        with: expiredUpdate,
+        at: url,
+        reserve: { false },
+      )
+    }
+    let afterExpiration = try decodeTatamiConfig(Data(contentsOf: url))
+    #expect(afterExpiration.hasSamePersistedContent(as: updated))
+
+    let first = Profile(name: "First")
+    let second = Profile(name: "Second")
+    var active = AppConfig(profiles: [first, second], activeProfileId: second.id)
+    TatamiConfigTransactionCoordinator.shared.recordSelfWrite(active)
+    active.activeProfileId = nil
+    let restored = TatamiConfigTransactionCoordinator.shared.preservingSessionProfile(in: active)
+    #expect(restored.activeProfileId == second.id)
+    TatamiConfigTransactionCoordinator.shared.recordSelfWrite(AppConfig())
+  }
+
+  @Test
+  func `same inode rewrite matching candidate bytes preserves the newer external generation`() throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("tatami-config-aba-\(UUID().uuidString)")
+    let url = directory.appendingPathComponent("config.toml")
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let baseline = AppConfig(profiles: [Profile(name: "Baseline")])
+    let displacedExternal = AppConfig(profiles: [Profile(name: "External")])
+    let updated = AppConfig(profiles: [Profile(name: "Updated")])
+    let updatedData = try encodeTatamiConfig(updated)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    try encodeTatamiConfig(baseline).write(to: url, options: .atomic)
+    let revision = try TatamiConfigTransactionCoordinator.shared.captureRevision(
+      expected: baseline,
+      at: url,
+    )
+    let displacedExternalData = try encodeTatamiConfig(displacedExternal)
+
+    let hookError = LockIsolated<String?>(nil)
+    let exchangeCalled = LockIsolated(false)
+    let inPlaceInodes = LockIsolated<[UInt64]>([])
+    #expect(throws: (any Error).self) {
+      try TatamiConfigTransactionCoordinator.shared.replace(
+        revision: revision,
+        with: updated,
+        at: url,
+        afterPreflightCheck: {
+          do {
+            // Land a rename-based writer after the raw preflight check so the
+            // transaction must still enter the exchange/restore path.
+            try displacedExternalData.write(to: url, options: .atomic)
+          } catch {
+            hookError.setValue(String(describing: error))
+          }
+        },
+        afterInitialExchange: {
+          exchangeCalled.setValue(true)
+          do {
+            let before = try fileInode(at: url)
+            // Ensure the same-byte write advances the high-resolution content
+            // generation even on a very fast filesystem.
+            Thread.sleep(forTimeInterval: 0.02)
+            let handle = try FileHandle(forWritingTo: url)
+            try handle.truncate(atOffset: 0)
+            try handle.write(contentsOf: updatedData)
+            try handle.synchronize()
+            try handle.close()
+            let after = try fileInode(at: url)
+            inPlaceInodes.setValue([before, after])
+          } catch {
+            hookError.setValue(String(describing: error))
+          }
+        },
+      )
+    }
+
+    #expect(hookError.value == nil)
+    #expect(exchangeCalled.value)
+    #expect(inPlaceInodes.value.count == 2)
+    #expect(inPlaceInodes.value.first == inPlaceInodes.value.last)
+    #expect(try Data(contentsOf: url) == updatedData)
+    #expect(try fileInode(at: url) == inPlaceInodes.value.last)
+  }
+}
+
+private func fileInode(at url: URL) throws -> UInt64 {
+  let attributes = try FileManager.default.attributesOfItem(atPath: url.path)
+  return try #require((attributes[.systemFileNumber] as? NSNumber)?.uint64Value)
+}
+
+// MARK: - CLIDomainCommandTests
+
+@MainActor
+struct CLIDomainCommandTests {
+  @Test
+  func `fixed domain command dispatches through the shared hotkey action`() async throws {
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: CLIServerFeature.State()) {
+      CLIServerFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(
+        command: .dispatchDomainCommand,
+        arguments: [CLIMessage.DomainCommand.windowFocusLeft.rawValue],
+        outputFormat: .json,
+      ),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.receive {
+      guard
+        case .delegate(.dispatchDomainCommandRequested(.focusLeft, let complete)) = $0
+      else {
+        return false
+      }
+      complete(nil)
+      return true
+    }
+    await store.finish()
+
+    let output = try #require(response.value?.output)
+    let info = try JSONDecoder().decode(
+      CLIMessage.DomainCommandResult.self,
+      from: Data(output.utf8),
+    )
+    #expect(response.value?.success == true)
+    #expect(info.command == .windowFocusLeft)
+    #expect(info.status == .accepted)
+  }
+
+  @Test
+  func `workspace activate waits for terminal completion`() async throws {
+    let workspace = Workspace(name: "Focus")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(
+        command: .dispatchDomainCommand,
+        arguments: [CLIMessage.DomainCommand.workspaceActivate.rawValue, workspace.name],
+        outputFormat: .json,
+      ),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    #expect(response.value == nil)
+    await store.receive {
+      guard
+        case .delegate(.activateWorkspaceRequested(let id, let complete)) = $0,
+        id == workspace.id
+      else { return false }
+      complete(nil)
+      return true
+    }
+    await store.finish()
+
+    let output = try #require(response.value?.output)
+    let info = try JSONDecoder().decode(
+      CLIMessage.DomainCommandResult.self,
+      from: Data(output.utf8),
+    )
+    #expect(response.value?.success == true)
+    #expect(info.command == .workspaceActivate)
+    #expect(info.status == .completed)
+  }
+
+  @Test
+  func `targeted domain command resolves a workspace name in the requested profile`() async {
+    let workspace = Workspace(name: "Coding")
+    let active = Profile(name: "Default")
+    let target = Profile(name: "Dual", workspaces: [workspace])
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [active, target],
+      activeProfileId: active.id,
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(
+        command: .dispatchDomainCommand,
+        arguments: [CLIMessage.DomainCommand.workspaceAssignAppTo.rawValue, workspace.name],
+        options: [CLIMessage.Option.profile.rawValue: target.name],
+      ),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.receive {
+      guard
+        case .delegate(.dispatchDomainCommandRequested(
+          .assignFocusedAppToWorkspace(let id),
+          let complete,
+        )) = $0,
+        id == workspace.id
+      else { return false }
+      complete(nil)
+      return true
+    }
+    await store.finish()
+
+    #expect(response.value?.success == true)
+  }
+
+  @Test
+  func `UUID shaped workspace name falls back from global ID lookup`() async {
+    let uuidName = "00000000-0000-0000-0000-00000000cafe"
+    let workspace = Workspace(name: uuidName)
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(
+        command: .dispatchDomainCommand,
+        arguments: [CLIMessage.DomainCommand.workspaceAssignAppTo.rawValue, uuidName],
+      ),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.receive {
+      guard
+        case .delegate(.dispatchDomainCommandRequested(
+          .assignFocusedAppToWorkspace(let id),
+          let complete,
+        )) = $0,
+        id == workspace.id
+      else { return false }
+      complete(nil)
+      return true
+    }
+    await store.finish()
+
+    #expect(response.value?.success == true)
+  }
+
+  @Test
+  func `borrow rejects a workspace owned by an inactive profile`() async {
+    let workspace = Workspace(name: "Scratch")
+    let active = Profile(name: "Default")
+    let inactive = Profile(name: "Dual", workspaces: [workspace])
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [active, inactive],
+      activeProfileId: active.id,
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(
+        command: .dispatchDomainCommand,
+        arguments: [CLIMessage.DomainCommand.workspaceBorrowFrom.rawValue, workspace.id.uuidString],
+      ),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.finish()
+
+    #expect(response.value?.success == false)
+    #expect(response.value?.error?.contains("active profile") == true)
+  }
+
+  @Test
+  func `raw generic action names are not a domain command escape hatch`() async {
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: CLIServerFeature.State()) {
+      CLIServerFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(command: .dispatchDomainCommand, arguments: ["focus-left"]),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.finish()
+
+    #expect(response.value?.success == false)
+    #expect(response.value?.error?.contains("Unknown internal domain command") == true)
+  }
+}
+
+// MARK: - CLIMutationTests
+
+@MainActor
+struct CLIMutationTests {
+  @Test
+  func `scratchpad activation is rejected instead of leaving A pending reply`() async {
+    let scratchpad = Workspace(name: "Scratch", kind: .scratchpad)
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [scratchpad])]
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(command: .activate, arguments: [scratchpad.id.uuidString]),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.finish()
+
+    #expect(response.value?.success == false)
+    #expect(response.value?.error?.contains("borrow-only") == true)
+  }
+
+  @Test
+  func `success reply follows the durable configuration commit`() async {
+    let workspace = Workspace(name: "Old")
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])]
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let committedBeforeReply = LockIsolated(false)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    } withDependencies: {
+      $0.configPersistence.commit = { config, baseline, _, updated, reserve in
+        committedBeforeReply.setValue(response.value == nil)
+        guard reserve() else { throw CancellationError() }
+        config.withLock { current in
+          guard current.hasSamePersistedContent(as: baseline) else { return }
+          current = updated
+        }
+      }
+    }
+
+    await store.send(.incomingRequest(
+      .init(command: .renameWorkspace, arguments: [workspace.id.uuidString, "New"]),
+      reply: CLIReply { response.setValue($0) },
+    )) {
+      $0.$config.withLock { $0.mutateWorkspace(workspace.id) { $0.name = "New" } }
+    }
+    await store.receive {
+      guard case .delegate(.configurationChanged) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(committedBeforeReply.value)
+    #expect(response.value?.success == true)
+  }
+
+  @Test
+  func `renaming workspace persists through shared config and delegates refresh`() async {
+    let workspace = Workspace(name: "Old")
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])]
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    }
+
+    await store.send(.incomingRequest(
+      .init(command: .renameWorkspace, arguments: [workspace.id.uuidString, "New"]),
+      reply: CLIReply { response.setValue($0) },
+    )) {
+      $0.$config.withLock { $0.mutateWorkspace(workspace.id) { $0.name = "New" } }
+    }
+    await store.receive {
+      guard case .delegate(.configurationChanged) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.config.workspace(id: workspace.id)?.name == "New")
+    #expect(response.value?.success == true)
+  }
+
+  @Test
+  func `duplicating workspace copies its layout and delegates refresh`() async throws {
+    let workspace = Workspace(name: "Work")
+    let shared = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])]
+    ))
+    let state = CLIServerFeature.State()
+    state.$config = shared
+    let snapshot = LayoutSnapshot(tree: .leaf(SlotID(bundleId: "com.apple.Terminal", occurrence: 0)))
+    let saved = LockIsolated<[Workspace.ID: LayoutSnapshot]>([:])
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let copyStartedBeforeCommit = LockIsolated(false)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { mapping in
+        copyStartedBeforeCommit.setValue(
+          response.value == nil
+            && shared.wrappedValue.activeProfile?.workspaces.count == 1
+        )
+        for (source, destination) in mapping where source == workspace.id {
+          saved.withValue { $0[destination] = snapshot }
+        }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(command: .duplicateWorkspace, arguments: [workspace.id.uuidString]),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.receive {
+      guard case .duplicationPrepared = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    let duplicate = try #require(
+      store.state.config.activeProfile?.workspaces.first(where: { $0.id != workspace.id })
+    )
+    #expect(duplicate.name == "Work copy")
+    #expect(copyStartedBeforeCommit.value)
+    #expect(saved.value[duplicate.id] == snapshot)
+    #expect(response.value?.success == true)
+  }
+
+  @Test
+  func `layout copy failure does not publish a partial duplicate`() async {
+    let workspace = Workspace(name: "Work")
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])]
+    ))
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in false }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(command: .duplicateWorkspace, arguments: [workspace.id.uuidString]),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.finish()
+
+    #expect(store.state.config.activeProfile?.workspaces.map(\.id) == [workspace.id])
+    #expect(response.value?.success == false)
+    #expect(response.value?.error?.contains("configuration was not changed") == true)
+  }
+
+  @Test
+  func `expired reply lease prevents a prepared duplicate from committing`() async {
+    let workspace = Workspace(name: "Work")
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])]
+    ))
+    let cleared = LockIsolated<[Workspace.ID]>([])
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let reply = CLIReply(
+      claim: { false },
+      finish: { response.setValue($0) },
+    )
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in true }
+      $0.layoutStore.removeLayouts = { ids in
+        cleared.withValue { $0.append(contentsOf: ids) }
+        return true
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(command: .duplicateWorkspace, arguments: [workspace.id.uuidString]),
+      reply: reply,
+    ))
+    await store.finish()
+
+    #expect(store.state.config.activeProfile?.workspaces.map(\.id) == [workspace.id])
+    #expect(response.value == nil)
+    #expect(cleared.value.count == 1)
+  }
+
+  @Test
+  func `config write failure rejects duplicate and cleans copied layout`() async {
+    struct WriteFailure: Error { }
+
+    let workspace = Workspace(name: "Work")
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])]
+    ))
+    let cleaned = LockIsolated<[Workspace.ID]>([])
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in true }
+      $0.layoutStore.removeLayouts = { ids in
+        cleaned.withValue { $0.append(contentsOf: ids) }
+        return true
+      }
+      $0.configPersistence.commit = { _, _, _, _, _ in throw WriteFailure() }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(command: .duplicateWorkspace, arguments: [workspace.id.uuidString]),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.finish()
+
+    #expect(store.state.config.activeProfile?.workspaces.map(\.id) == [workspace.id])
+    #expect(cleaned.value.count == 1)
+    #expect(response.value?.success == false)
+    #expect(response.value?.error?.contains("config.toml could not be saved") == true)
+  }
+
+  @Test
+  func `unknown duplicate outcome preserves copied layout for recovery`() async {
+    let workspace = Workspace(name: "Work")
+    let state = CLIServerFeature.State()
+    state.$config = Shared(value: AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])]
+    ))
+    let cleaned = LockIsolated<[Workspace.ID]>([])
+    let response = LockIsolated<CLIMessage.Response?>(nil)
+    let store = TestStore(initialState: state) {
+      CLIServerFeature()
+    } withDependencies: {
+      $0.layoutStore.copyLayouts = { _ in true }
+      $0.layoutStore.removeLayouts = { ids in
+        cleaned.withValue { $0.append(contentsOf: ids) }
+        return true
+      }
+      $0.configPersistence.commit = { _, _, _, _, reserve in
+        _ = reserve()
+        throw ConfigPersistenceError.outcomeUnknown(recoveryPath: nil)
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.incomingRequest(
+      .init(command: .duplicateWorkspace, arguments: [workspace.id.uuidString]),
+      reply: CLIReply { response.setValue($0) },
+    ))
+    await store.finish()
+
+    #expect(cleaned.value.isEmpty)
+    #expect(response.value?.success == false)
+    #expect(response.value?.error?.hasPrefix("Command outcome is unknown") == true)
+  }
+}

--- a/TatamiTests/Sources/ConfigDecodeTests.swift
+++ b/TatamiTests/Sources/ConfigDecodeTests.swift
@@ -46,7 +46,52 @@ struct ConfigDecodeTests {
     #expect(config.settings.switching.recentAcrossDisplays)
     #expect(config.settings.switching.toggleBorrowOnRepeat)
     #expect(config.settings.hud.windowCycle)
+    #expect(config.hooks.isEmpty)
     #expect(reported.value == 0)
+  }
+
+  @Test
+  func hooksDecodeWithDefaultsAndRoundTrip() throws {
+    let toml = """
+    [[hooks]]
+    id = "notify"
+    event = "workspaceActivated"
+    command = ["/usr/bin/true"]
+
+    [[hooks]]
+    id = "profile-log"
+    event = "profileChanged"
+    enabled = false
+    command = ["/bin/zsh", "-c", "print changed"]
+    timeoutMs = 1234
+    workingDirectory = "~/Documents"
+    environment = { MODE = "test" }
+    """
+
+    let decoded = try TOMLDecoder().decode(AppConfig.self, from: toml)
+
+    #expect(decoded.hooks.count == 2)
+    #expect(decoded.hooks[0].enabled)
+    #expect(decoded.hooks[0].timeoutMs == 5_000)
+    #expect(decoded.hooks[1].environment == ["MODE": "test"])
+
+    let encoder = TOMLEncoder()
+    let encoded = try encoder.encode(decoded)
+    #expect(try TOMLDecoder().decode(AppConfig.self, from: encoded).hooks == decoded.hooks)
+  }
+
+  @Test
+  func unknownHookEventFailsTheWholeConfigDecode() {
+    let toml = """
+    [[hooks]]
+    id = "unknown"
+    event = "windowFocused"
+    command = ["/usr/bin/true"]
+    """
+
+    #expect(throws: (any Error).self) {
+      try TOMLDecoder().decode(AppConfig.self, from: toml)
+    }
   }
 
   @Test

--- a/TatamiTests/Sources/GestureTests.swift
+++ b/TatamiTests/Sources/GestureTests.swift
@@ -2,7 +2,9 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import CoreGraphics
+import CustomDump
 import Foundation
+import TatamiCLIProtocol
 import Testing
 @testable import TatamiKit
 
@@ -54,6 +56,38 @@ struct GestureTests {
     #expect(categorized.count == Set(categorized).count)
     for category in GestureAction.Category.allCases {
       #expect(category.actions.allSatisfy { $0.category == category })
+    }
+  }
+
+  @Test
+  func `every executable gesture capability has a domain CLI command`() throws {
+    let workspaceID = try #require(
+      UUID(uuidString: "00000000-0000-0000-0000-000000000001")
+    )
+    let profileID = try #require(
+      UUID(uuidString: "00000000-0000-0000-0000-000000000002")
+    )
+    let actions = GestureAction.fixedActions.filter { $0 != .none } + [
+      .activateWorkspace(workspaceID),
+      .assignAppToWorkspace(workspaceID),
+      .borrowWorkspace(workspaceID),
+      .activateProfile(profileID),
+    ]
+    let routes = actions.compactMap(\.cliDomainCommand)
+
+    expectNoDifference(actions.count, 38)
+    expectNoDifference(routes.count, actions.count)
+    expectNoDifference(Set(routes), Set(CLIMessage.DomainCommand.allCases))
+    expectNoDifference(Set(routes).count, routes.count)
+    for (action, route) in zip(actions, routes) {
+      expectNoDifference(
+        GestureAction.cliAction(
+          for: route,
+          workspaceId: workspaceID,
+          profileId: profileID,
+        ),
+        action,
+      )
     }
   }
 

--- a/TatamiTests/Sources/HookIntegrationTests.swift
+++ b/TatamiTests/Sources/HookIntegrationTests.swift
@@ -1,0 +1,369 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable import TatamiKit
+
+@MainActor
+struct HookIntegrationTests {
+
+  // MARK: Internal
+
+  @Test
+  func `manual profile change emits exactly one hook event`() async {
+    let first = Profile(name: "Default")
+    let second = Profile(name: "Dual")
+    let (store, invocations, _) = makeStore(AppConfig(
+      profiles: [first, second],
+      activeProfileId: first.id,
+    ))
+
+    await store.send(.activateProfile(second.id, focus: nil)) {
+      $0.$config.withLock { $0.activeProfileId = second.id }
+    }
+    await store.receive {
+      guard case .hooks(.emit(let invocation)) = $0 else { return false }
+      return invocation.event == .profileChanged
+        && invocation.profile.id == second.id
+        && invocation.previousProfile?.id == first.id
+        && invocation.occurredAt == date
+    }
+    await store.finish()
+    #expect(invocations.value.count == 1)
+  }
+
+  @Test
+  func `deleting the active profile keeps its snapshot in the change hook`() async {
+    let first = Profile(name: "Default")
+    let second = Profile(name: "Dual")
+    let (store, invocations, _) = makeStore(AppConfig(
+      profiles: [first, second],
+      activeProfileId: first.id,
+    ))
+
+    await store.send(.workspaceList(.deleteProfileRequested(first.id)))
+    await store.send(.workspaceList(.alert(.presented(.confirmProfileDeletion(first.id)))))
+    await store.finish()
+
+    #expect(store.state.config.activeProfileId == second.id)
+    #expect(invocations.value.count == 1)
+    #expect(invocations.value.first?.profile.id == second.id)
+    #expect(invocations.value.first?.previousProfile?.id == first.id)
+  }
+
+  @Test
+  func `activating the current profile does not emit A change`() async {
+    let profile = Profile(name: "Default")
+    let (store, invocations, _) = makeStore(AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+
+    await store.send(.activateProfile(profile.id, focus: nil))
+    await store.finish()
+    #expect(invocations.value.isEmpty)
+  }
+
+  @Test
+  func `automatic profile change emits exactly one hook event`() async {
+    let first = Profile(name: "Default")
+    let second = Profile(name: "Dual")
+    let (store, invocations, _) = makeStore(AppConfig(
+      profiles: [first, second],
+      activeProfileId: second.id,
+    ))
+
+    await store.send(.activation(.delegate(.profileAutoActivated(
+      previous: first.id,
+      current: second.id,
+    ))))
+    await store.receive {
+      guard case .hooks(.emit(let invocation)) = $0 else { return false }
+      return invocation.event == .profileChanged
+        && invocation.profile.id == second.id
+        && invocation.previousProfile?.id == first.id
+    }
+    await store.finish()
+    #expect(invocations.value.count == 1)
+  }
+
+  @Test
+  func `startup profile selection emits one event with no previous profile`() async {
+    let profile = Profile(name: "Default")
+    let (store, invocations, _) = makeStore(AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+
+    await store.send(.startupProfileRestored) {
+      $0.didRestoreStartupProfile = true
+    }
+    await store.send(.cli(.startCompleted(.success(())))) {
+      $0.didCompleteCLIStart = true
+      $0.didPublishTatamiLaunched = true
+    }
+    await store.receive {
+      guard case .hooks(.emit(let invocation)) = $0 else { return false }
+      return invocation.event == .profileChanged
+        && invocation.profile.id == profile.id
+        && invocation.previousProfile == nil
+    }
+    await store.finish()
+    #expect(invocations.value.count == 1)
+  }
+
+  @Test
+  func `completed workspace activation emits display context`() async {
+    let workspace = Workspace(name: "Work")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let display = DisplayName(uuid: "display-a", name: "Built-in")
+    let (store, invocations, _) = makeStore(
+      AppConfig(
+        profiles: [profile],
+        activeProfileId: profile.id,
+      ),
+      activationGeneration: 1,
+    )
+
+    await store.send(.activation(.activationCompleted(
+      workspaceId: workspace.id,
+      display: display,
+      generation: 1,
+    )))
+    await store.receive {
+      guard case .hooks(.emit(let invocation)) = $0 else { return false }
+      return invocation.event == .workspaceActivated
+        && invocation.profile.id == profile.id
+        && invocation.workspace?.id == workspace.id
+        && invocation.display == .init(display)
+    }
+    await store.finish()
+    #expect(invocations.value.count == 1)
+  }
+
+  @Test
+  func `CLI readiness publishes tatami launched once before startup profile changed`() async {
+    let profile = Profile(name: "Default")
+    let profileHook = HookDefinition(
+      id: "profile",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let launchHook = HookDefinition(
+      id: "launch",
+      event: .tatamiLaunched,
+      command: ["/usr/bin/true"],
+    )
+    let (store, invocations, _) = makeStore(AppConfig(
+      profiles: [profile],
+      hooks: [profileHook, launchHook],
+      activeProfileId: profile.id,
+    ))
+
+    await store.send(.startupProfileRestored) {
+      $0.didRestoreStartupProfile = true
+    }
+    await store.send(.cli(.startCompleted(.success(())))) {
+      $0.didCompleteCLIStart = true
+      $0.didPublishTatamiLaunched = true
+    }
+    await store.receive {
+      guard case .hooks(.emit(let invocation)) = $0 else { return false }
+      return invocation.event == .tatamiLaunched
+        && invocation.occurredAt == date
+        && invocation.profile == .init(profile)
+        && invocation.previousProfile == nil
+        && invocation.workspace == nil
+        && invocation.display == nil
+    }
+    await store.receive {
+      guard case .hooks(.emit(let invocation)) = $0 else { return false }
+      return invocation.event == .profileChanged
+        && invocation.profile == .init(profile)
+        && invocation.previousProfile == nil
+        && invocation.workspace == nil
+        && invocation.display == nil
+    }
+    await store.receive {
+      guard case .activation(.activateInitial) = $0 else { return false }
+      return true
+    }
+    await store.send(.cli(.startCompleted(.success(()))))
+    await store.send(.startupProfileRestored)
+    await store.finish()
+
+    #expect(invocations.value.count { $0.event == .tatamiLaunched } == 1)
+    #expect(invocations.value.count { $0.event == .profileChanged } == 1)
+    #expect(invocations.value.map(\.event) == [.tatamiLaunched, .profileChanged])
+  }
+
+  @Test
+  func `disabled or invalid launch hooks do not run and later additions are not replayed`() async {
+    let profile = Profile(name: "Default")
+    let disabled = HookDefinition(
+      id: "disabled-launch",
+      event: .tatamiLaunched,
+      enabled: false,
+      command: ["/usr/bin/true"],
+    )
+    let invalid = HookDefinition(
+      id: "invalid-launch",
+      event: .tatamiLaunched,
+      command: [],
+    )
+    let (store, invocations, shared) = makeStore(AppConfig(
+      profiles: [profile],
+      hooks: [disabled, invalid],
+      activeProfileId: profile.id,
+    ))
+
+    await store.send(.startupProfileRestored) {
+      $0.didRestoreStartupProfile = true
+    }
+    await store.send(.cli(.startCompleted(.success(())))) {
+      $0.didCompleteCLIStart = true
+      $0.didPublishTatamiLaunched = true
+    }
+    shared.withLock {
+      $0.hooks.append(HookDefinition(
+        id: "added-later",
+        event: .tatamiLaunched,
+        command: ["/usr/bin/true"],
+      ))
+    }
+    await store.send(.cli(.startCompleted(.success(()))))
+    await store.send(.startupProfileRestored)
+    await store.finish()
+
+    #expect(invocations.value.filter { $0.event == .tatamiLaunched }.isEmpty)
+  }
+
+  @Test
+  func `CLI startup failure still publishes tatami launched alongside its report`() async {
+    struct CLIStartFailure: Error { }
+
+    let profile = Profile(name: "Default")
+    let launchHook = HookDefinition(
+      id: "launch",
+      event: .tatamiLaunched,
+      command: ["/usr/bin/true"],
+    )
+    let reportedDomains = LockIsolated<[String]>([])
+    let (store, invocations, _) = makeStore(
+      AppConfig(
+        profiles: [profile],
+        hooks: [launchHook],
+        activeProfileId: profile.id,
+      ),
+      reportedDomains: reportedDomains,
+    )
+
+    await store.send(.startupProfileRestored) {
+      $0.didRestoreStartupProfile = true
+    }
+    await store.send(.cli(.startCompleted(.failure(CLIStartFailure())))) {
+      $0.didCompleteCLIStart = true
+      $0.didPublishTatamiLaunched = true
+    }
+    await store.receive {
+      guard case .hooks(.emit(let invocation)) = $0 else { return false }
+      return invocation.event == .tatamiLaunched
+    }
+    await store.receive {
+      guard case .activation(.activateInitial) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(reportedDomains.value.contains("CLI"))
+    #expect(invocations.value.count { $0.event == .tatamiLaunched } == 1)
+  }
+
+  @Test
+  func `missing active profile reports the broken launch invariant`() async {
+    let launchHook = HookDefinition(
+      id: "launch",
+      event: .tatamiLaunched,
+      command: ["/usr/bin/true"],
+    )
+    let reportedDomains = LockIsolated<[String]>([])
+    let (store, invocations, _) = makeStore(
+      AppConfig(profiles: [], hooks: [launchHook]),
+      reportedDomains: reportedDomains,
+    )
+
+    await store.send(.startupProfileRestored) {
+      $0.didRestoreStartupProfile = true
+    }
+    await store.send(.cli(.startCompleted(.success(())))) {
+      $0.didCompleteCLIStart = true
+      $0.didPublishTatamiLaunched = true
+    }
+    await store.finish()
+
+    #expect(reportedDomains.value.contains("StartupHooks"))
+    #expect(invocations.value.isEmpty)
+  }
+
+  // MARK: Private
+
+  private let date = Date(timeIntervalSince1970: 1_700_000_000)
+
+  private func makeStore(
+    _ config: AppConfig,
+    activationGeneration: UInt64? = nil,
+    reportedDomains: LockIsolated<[String]>? = nil,
+  ) -> (TestStoreOf<AppFeature>, LockIsolated<[HookInvocation]>, Shared<AppConfig>) {
+    var config = config
+    if config.hooks.isEmpty {
+      config.hooks = [
+        HookDefinition(
+          id: "integration",
+          event: .profileChanged,
+          command: ["/usr/bin/true"],
+        ),
+        HookDefinition(
+          id: "integration-workspace",
+          event: .workspaceActivated,
+          command: ["/usr/bin/true"],
+        ),
+      ]
+    }
+    let shared = Shared(value: config)
+    var state = AppFeature.State()
+    state.$config = shared
+    state.activation.$config = shared
+    state.cli.$config = shared
+    state.hooks.$config = shared
+    state.hotKeys.$config = shared
+    state.workspaceList.$config = shared
+    if let activationGeneration {
+      state.activation.isActivating = true
+      state.activation.activationGeneration = activationGeneration
+      state.activation.activeActivationGeneration = activationGeneration
+    }
+    let invocations = LockIsolated<[HookInvocation]>([])
+    let store = TestStore(initialState: state) {
+      AppFeature()
+    } withDependencies: {
+      $0.date.now = date
+      $0.displays.all = { [] }
+      $0.errorReporter.report = { domain, _, _ in
+        reportedDomains?.withValue { $0.append(domain) }
+      }
+      $0.hotKeys.register = { _ in }
+      $0.hookRunner.run = { _, invocation in
+        invocations.withValue { $0.append(invocation) }
+        return .success(stdout: "", stderr: "")
+      }
+      $0.profileSessionStore.saveActiveProfileId = { _ in }
+      $0.profileSessionStore.saveWorkspaceState = { _, _ in }
+      $0.windowObserver.observe = { _ in }
+    }
+    store.exhaustivity = .off
+    return (store, invocations, shared)
+  }
+
+}

--- a/TatamiTests/Sources/HookSettingsFeatureTests.swift
+++ b/TatamiTests/Sources/HookSettingsFeatureTests.swift
@@ -1,0 +1,460 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Foundation
+import Testing
+@testable import TatamiKit
+
+@MainActor
+struct HookSettingsFeatureTests {
+
+  // MARK: Internal
+
+  @Test
+  func `invalid add stays in the editor without committing`() async {
+    let commits = LockIsolated(0)
+    let store = TestStore(initialState: settingsState(AppConfig())) {
+      HookSettingsFeature()
+    } withDependencies: {
+      $0.configPersistence.commit = { _, _, _, _, _ in
+        commits.withValue { $0 += 1 }
+      }
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addButtonTapped)
+    await store.send(.editor(.presented(.saveButtonTapped)))
+    await store.finish()
+
+    #expect(store.state.config.hooks.isEmpty)
+    #expect(store.state.editor?.showsValidation == true)
+    #expect(store.state.editor?.showsTestValidation == false)
+    #expect(store.state.editor?.validationIssues.contains {
+      $0.code == .definition(.emptyCommand)
+    } == true)
+    #expect(commits.value == 0)
+  }
+
+  @Test
+  func `valid add preserves an unrelated invalid hook`() async {
+    let invalid = HookDefinition(
+      id: "invalid id",
+      event: .profileChanged,
+      command: [],
+    )
+    let store = TestStore(initialState: settingsState(AppConfig(hooks: [invalid]))) {
+      HookSettingsFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.addButtonTapped)
+    await store.send(.editor(.presented(.executableChanged("/usr/bin/true"))))
+    await store.send(.editor(.presented(.saveButtonTapped)))
+    await store.receive {
+      guard case .editor(.presented(.delegate(.saveRequested))) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .mutationResponse(.add, .success) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.config.hooks.count == 2)
+    #expect(store.state.config.hooks.first == invalid)
+    #expect(store.state.config.hooks.last?.id == "hook")
+    #expect(store.state.editor == nil)
+  }
+
+  @Test
+  func `edit replaces the located hook and preserves argv and environment rows`() async throws {
+    let hook = HookDefinition(
+      id: "notify",
+      event: .workspaceActivated,
+      command: ["/bin/zsh", "-c", "print ok"],
+      environment: ["MODE": "desktop"],
+    )
+    let store = TestStore(initialState: settingsState(AppConfig(hooks: [hook]))) {
+      HookSettingsFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.configurationChanged)
+    let locator = try #require(store.state.rows.first?.locator)
+    let rowID = try #require(store.state.rows.first?.id)
+    await store.send(.editButtonTapped(locator))
+
+    #expect(store.state.editor?.draft.executable == "/bin/zsh")
+    #expect(store.state.editor?.draft.arguments.map(\.value) == ["-c", "print ok"])
+    #expect(store.state.editor?.draft.environment.first?.key == "MODE")
+
+    await store.send(.editor(.presented(.idChanged("notify-new"))))
+    await store.send(.editor(.presented(.saveButtonTapped)))
+    await store.receive {
+      guard case .editor(.presented(.delegate(.saveRequested))) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .mutationResponse(.edit(_), .success) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.config.hooks.first?.id == "notify-new")
+    #expect(store.state.config.hooks.first?.command == hook.command)
+    #expect(store.state.config.hooks.first?.environment == hook.environment)
+    #expect(store.state.rows.first?.id == rowID)
+  }
+
+  @Test
+  func `toggle commits immediately and retains the stable row id`() async throws {
+    let hook = HookDefinition(
+      id: "notify",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let store = TestStore(initialState: settingsState(AppConfig(hooks: [hook]))) {
+      HookSettingsFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.configurationChanged)
+    let row = try #require(store.state.rows.first)
+    await store.send(.enabledChanged(row.locator, false))
+    await store.receive {
+      guard case .mutationResponse(.setEnabled(_, _), .success) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.config.hooks.first?.enabled == false)
+    #expect(store.state.rows.first?.id == row.id)
+    #expect(store.state.rows.first?.locator.expected.enabled == false)
+  }
+
+  @Test
+  func `delete requires confirmation and removes only the located hook`() async throws {
+    let first = HookDefinition(
+      id: "first",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let second = HookDefinition(
+      id: "second",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    let store = TestStore(initialState: settingsState(AppConfig(hooks: [first, second]))) {
+      HookSettingsFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.configurationChanged)
+    let locator = try #require(store.state.rows.first?.locator)
+    await store.send(.deleteButtonTapped(locator))
+    #expect(store.state.config.hooks == [first, second])
+    #expect(store.state.alert != nil)
+
+    await store.send(.alert(.presented(.confirmDelete(locator))))
+    await store.receive {
+      guard case .mutationResponse(.delete(_), .success) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.config.hooks == [second])
+  }
+
+  @Test
+  func `stale locator cannot change another hook`() async {
+    let original = HookDefinition(
+      id: "original",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let replacement = HookDefinition(
+      id: "replacement",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let locator = HookLocator(offset: 0, expected: original)
+    let store = TestStore(initialState: settingsState(AppConfig(hooks: [replacement]))) {
+      HookSettingsFeature()
+    } withDependencies: {
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.enabledChanged(locator, false))
+
+    #expect(store.state.config.hooks == [replacement])
+    #expect(store.state.alert != nil)
+  }
+
+  @Test
+  func `CAS failure keeps the config and editor draft`() async throws {
+    let hook = HookDefinition(
+      id: "notify",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let store = TestStore(initialState: settingsState(AppConfig(hooks: [hook]))) {
+      HookSettingsFeature()
+    } withDependencies: {
+      $0.configPersistence.captureRevision = { _ in
+        throw ConfigPersistenceError.changedOnDisk
+      }
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.configurationChanged)
+    let locator = try #require(store.state.rows.first?.locator)
+    await store.send(.editButtonTapped(locator))
+    await store.send(.editor(.presented(.idChanged("changed"))))
+    await store.send(.editor(.presented(.saveButtonTapped)))
+    await store.receive {
+      guard case .editor(.presented(.delegate(.saveRequested))) = $0 else { return false }
+      return true
+    }
+    await store.receive {
+      guard case .mutationResponse(.edit(_), .failure) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.config.hooks == [hook])
+    #expect(store.state.editor?.draft.id == "changed")
+    #expect(store.state.editor?.saveError != nil)
+    #expect(store.state.alert == nil)
+  }
+
+  @Test
+  func `local validation identifies duplicate ids timeout and environment keys`() throws {
+    let existing = HookDefinition(
+      id: "notify",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    var state = HookEditorFeature.State(
+      mode: .add,
+      baseline: AppConfig(hooks: [existing]),
+      hook: HookDefinition(
+        id: "notify",
+        event: .profileChanged,
+        command: ["/usr/bin/true"],
+        timeoutMs: 99,
+      ),
+      makeUUID: { UUID() },
+    )
+    let firstID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
+    let secondID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002"))
+    state.draft.environment = [
+      .init(id: firstID, key: "MODE", value: "one"),
+      .init(id: secondID, key: "MODE", value: "two"),
+    ]
+
+    let codes = state.validationIssues.map(\.code)
+    #expect(codes.contains(.definition(.duplicateID)))
+    #expect(codes.contains(.definition(.timeoutOutOfRange)))
+    #expect(codes.count(where: { $0 == .duplicateEnvironmentKey }) == 2)
+  }
+
+  @Test
+  func `Run Test reuses the runner with deterministic workspace context`() async throws {
+    let workspace = Workspace(name: "Work")
+    let profile = Profile(name: "Default", workspaces: [workspace])
+    let baseline = AppConfig(
+      profiles: [profile],
+      hooks: [],
+      activeProfileId: profile.id,
+    )
+    let hook = HookDefinition(
+      id: "notify",
+      event: .workspaceActivated,
+      command: ["/usr/bin/printf", "ok"],
+    )
+    let state = HookEditorFeature.State(
+      mode: .add,
+      baseline: baseline,
+      hook: hook,
+      makeUUID: { UUID() },
+    )
+    let received = LockIsolated<(HookDefinition, HookInvocation)?>(nil)
+    let date = Date(timeIntervalSince1970: 1_700_000_000)
+    let store = TestStore(initialState: state) {
+      HookEditorFeature()
+    } withDependencies: {
+      $0.date.now = date
+      $0.hookRunner.run = { definition, invocation in
+        received.setValue((definition, invocation))
+        return .success(stdout: "ok", stderr: "")
+      }
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.testButtonTapped)
+    await store.receive {
+      guard case .testResponse(_, .success) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    let invocation = try #require(received.value?.1)
+    #expect(received.value?.0 == hook)
+    #expect(invocation.occurredAt == date)
+    #expect(invocation.profile.id == profile.id)
+    #expect(invocation.workspace?.id == workspace.id)
+    #expect(store.state.showsValidation == false)
+    #expect(store.state.showsTestValidation)
+    #expect(store.state.testStatus == .succeeded(stdout: "ok", stderr: ""))
+  }
+
+  @Test
+  func `Run Test rejects a scratchpad even when its id is selected`() async {
+    let scratchpad = Workspace(name: "Scratch", kind: .scratchpad)
+    let workspace = Workspace(name: "Work")
+    let profile = Profile(name: "Default", workspaces: [scratchpad, workspace])
+    let baseline = AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    )
+    let hook = HookDefinition(
+      id: "notify",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    var state = HookEditorFeature.State(
+      mode: .add,
+      baseline: baseline,
+      hook: hook,
+      makeUUID: { UUID() },
+    )
+    state.testWorkspaceID = scratchpad.id
+    let runs = LockIsolated(0)
+    let store = TestStore(initialState: state) {
+      HookEditorFeature()
+    } withDependencies: {
+      $0.hookRunner.run = { _, _ in
+        runs.withValue { $0 += 1 }
+        return .success(stdout: "", stderr: "")
+      }
+    }
+
+    await store.send(.testButtonTapped) {
+      $0.showsTestValidation = true
+    }
+
+    #expect(store.state.testWorkspaces.map(\.id) == [workspace.id])
+    #expect(store.state.testValidationIssues.contains { $0.code == .noWorkspace })
+    #expect(!store.state.showsValidation)
+    #expect(runs.value == 0)
+  }
+
+  @Test
+  func `Run Test surfaces process failure output`() async {
+    let hook = HookDefinition(
+      id: "notify",
+      event: .profileChanged,
+      command: ["/usr/bin/false"],
+    )
+    let state = HookEditorFeature.State(
+      mode: .add,
+      baseline: AppConfig(),
+      hook: hook,
+      makeUUID: { UUID() },
+    )
+    let store = TestStore(initialState: state) {
+      HookEditorFeature()
+    } withDependencies: {
+      $0.date.now = Date(timeIntervalSince1970: 1_700_000_000)
+      $0.hookRunner.run = { _, _ in
+        .failure(message: "Exited with status 1", stdout: "out", stderr: "err")
+      }
+      $0.uuid = .incrementing
+    }
+    store.exhaustivity = .off
+
+    await store.send(.testButtonTapped)
+    await store.receive {
+      guard case .testResponse(_, .failure) = $0 else { return false }
+      return true
+    }
+    await store.finish()
+
+    #expect(store.state.testStatus == .failed(
+      message: "Exited with status 1",
+      stdout: "out",
+      stderr: "err",
+    ))
+  }
+
+  @Test
+  func `stale test response cannot replace the latest run`() async throws {
+    let oldID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001"))
+    let currentID = try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000002"))
+    var state = HookEditorFeature.State(
+      mode: .add,
+      baseline: AppConfig(),
+      hook: HookDefinition(
+        id: "notify",
+        event: .profileChanged,
+        command: ["/usr/bin/true"],
+      ),
+      makeUUID: { UUID() },
+    )
+    state.testStatus = .running(currentID)
+    let store = TestStore(initialState: state) {
+      HookEditorFeature()
+    }
+
+    await store.send(.testResponse(
+      oldID,
+      .failure(message: "old", stdout: "", stderr: "old"),
+    ))
+
+    #expect(store.state.testStatus == .running(currentID))
+  }
+
+  @Test
+  func `stale editor definition has its own validation code`() {
+    let original = HookDefinition(
+      id: "original",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let replacement = HookDefinition(
+      id: "replacement",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let state = HookEditorFeature.State(
+      mode: .edit(HookLocator(offset: 0, expected: original)),
+      baseline: AppConfig(hooks: [replacement]),
+      hook: original,
+      makeUUID: { UUID() },
+    )
+
+    #expect(state.validationIssues.map(\.code) == [.staleDefinition])
+  }
+
+  // MARK: Private
+
+  private func settingsState(_ config: AppConfig) -> HookSettingsFeature.State {
+    let state = HookSettingsFeature.State()
+    state.$config = Shared(value: config)
+    return state
+  }
+
+}

--- a/TatamiTests/Sources/HookTests.swift
+++ b/TatamiTests/Sources/HookTests.swift
@@ -467,6 +467,34 @@ struct HooksFeatureTests {
   // MARK: Internal
 
   @Test
+  func `invalid configuration reports the localized validation detail`() async {
+    let invalid = HookDefinition(
+      id: "missing-command",
+      event: .profileChanged,
+      command: [],
+    )
+    let report = LockIsolated<[String]>([])
+    let state = HooksFeature.State()
+    state.$config = Shared(value: AppConfig(hooks: [invalid]))
+    let store = TestStore(initialState: state) {
+      HooksFeature()
+    } withDependencies: {
+      $0.errorReporter.report = { domain, title, detail in
+        report.withValue { $0 = [domain, title, detail ?? ""] }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.configurationChanged)
+
+    #expect(report.value == [
+      "Hooks",
+      String(localized: "Hook configuration is invalid"),
+      String(localized: HookValidationIssue.Code.emptyCommand.localizedMessage),
+    ])
+  }
+
+  @Test
   func `matching enabled hooks run and failures resolve per hook`() async {
     let matching = HookDefinition(
       id: "matching",

--- a/TatamiTests/Sources/HookTests.swift
+++ b/TatamiTests/Sources/HookTests.swift
@@ -1,0 +1,715 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Darwin
+import Foundation
+import Testing
+@testable import TatamiKit
+
+// MARK: - HookDefinitionTests
+
+struct HookDefinitionTests {
+  @Test
+  func `defaults decode and round trip`() throws {
+    let data = Data(#"{"id":"notify","event":"workspaceActivated","command":["/usr/bin/true"]}"#.utf8)
+    let hook = try JSONDecoder().decode(HookDefinition.self, from: data)
+
+    #expect(hook.enabled)
+    #expect(hook.timeoutMs == 5_000)
+    #expect(hook.workingDirectory == nil)
+    #expect(hook.environment.isEmpty)
+    #expect(try JSONDecoder().decode(HookDefinition.self, from: JSONEncoder().encode(hook)) == hook)
+  }
+
+  @Test
+  func `tatami launched event decodes and round trips`() throws {
+    let data = Data(#"{"id":"launch","event":"tatamiLaunched","command":["/usr/bin/true"]}"#.utf8)
+    let hook = try JSONDecoder().decode(HookDefinition.self, from: data)
+
+    #expect(hook.event == .tatamiLaunched)
+    #expect(try JSONDecoder().decode(HookDefinition.self, from: JSONEncoder().encode(hook)) == hook)
+  }
+
+  @Test
+  func `semantic validation rejects only invalid entries`() {
+    let valid = HookDefinition(
+      id: "valid-hook",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let duplicateA = HookDefinition(
+      id: "duplicate",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let duplicateB = HookDefinition(
+      id: "duplicate",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    let relativeDirectory = HookDefinition(
+      id: "relative",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+      workingDirectory: "tmp",
+    )
+
+    let result = HookDefinition.validate([valid, duplicateA, duplicateB, relativeDirectory])
+
+    #expect(result.validHooks == [valid])
+    #expect(result.issues.contains { $0.contains("duplicated") })
+    #expect(result.issues.contains { $0.contains("workingDirectory") })
+  }
+
+  @Test
+  func `semantic validation reports every invalid field on one hook`() {
+    let invalid = HookDefinition(
+      id: "bad id",
+      event: .workspaceActivated,
+      command: ["", "bad\0argument"],
+      timeoutMs: 99,
+      workingDirectory: "relative/path",
+      environment: [
+        "1INVALID": "value",
+        "VALID_KEY": "bad\0value",
+      ],
+    )
+
+    let result = HookDefinition.validate([invalid])
+
+    #expect(result.validHooks.isEmpty)
+    #expect(result.detailedIssues.map(\.hookIndex) == [0, 0, 0, 0, 0, 0, 0])
+    #expect(Set(result.detailedIssues.map(\.code)) == [
+      .invalidID,
+      .emptyCommand,
+      .nulCommand,
+      .timeoutOutOfRange,
+      .invalidWorkingDirectory,
+      .invalidEnvironment,
+    ])
+    #expect(result.detailedIssues.contains {
+      $0.field == .environment(key: "1INVALID") && $0.code == .invalidEnvironment
+    })
+    #expect(result.detailedIssues.contains {
+      $0.field == .environment(key: "VALID_KEY") && $0.code == .invalidEnvironment
+    })
+    #expect(result.issues == [
+      "Hook \"bad id\" has an invalid id (use ASCII letters, numbers, '.', '_' or '-')",
+      "Hook \"bad id\" has an empty command",
+      "Hook \"bad id\" has a command argument containing NUL",
+      "Hook \"bad id\" timeoutMs must be between 100 and 300000",
+      "Hook \"bad id\" workingDirectory must be absolute or start with ~/",
+      "Hook \"bad id\" has an invalid environment entry \"1INVALID\"",
+      "Hook \"bad id\" has an invalid environment entry \"VALID_KEY\"",
+    ])
+  }
+
+  @Test
+  func `empty and overlong ids report their specific codes`() {
+    let empty = HookDefinition(
+      id: "",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let overlong = HookDefinition(
+      id: String(repeating: "a", count: 65),
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+
+    let result = HookDefinition.validate([empty, overlong])
+
+    #expect(result.validHooks.isEmpty)
+    #expect(result.detailedIssues.contains {
+      $0.hookIndex == 0 && $0.field == .id && $0.code == .emptyID
+    })
+    #expect(result.detailedIssues.contains {
+      $0.hookIndex == 1 && $0.field == .id && $0.code == .invalidID
+    })
+  }
+
+  @Test
+  func `duplicate id reports every related hook index while flat issues stay deduplicated`() {
+    let first = HookDefinition(
+      id: "duplicate",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let second = HookDefinition(
+      id: "duplicate",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+
+    let result = HookDefinition.validate([first, second])
+    let duplicateIssues = result.detailedIssues.filter { $0.code == .duplicateID }
+
+    #expect(result.validHooks.isEmpty)
+    #expect(duplicateIssues.map(\.hookIndex) == [0, 1])
+    #expect(duplicateIssues.allSatisfy { $0.field == .id })
+    #expect(result.issues.count { $0 == "Hook id \"duplicate\" is duplicated" } == 1)
+  }
+
+  @Test
+  func `empty command array and empty executable are both invalid`() {
+    let missing = HookDefinition(
+      id: "missing",
+      event: .profileChanged,
+      command: [],
+    )
+    let emptyExecutable = HookDefinition(
+      id: "empty-executable",
+      event: .profileChanged,
+      command: ["", "argument"],
+    )
+
+    let result = HookDefinition.validate([missing, emptyExecutable])
+
+    #expect(result.validHooks.isEmpty)
+    #expect(result.detailedIssues.filter { $0.code == .emptyCommand }.map(\.hookIndex) == [0, 1])
+    #expect(result.detailedIssues.filter { $0.code == .emptyCommand }.allSatisfy {
+      $0.field == .command
+    })
+  }
+
+  @Test
+  func `timeout accepts inclusive boundaries and rejects adjacent values`() {
+    let hooks = [99, 100, 300_000, 300_001].enumerated().map { index, timeout in
+      HookDefinition(
+        id: "timeout-\(index)",
+        event: .profileChanged,
+        command: ["/usr/bin/true"],
+        timeoutMs: timeout,
+      )
+    }
+
+    let result = HookDefinition.validate(hooks)
+
+    #expect(result.validHooks == [hooks[1], hooks[2]])
+    #expect(result.detailedIssues.filter { $0.code == .timeoutOutOfRange }.map(\.hookIndex) == [0, 3])
+    #expect(result.detailedIssues.filter { $0.code == .timeoutOutOfRange }.allSatisfy {
+      $0.field == .timeoutMs
+    })
+  }
+
+  @Test
+  func `working directory accepts absolute and home relative paths`() {
+    let absolute = HookDefinition(
+      id: "absolute",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+      workingDirectory: "/tmp",
+    )
+    let homeRelative = HookDefinition(
+      id: "home-relative",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+      workingDirectory: "~/Documents",
+    )
+    let bareHome = HookDefinition(
+      id: "bare-home",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+      workingDirectory: "~",
+    )
+
+    let result = HookDefinition.validate([absolute, homeRelative, bareHome])
+
+    #expect(result.validHooks == [absolute, homeRelative])
+    #expect(result.detailedIssues.count == 1)
+    #expect(result.detailedIssues[0].hookIndex == 2)
+    #expect(result.detailedIssues[0].field == .workingDirectory)
+    #expect(result.detailedIssues[0].code == .invalidWorkingDirectory)
+  }
+
+  @Test
+  func `environment validates key grammar and NUL values`() {
+    let valid = HookDefinition(
+      id: "valid-environment",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+      environment: ["_A": "", "ABC_123": "value"],
+    )
+    let invalid = HookDefinition(
+      id: "invalid-environment",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+      environment: ["BAD-KEY": "value", "GOOD_KEY": "bad\0value"],
+    )
+
+    let result = HookDefinition.validate([valid, invalid])
+    let environmentIssues = result.detailedIssues.filter { $0.code == .invalidEnvironment }
+
+    #expect(result.validHooks == [valid])
+    #expect(environmentIssues.map(\.hookIndex) == [1, 1])
+    #expect(Set(environmentIssues.map(\.field)) == [
+      .environment(key: "BAD-KEY"),
+      .environment(key: "GOOD_KEY"),
+    ])
+  }
+
+  @Test
+  func `legacy validation initializer defaults detailed issues to empty`() {
+    let valid = HookDefinition(
+      id: "valid",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let validation = HookConfigurationValidation(validHooks: [valid], issues: [])
+
+    #expect(validation.validHooks == [valid])
+    #expect(validation.issues.isEmpty)
+    #expect(validation.detailedIssues.isEmpty)
+  }
+}
+
+// MARK: - HookRunnerTests
+
+struct HookRunnerTests {
+
+  // MARK: Internal
+
+  @Test
+  func `passes arguments environment working directory and JSON`() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("tatami-hook-test-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+
+    let profile = HookInvocation.ProfileSnapshot(
+      id: try #require(UUID(uuidString: "00000000-0000-0000-0000-000000000001")),
+      name: "Dual",
+    )
+    let invocation = HookInvocation(
+      event: .profileChanged,
+      occurredAt: Date(timeIntervalSince1970: 0),
+      profile: profile,
+    )
+    let script = #"""
+      printf '%s\n' "$TATAMI_HOOK_EVENT"
+      printf '%s\n' "$CUSTOM_VALUE"
+      pwd
+      cat
+      """#
+    let hook = HookDefinition(
+      id: "runner",
+      event: .profileChanged,
+      command: ["/bin/zsh", "-c", script],
+      timeoutMs: 2_000,
+      workingDirectory: directory.path,
+      environment: [
+        "CUSTOM_VALUE": "from-config",
+        "TATAMI_HOOK_EVENT": "must-not-win",
+      ],
+    )
+
+    let result = await HookRunnerClient.liveValue.run(hook, invocation)
+    guard case .success(let stdout, let stderr) = result else {
+      Issue.record("Expected hook success, got \(result)")
+      return
+    }
+
+    let lines = stdout.split(separator: "\n", omittingEmptySubsequences: false)
+    #expect(lines.count >= 5)
+    #expect(lines[0] == "profileChanged")
+    #expect(lines[1] == "from-config")
+    let reportedDirectory = URL(fileURLWithPath: String(lines[2])).resolvingSymlinksInPath()
+    #expect(reportedDirectory == directory.resolvingSymlinksInPath())
+    let payload = Data(lines[3].utf8)
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    #expect(try decoder.decode(HookInvocation.self, from: payload) == invocation)
+    #expect(stderr.isEmpty)
+  }
+
+  @Test
+  func `nonzero exit captures both streams`() async {
+    let hook = HookDefinition(
+      id: "failure",
+      event: .profileChanged,
+      command: ["/bin/zsh", "-c", "print output; print error >&2; exit 7"],
+    )
+
+    let result = await HookRunnerClient.liveValue.run(hook, invocation())
+
+    guard case .failure(let message, let stdout, let stderr) = result else {
+      Issue.record("Expected hook failure, got \(result)")
+      return
+    }
+    #expect(message == "Exited with status 7")
+    #expect(stdout == "output\n")
+    #expect(stderr == "error\n")
+  }
+
+  @Test
+  func `timeout terminates the child process group`() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("tatami-hook-timeout-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let pidURL = directory.appendingPathComponent("child.pid")
+    // The parent uses default SIGTERM behavior, while its child deliberately
+    // ignores TERM. swift-subprocess 1.0 observes the parent exit and otherwise
+    // stops before its implicit group SIGKILL, which is the leak we guard.
+    let script = """
+      /bin/zsh -c 'trap "" TERM; print -r -- $$ > "$1"; i=0; while (( i < 30 )); do /bin/sleep 1; (( i++ )); done' child "\(pidURL.path)" &
+      wait
+      """
+    let hook = HookDefinition(
+      id: "timeout",
+      event: .profileChanged,
+      command: ["/bin/zsh", "-c", script],
+      timeoutMs: 2_000,
+    )
+    let clock = ContinuousClock()
+    let started = clock.now
+    let task = Task {
+      await HookRunnerClient.liveValue.run(hook, invocation())
+    }
+    defer { task.cancel() }
+
+    let startDeadline = clock.now.advanced(by: .seconds(3))
+    while !FileManager.default.fileExists(atPath: pidURL.path), clock.now < startDeadline {
+      try await Task.sleep(for: .milliseconds(10))
+    }
+    try #require(FileManager.default.fileExists(atPath: pidURL.path))
+
+    let result = await task.value
+
+    guard case .failure(let message, _, _) = result else {
+      Issue.record("Expected timeout failure, got \(result)")
+      return
+    }
+    #expect(message == "Timed out after 2000 ms")
+    #expect(started.duration(to: clock.now) < .seconds(4))
+    let pid = try #require(Int32(
+      String(contentsOf: pidURL, encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    ))
+    defer { _ = Darwin.kill(pid, SIGKILL) }
+    let stopDeadline = clock.now.advanced(by: .seconds(2))
+    var probe = Darwin.kill(pid, 0)
+    while probe == 0, clock.now < stopDeadline {
+      try await Task.sleep(for: .milliseconds(10))
+      probe = Darwin.kill(pid, 0)
+    }
+    #expect(probe == -1)
+    #expect(errno == ESRCH)
+  }
+
+  @Test
+  func `leader exit also terminates surviving descendants`() async throws {
+    let directory = FileManager.default.temporaryDirectory
+      .appendingPathComponent("tatami-hook-exit-\(UUID().uuidString)", isDirectory: true)
+    try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+    defer { try? FileManager.default.removeItem(at: directory) }
+    let pidURL = directory.appendingPathComponent("child.pid")
+    let script = """
+      /bin/zsh -c 'trap "" TERM; print -r -- $$ > "$1"; i=0; while (( i < 30 )); do /bin/sleep 1; (( i++ )); done' child "\(pidURL.path)" &
+      while [[ ! -s "\(pidURL.path)" ]]; do /bin/sleep 0.01; done
+      """
+    let hook = HookDefinition(
+      id: "descendant",
+      event: .profileChanged,
+      command: ["/bin/zsh", "-c", script],
+      timeoutMs: 5_000,
+    )
+
+    let result = await HookRunnerClient.liveValue.run(hook, invocation())
+    #expect(result == .success(stdout: "", stderr: ""))
+    let pid = try #require(Int32(
+      String(contentsOf: pidURL, encoding: .utf8)
+        .trimmingCharacters(in: .whitespacesAndNewlines)
+    ))
+    defer { _ = Darwin.kill(pid, SIGKILL) }
+    #expect(Darwin.kill(pid, 0) == -1)
+    #expect(errno == ESRCH)
+  }
+
+  @Test
+  func `parent cancellation returns cancelled`() async {
+    let hook = HookDefinition(
+      id: "cancel",
+      event: .profileChanged,
+      command: ["/bin/sleep", "10"],
+      timeoutMs: 5_000,
+    )
+    let task = Task {
+      await HookRunnerClient.liveValue.run(hook, invocation())
+    }
+    await Task.yield()
+    task.cancel()
+
+    #expect(await task.value == .cancelled)
+  }
+
+  // MARK: Private
+
+  private func invocation() -> HookInvocation {
+    HookInvocation(
+      event: .profileChanged,
+      occurredAt: Date(timeIntervalSince1970: 0),
+      profile: .init(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+        name: "Default",
+      ),
+    )
+  }
+
+}
+
+// MARK: - HooksFeatureTests
+
+@MainActor
+struct HooksFeatureTests {
+
+  // MARK: Internal
+
+  @Test
+  func `matching enabled hooks run and failures resolve per hook`() async {
+    let matching = HookDefinition(
+      id: "matching",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    let disabled = HookDefinition(
+      id: "disabled",
+      event: .workspaceActivated,
+      enabled: false,
+      command: ["/usr/bin/true"],
+    )
+    let otherEvent = HookDefinition(
+      id: "profile",
+      event: .profileChanged,
+      command: ["/usr/bin/true"],
+    )
+    let state = HooksFeature.State()
+    state.$config = Shared(value: AppConfig(hooks: [matching, disabled, otherEvent]))
+    let ran = LockIsolated<[String]>([])
+    let resolved = LockIsolated<[String]>([])
+    let store = TestStore(initialState: state) {
+      HooksFeature()
+    } withDependencies: {
+      $0.hookRunner.run = { hook, _ in
+        ran.withValue { $0.append(hook.id) }
+        return .success(stdout: "", stderr: "")
+      }
+      $0.errorReporter.resolve = { domain in
+        resolved.withValue { $0.append(domain) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.emit(workspaceInvocation()))
+    await store.finish()
+
+    #expect(ran.value == ["matching"])
+    #expect(resolved.value.contains("Hook:matching"))
+  }
+
+  @Test
+  func `consecutive lifecycle events both run without cancelling each other`() async {
+    let hook = HookDefinition(
+      id: "notify",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    let state = HooksFeature.State()
+    state.$config = Shared(value: AppConfig(hooks: [hook]))
+    let started = LockIsolated<[Date]>([])
+    let cancelled = LockIsolated(0)
+    let store = TestStore(initialState: state) {
+      HooksFeature()
+    } withDependencies: {
+      $0.hookRunner.run = { _, invocation in
+        started.withValue { $0.append(invocation.occurredAt) }
+        do {
+          try await Task.sleep(for: .milliseconds(50))
+          return .success(stdout: "", stderr: "")
+        } catch {
+          cancelled.withValue { $0 += 1 }
+          return .cancelled
+        }
+      }
+    }
+    store.exhaustivity = .off
+    var secondInvocation = workspaceInvocation()
+    secondInvocation.occurredAt.addTimeInterval(1)
+
+    await store.send(.emit(workspaceInvocation()))
+    await store.send(.emit(secondInvocation))
+    await store.finish()
+
+    #expect(Set(started.value) == Set([
+      workspaceInvocation().occurredAt,
+      secondInvocation.occurredAt,
+    ]))
+    #expect(cancelled.value == 0)
+  }
+
+  @Test
+  func `runtime failure reports first stderr line and later success resolves`() async {
+    let reports = LockIsolated<[(String, String?)]>([])
+    let resolved = LockIsolated<[String]>([])
+    var state = HooksFeature.State()
+    state.latestGenerationByHookID["notify"] = 1
+    state.$config = Shared(value: AppConfig())
+    let store = TestStore(initialState: state) {
+      HooksFeature()
+    } withDependencies: {
+      $0.errorReporter.report = { domain, _, detail in
+        reports.withValue { $0.append((domain, detail)) }
+      }
+      $0.errorReporter.resolve = { domain in
+        resolved.withValue { $0.append(domain) }
+      }
+    }
+
+    await store.send(.hookFinished(
+      id: "notify",
+      generation: 1,
+      .failure(message: "Exited", stdout: "", stderr: "first\nsecond"),
+    )) {
+      $0.failingHookIDs.insert("notify")
+    }
+    await store.send(.hookFinished(
+      id: "notify",
+      generation: 1,
+      .success(stdout: "", stderr: ""),
+    )) {
+      $0.failingHookIDs.remove("notify")
+    }
+
+    #expect(reports.value.first?.0 == "Hook:notify")
+    #expect(reports.value.first?.1 == "first")
+    #expect(resolved.value == ["Hook:notify"])
+  }
+
+  @Test
+  func `stale completion cannot overwrite the latest hook result`() async {
+    let resolved = LockIsolated<[String]>([])
+    let logs = LockIsolated<[String]>([])
+    var state = HooksFeature.State()
+    state.latestGenerationByHookID["notify"] = 2
+    state.failingHookIDs.insert("notify")
+    let store = TestStore(initialState: state) {
+      HooksFeature()
+    } withDependencies: {
+      $0.errorReporter.resolve = { domain in
+        resolved.withValue { $0.append(domain) }
+      }
+      $0.debugLog.isEnabled = { true }
+      $0.debugLog.log = { _, message in logs.withValue { $0.append(message) } }
+    }
+
+    await store.send(.hookFinished(
+      id: "notify",
+      generation: 1,
+      .success(stdout: "old", stderr: ""),
+    ))
+    #expect(resolved.value.isEmpty)
+    #expect(store.state.failingHookIDs == ["notify"])
+    #expect(logs.value.contains { $0.contains("old") })
+
+    await store.send(.hookFinished(
+      id: "notify",
+      generation: 1,
+      .failure(message: "Old failure", stdout: "", stderr: "stale stderr"),
+    ))
+    #expect(logs.value.contains { $0.contains("Old failure") })
+    #expect(logs.value.contains { $0.contains("stale stderr") })
+  }
+
+  @Test
+  func `disabling a failed hook resolves its standing runtime problem`() async {
+    let hook = HookDefinition(
+      id: "notify",
+      event: .workspaceActivated,
+      command: ["/usr/bin/true"],
+    )
+    let disabled = HookDefinition(
+      id: hook.id,
+      event: hook.event,
+      enabled: false,
+      command: hook.command,
+    )
+    let resolved = LockIsolated<[String]>([])
+    var state = HooksFeature.State()
+    state.activeDefinitions[hook.id] = hook
+    state.failingHookIDs.insert(hook.id)
+    state.latestGenerationByHookID[hook.id] = 1
+    state.$config = Shared(value: AppConfig(hooks: [disabled]))
+    let store = TestStore(initialState: state) {
+      HooksFeature()
+    } withDependencies: {
+      $0.errorReporter.resolve = { domain in
+        resolved.withValue { $0.append(domain) }
+      }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.configurationChanged) {
+      $0.activeDefinitions = [:]
+      $0.failingHookIDs = []
+      $0.latestGenerationByHookID[hook.id] = 2
+    }
+
+    #expect(resolved.value.contains("Hook:notify"))
+  }
+
+  @Test
+  func `changing a failed hook resolves the old definition problem`() async {
+    let hook = HookDefinition(
+      id: "notify",
+      event: .workspaceActivated,
+      command: ["/usr/bin/false"],
+    )
+    let changed = HookDefinition(
+      id: hook.id,
+      event: hook.event,
+      command: ["/usr/bin/true"],
+    )
+    let resolved = LockIsolated<[String]>([])
+    var state = HooksFeature.State()
+    state.activeDefinitions[hook.id] = hook
+    state.failingHookIDs.insert(hook.id)
+    state.latestGenerationByHookID[hook.id] = 1
+    state.$config = Shared(value: AppConfig(hooks: [changed]))
+    let store = TestStore(initialState: state) {
+      HooksFeature()
+    } withDependencies: {
+      $0.errorReporter.resolve = { domain in
+        resolved.withValue { $0.append(domain) }
+      }
+      $0.hookRunner.run = { _, _ in .success(stdout: "", stderr: "") }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.emit(workspaceInvocation()))
+    await store.finish()
+
+    #expect(resolved.value.contains("Hook:notify"))
+    #expect(store.state.activeDefinitions[hook.id] == changed)
+    #expect(store.state.failingHookIDs.isEmpty)
+  }
+
+  // MARK: Private
+
+  private func workspaceInvocation() -> HookInvocation {
+    HookInvocation(
+      event: .workspaceActivated,
+      occurredAt: Date(timeIntervalSince1970: 0),
+      profile: .init(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000001")!,
+        name: "Default",
+      ),
+      workspace: .init(
+        id: UUID(uuidString: "00000000-0000-0000-0000-000000000002")!,
+        name: "Work",
+        kind: .normal,
+      ),
+    )
+  }
+
+}

--- a/TatamiTests/Sources/HotKeyTests.swift
+++ b/TatamiTests/Sources/HotKeyTests.swift
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2026 PangMo5 and contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import CustomDump
 import Foundation
 import Testing
 @testable import TatamiKit
@@ -52,5 +53,191 @@ struct HotKeyTests {
 
     #expect(reverse.holdModifiers == .option)
     #expect(shiftOnly.holdModifiers == .shift)
+  }
+}
+
+@Suite("Profile-scoped hot keys")
+struct ProfileScopedHotKeyTests {
+  @Test
+  func runtimeProjectionRegistersOnlyTheSelectedProfilesWorkspaceBinding() throws {
+    let key = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let defaultWorkspaceId = try #require(
+      UUID(uuidString: "00000000-0000-0000-0000-000000000011")
+    )
+    let dualWorkspaceId = try #require(
+      UUID(uuidString: "00000000-0000-0000-0000-000000000012")
+    )
+    let defaultProfileId = try #require(
+      UUID(uuidString: "00000000-0000-0000-0000-000000000001")
+    )
+    let dualProfileId = try #require(
+      UUID(uuidString: "00000000-0000-0000-0000-000000000002")
+    )
+    let defaultWorkspace = Workspace(
+      id: defaultWorkspaceId,
+      name: "Default A",
+      activateShortcut: key
+    )
+    let dualWorkspace = Workspace(
+      id: dualWorkspaceId,
+      name: "Dual A",
+      activateShortcut: key
+    )
+    let defaultProfile = Profile(
+      id: defaultProfileId,
+      name: "Default",
+      workspaces: [defaultWorkspace]
+    )
+    let dualProfile = Profile(
+      id: dualProfileId,
+      name: "Dual",
+      workspaces: [dualWorkspace]
+    )
+    var config = AppConfig(
+      profiles: [defaultProfile, dualProfile],
+      activeProfileId: defaultProfile.id
+    )
+
+    expectNoDifference(
+      config.hotKeyBindings.filter { $0.hotKey == key }.map(\.action),
+      [.activateWorkspace(defaultWorkspace.id)]
+    )
+
+    config.activeProfileId = dualProfile.id
+    expectNoDifference(
+      config.hotKeyBindings.filter { $0.hotKey == key }.map(\.action),
+      [.activateWorkspace(dualWorkspace.id)]
+    )
+  }
+
+  @Test
+  func inactiveProfileCanReuseAWorkspaceKeyFromTheActiveProfile() throws {
+    let key = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let defaultWorkspace = Workspace(name: "Default A", keyEquivalent: "a")
+    let dualWorkspace = Workspace(name: "Dual A", keyEquivalent: "a")
+    let defaultProfile = Profile(name: "Default", workspaces: [defaultWorkspace])
+    let dualProfile = Profile(name: "Dual", workspaces: [dualWorkspace])
+    let config = AppConfig(
+      profiles: [defaultProfile, dualProfile],
+      activeProfileId: defaultProfile.id
+    )
+
+    #expect(
+      config.shortcutConflict(
+        for: key,
+        excluding: .activateWorkspace(dualWorkspace.id),
+        in: dualProfile.id
+      ) == nil
+    )
+  }
+
+  @Test
+  func inactiveProfileStillRejectsAKeyUsedByItsSiblingWorkspace() throws {
+    let key = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let defaultWorkspace = Workspace(name: "Default A", keyEquivalent: "a")
+    let dualWorkspace = Workspace(name: "Dual A")
+    let dualSibling = Workspace(name: "Dual sibling", keyEquivalent: "a")
+    let defaultProfile = Profile(name: "Default", workspaces: [defaultWorkspace])
+    let dualProfile = Profile(name: "Dual", workspaces: [dualWorkspace, dualSibling])
+    let config = AppConfig(
+      profiles: [defaultProfile, dualProfile],
+      activeProfileId: defaultProfile.id
+    )
+    let expectedTitle = String(localized: "Activate \(dualSibling.name)")
+
+    #expect(
+      config.shortcutConflict(
+        for: key,
+        excluding: .activateWorkspace(dualWorkspace.id),
+        in: dualProfile.id
+      ) == expectedTitle
+    )
+  }
+
+  @Test
+  func globalShortcutRejectsAKeyUsedByAnInactiveProfilesWorkspace() throws {
+    let key = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let defaultProfile = Profile(name: "Default")
+    let dualWorkspace = Workspace(name: "Dual A", activateShortcut: key)
+    let dualProfile = Profile(name: "Dual", workspaces: [dualWorkspace])
+    let config = AppConfig(
+      profiles: [defaultProfile, dualProfile],
+      activeProfileId: defaultProfile.id
+    )
+    let expectedTitle = String(localized: "Activate \(dualWorkspace.name)")
+
+    #expect(
+      config.shortcutConflict(
+        for: key,
+        excluding: .focusLeft
+      ) == expectedTitle
+    )
+  }
+
+  @Test
+  func workspaceKeyEquivalentIgnoresActionsWithExplicitOverrides() throws {
+    let derivedKey = try #require(HotKey(parsing: "ctrl - a"))
+    let explicitKey = try #require(HotKey(parsing: "cmd - x"))
+    let workspace = Workspace(name: "Coding", activateShortcut: explicitKey)
+    var settings = AppSettings()
+    settings.shortcuts.keyEquivalentModifiers = ["ctrl"]
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    settings.shortcuts.focusLeft = derivedKey
+    var config = AppConfig(
+      profiles: [Profile(name: "Default", workspaces: [workspace])],
+      settings: settings
+    )
+
+    #expect(
+      config.workspaceKeyEquivalentConflict(
+        for: "a",
+        workspaceId: workspace.id
+      ) == nil
+    )
+
+    config.profiles[0].workspaces[0].activateShortcut = nil
+    #expect(
+      config.workspaceKeyEquivalentConflict(
+        for: "a",
+        workspaceId: workspace.id
+      ) == String(localized: "Focus left")
+    )
+  }
+
+  @Test
+  func navigationKeyEquivalentIgnoresActionsWithExplicitOverrides() throws {
+    let derivedKey = try #require(HotKey(parsing: "ctrl - a"))
+    let explicitKey = try #require(HotKey(parsing: "cmd - x"))
+    var settings = AppSettings()
+    settings.shortcuts.keyEquivalentModifiers = ["ctrl"]
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    settings.shortcuts.focusLeft = derivedKey
+    let config = AppConfig(settings: settings)
+
+    #expect(
+      config.navigationKeyEquivalentConflict(
+        for: "a",
+        switchAction: .switchToRecentWorkspace,
+        switchOverride: explicitKey,
+        assignAction: .assignFocusedAppToRecentWorkspace,
+        assignOverride: nil,
+        borrowAction: .borrowRecentWorkspace,
+        borrowOverride: nil
+      ) == nil
+    )
+
+    #expect(
+      config.navigationKeyEquivalentConflict(
+        for: "a",
+        switchAction: .switchToRecentWorkspace,
+        switchOverride: nil,
+        assignAction: .assignFocusedAppToRecentWorkspace,
+        assignOverride: nil,
+        borrowAction: .borrowRecentWorkspace,
+        borrowOverride: nil
+      ) == String(localized: "Focus left")
+    )
   }
 }

--- a/TatamiTests/Sources/ProfileSyncTests.swift
+++ b/TatamiTests/Sources/ProfileSyncTests.swift
@@ -63,6 +63,22 @@ struct ProfileSyncTests {
     #expect(target.displayHint == "Built-in") // display left alone
   }
 
+  @Test
+  func effectiveSelectionDropsStaleAndDisabledChildIDs() {
+    let selected: Set<String> = ["parent", "child", "stale"]
+    let valid: Set<String> = ["parent", "child"]
+    #expect(WorkspaceSync.effectiveSelection(
+      selected: selected,
+      validIDs: valid,
+      parentByItemID: ["child": "parent"]
+    ) == ["parent", "child"])
+    #expect(WorkspaceSync.effectiveSelection(
+      selected: ["child", "stale"],
+      validIDs: valid,
+      parentByItemID: ["child": "parent"]
+    ).isEmpty)
+  }
+
   // MARK: - Profile sync
 
   private func twoProfiles() -> AppConfig {
@@ -119,5 +135,257 @@ struct ProfileSyncTests {
     #expect(ws.apps.map(\.bundleIdentifier) == ["x", "y"])
     #expect(ws.symbolIconName == "star") // pulled
     #expect(ws.displayHint == "Built-in") // excluded, kept
+  }
+
+  // MARK: - Shortcut-safe projections
+
+  @Test
+  func workspaceImportUsesProjectedExplicitOverridePrecedence() throws {
+    let explicit = try #require(HotKey(parsing: "cmd - x"))
+    let derived = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let sourceWorkspace = Workspace(
+      name: "Source",
+      activateShortcut: explicit,
+      keyEquivalent: "a"
+    )
+    let targetWorkspace = Workspace(name: "Target", keyEquivalent: "b")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    settings.shortcuts.focusLeft = derived
+    let config = AppConfig(profiles: [target, source], settings: settings)
+
+    let allSelected = try #require(config.workspaceImportProjection(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    ))
+    #expect(allSelected.conflicts.isEmpty)
+    #expect(allSelected.config.workspace(id: targetWorkspace.id)?.keyEquivalent == "a")
+    #expect(allSelected.config.workspace(id: targetWorkspace.id)?.activateShortcut == explicit)
+
+    let withoutOverride = try #require(config.workspaceImportProjection(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id,
+      excludingFields: [WorkspaceShortcutField.activateShortcut.rawValue]
+    ))
+    #expect(withoutOverride.conflicts.map(\.selection.field) == [.keyEquivalent])
+    #expect(withoutOverride.conflicts.map(\.hotKey) == [derived])
+  }
+
+  @Test
+  func profileSyncDetectsConflictsBetweenSelectedWorkspaceKeys() throws {
+    let firstOverride = try #require(HotKey(parsing: "cmd - x"))
+    let secondOverride = try #require(HotKey(parsing: "cmd - y"))
+    let sourceFirst = Workspace(
+      name: "First",
+      activateShortcut: firstOverride,
+      keyEquivalent: "a"
+    )
+    let sourceSecond = Workspace(
+      name: "Second",
+      activateShortcut: secondOverride,
+      keyEquivalent: "a"
+    )
+    let targetFirst = Workspace(name: "First", keyEquivalent: "b")
+    let targetSecond = Workspace(name: "Second", keyEquivalent: "c")
+    let source = Profile(name: "Source", workspaces: [sourceFirst, sourceSecond])
+    let target = Profile(name: "Target", workspaces: [targetFirst, targetSecond])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    let config = AppConfig(profiles: [target, source], settings: settings)
+
+    let projection = try #require(config.profileSyncProjection(
+      into: target.id,
+      from: source.id,
+      excludedFieldsByWorkspace: [
+        targetFirst.id: [WorkspaceShortcutField.activateShortcut.rawValue],
+        targetSecond.id: [WorkspaceShortcutField.activateShortcut.rawValue],
+      ]
+    ))
+
+    #expect(Set(projection.conflicts.map(\.selection)) == [
+      .init(workspaceId: targetFirst.id, field: .keyEquivalent),
+      .init(workspaceId: targetSecond.id, field: .keyEquivalent),
+    ])
+    #expect(Set(projection.conflicts.map(\.hotKey)).count == 1)
+  }
+
+  @Test
+  func workspaceKeysMayBeReusedAcrossProfiles() throws {
+    let sourceWorkspace = Workspace(name: "Browser", keyEquivalent: "a")
+    let targetWorkspace = Workspace(name: "Browser", keyEquivalent: "b")
+    let source = Profile(name: "Default", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Dual", workspaces: [targetWorkspace])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    let config = AppConfig(profiles: [source, target], settings: settings)
+
+    let projection = try #require(config.profileSyncProjection(
+      into: target.id,
+      from: source.id
+    ))
+
+    #expect(projection.conflicts.isEmpty)
+    #expect(projection.config.workspace(id: targetWorkspace.id)?.keyEquivalent == "a")
+  }
+
+  @Test
+  func unrelatedLegacyConflictDoesNotBlockNonShortcutCopy() throws {
+    let legacyConflict = try #require(HotKey(parsing: "cmd - h"))
+    let sourceWorkspace = Workspace(name: "Source", symbolIconName: "star")
+    let targetWorkspace = Workspace(name: "Target", symbolIconName: "bolt")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    var settings = AppSettings()
+    settings.shortcuts.focusLeft = legacyConflict
+    settings.shortcuts.focusRight = legacyConflict
+    var config = AppConfig(profiles: [target, source], settings: settings)
+
+    let conflicts = config.importWorkspace(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    )
+
+    #expect(conflicts.isEmpty)
+    #expect(config.workspace(id: targetWorkspace.id)?.symbolIconName == "star")
+  }
+
+  @Test
+  func representationOnlyExplicitOverrideDoesNotIntroduceLegacyConflict() throws {
+    let effectiveKey = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let sourceWorkspace = Workspace(
+      name: "Source",
+      activateShortcut: effectiveKey,
+      keyEquivalent: "a"
+    )
+    let targetWorkspace = Workspace(name: "Target", keyEquivalent: "a")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    settings.shortcuts.focusLeft = effectiveKey
+    var config = AppConfig(profiles: [target, source], settings: settings)
+
+    let projection = try #require(config.workspaceImportProjection(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    ))
+    #expect(projection.conflicts.isEmpty)
+
+    let conflicts = config.importWorkspace(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    )
+    #expect(conflicts.isEmpty)
+    #expect(config.workspace(id: targetWorkspace.id)?.activateShortcut == effectiveKey)
+  }
+
+  @Test
+  func counterfactualAttributesCombinedCollisionOnlyToCausalField() throws {
+    let effectiveKey = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let sourceWorkspace = Workspace(
+      name: "Source",
+      activateShortcut: effectiveKey,
+      assignAppShortcut: effectiveKey,
+      keyEquivalent: "a"
+    )
+    let targetWorkspace = Workspace(name: "Target", keyEquivalent: "a")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    let config = AppConfig(profiles: [target, source], settings: settings)
+
+    let projection = try #require(config.workspaceImportProjection(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    ))
+
+    #expect(projection.conflicts.map(\.selection.field) == [.assignAppShortcut])
+    #expect(projection.conflicts.map(\.hotKey) == [effectiveKey])
+  }
+
+  @Test
+  func jointKeyAndExplicitFieldsCannotHideIntroducedCollision() throws {
+    let conflictingKey = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let sourceWorkspace = Workspace(
+      name: "Source",
+      activateShortcut: conflictingKey,
+      keyEquivalent: "a"
+    )
+    let targetWorkspace = Workspace(name: "Target", keyEquivalent: "b")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    var settings = AppSettings()
+    settings.shortcuts.assignModifiers = []
+    settings.shortcuts.borrowModifiers = []
+    settings.shortcuts.focusLeft = conflictingKey
+    var config = AppConfig(profiles: [target, source], settings: settings)
+
+    let projection = try #require(config.workspaceImportProjection(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    ))
+
+    #expect(Set(projection.conflicts.map(\.selection.field)) == [
+      .keyEquivalent,
+      .activateShortcut,
+    ])
+    let conflicts = config.importWorkspace(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    )
+    #expect(!conflicts.isEmpty)
+    #expect(config.workspace(id: targetWorkspace.id)?.keyEquivalent == "b")
+    #expect(config.workspace(id: targetWorkspace.id)?.activateShortcut == nil)
+  }
+
+  @Test
+  func applyRevalidatesCurrentConfigAndRejectsWholeCopy() throws {
+    let derived = try #require(HotKey(parsing: "ctrl + alt - a"))
+    let copiedApp = app("copied")
+    let sourceWorkspace = Workspace(
+      name: "Source",
+      keyEquivalent: "a",
+      apps: [copiedApp]
+    )
+    let targetWorkspace = Workspace(name: "Target", keyEquivalent: "b")
+    let source = Profile(name: "Source", workspaces: [sourceWorkspace])
+    let target = Profile(name: "Target", workspaces: [targetWorkspace])
+    var config = AppConfig(profiles: [target, source])
+
+    let chooserProjection = try #require(config.workspaceImportProjection(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    ))
+    #expect(chooserProjection.conflicts.isEmpty)
+
+    // Simulate a shortcut edit landing after the sheet rendered but before
+    // Apply. The mutation must be validated against this current config.
+    config.settings.shortcuts.focusLeft = derived
+    let conflicts = config.importWorkspace(
+      into: targetWorkspace.id,
+      from: source.id,
+      sourceWorkspace: sourceWorkspace.id
+    )
+
+    #expect(!conflicts.isEmpty)
+    #expect(config.workspace(id: targetWorkspace.id)?.keyEquivalent == "b")
+    #expect(config.workspace(id: targetWorkspace.id)?.apps.isEmpty == true)
   }
 }

--- a/TatamiTests/Sources/WorkspaceActivationTests.swift
+++ b/TatamiTests/Sources/WorkspaceActivationTests.swift
@@ -836,7 +836,7 @@ struct WorkspaceActivationFeatureTests {
     let composition = Composition(
       host: browser.id,
       borrowed: [
-        BorrowedSlot(workspace: figma.id, edge: .right, fraction: 0.4),
+        BorrowedSlot(workspace: figma.id, edge: .right, fraction: 0.4)
       ],
     )
     let state = Self.makeState(workspaces: [browser, terminal, figma]) {
@@ -896,7 +896,7 @@ struct WorkspaceActivationFeatureTests {
     let composition = Composition(
       host: browser.id,
       borrowed: [
-        BorrowedSlot(workspace: figma.id, edge: .right, fraction: 0.4),
+        BorrowedSlot(workspace: figma.id, edge: .right, fraction: 0.4)
       ],
     )
     let state = Self.makeState(workspaces: [browser, terminal, figma]) {
@@ -976,7 +976,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activate(workspaceId: browser.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == browser.id && display == displayA
     }
     await store.finish()
@@ -1005,7 +1005,7 @@ struct WorkspaceActivationFeatureTests {
     let composition = Composition(
       host: browser.id,
       borrowed: [
-        BorrowedSlot(workspace: figma.id, edge: .right, fraction: 0.4),
+        BorrowedSlot(workspace: figma.id, edge: .right, fraction: 0.4)
       ],
     )
     let state = Self.makeState(workspaces: [browser, terminal, figma]) {
@@ -1078,7 +1078,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activate(workspaceId: homeless.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == homeless.id && display == only
     }
     await store.finish()
@@ -1134,7 +1134,7 @@ struct WorkspaceActivationFeatureTests {
     // Browser is dynamic and the pointer is on A, so it leaves B.
     await store.send(.activate(workspaceId: browser.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == browser.id && display == displayA
     }
     await store.finish()
@@ -1295,7 +1295,8 @@ struct WorkspaceActivationFeatureTests {
 
     // Follows the raised window, not the workspace's MRU pick — otherwise a
     // multi-window app gives no clue which window took focus.
-    let target = try? #require(frames[second])
+    let target = frames[second]
+    #expect(target != nil)
     #expect(warps.value == [CGPoint(x: target?.midX ?? 0, y: target?.midY ?? 0)])
   }
 
@@ -1324,7 +1325,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activate(workspaceId: browser.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == browser.id && display == displayA
     }
     await store.finish()
@@ -1404,7 +1405,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activateRecent)
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == localRecent.id && display == displayA
     }
     await store.finish()
@@ -1496,7 +1497,7 @@ struct WorkspaceActivationFeatureTests {
   @Test(arguments: AutoBalanceMode.allCases)
   func `fresh activation initializes a missing layout from auto balance`(
     mode: AutoBalanceMode
-  ) async {
+  ) async throws {
     let keys = [
       WindowKey(pid: 1, windowID: 101, bundleId: "app.one"),
       WindowKey(pid: 2, windowID: 202, bundleId: "app.two"),
@@ -1510,14 +1511,14 @@ struct WorkspaceActivationFeatureTests {
       },
     )
     let workArea = CGRect(x: 0, y: 0, width: 1_000, height: 800)
-    let initial = WorkspaceActivationFeature.mergeTree(
+    let initial = try #require(WorkspaceActivationFeature.mergeTree(
       existing: nil,
       target: keys,
       focused: { nil },
       insertionPoint: nil,
       workArea: workArea,
       settings: AppSettings(),
-    )!
+    ))
     let expected = initial.balancedForCommand(
       autoBalance: mode,
       in: workArea,
@@ -1549,7 +1550,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activate(workspaceId: workspace.id, setFocus: false))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, _) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, _, _) = $0 else { return false }
       return workspaceId == workspace.id
     }
     await store.finish()
@@ -1564,6 +1565,8 @@ struct WorkspaceActivationFeatureTests {
     let state = Self.makeState(workspaces: [ws1, ws2]) {
       $0.activeWorkspacesByDisplay[Self.display] = ws1.id
       $0.isActivating = true
+      $0.activationGeneration = 1
+      $0.activeActivationGeneration = 1
     }
     let savedHistory = LockIsolated<[DisplayName: [UUID]]?>(nil)
     let savedMRU = LockIsolated<[UUID]?>(nil)
@@ -1577,7 +1580,11 @@ struct WorkspaceActivationFeatureTests {
       }
     }
 
-    await store.send(.activationCompleted(workspaceId: ws2.id, display: Self.display)) {
+    await store.send(.activationCompleted(
+      workspaceId: ws2.id,
+      display: Self.display,
+      generation: 1,
+    )) {
       $0.isActivating = false
       $0.previousWorkspacesByDisplay[Self.display] = ws1.id
       $0.activeWorkspacesByDisplay[Self.display] = ws2.id
@@ -1592,7 +1599,316 @@ struct WorkspaceActivationFeatureTests {
   }
 
   @Test
-  func `restored workspace history keeps only valid normal workspaces`() async {
+  func `CLI activation completes only after the activation tail`() async {
+    let workspace = Workspace(name: "CLI")
+    let state = Self.makeState(workspaces: [workspace]) {
+      $0.isActivating = true
+      $0.activationGeneration = 1
+      $0.activeActivationGeneration = 1
+    }
+    let completions = LockIsolated<[String?]>([])
+    let request = WorkspaceActivationFeature.CLIActivationRequest(
+      target: .workspace(workspace.id),
+      complete: { error in completions.withValue { $0.append(error) } },
+    )
+    let store = TestStore(initialState: state) {
+      WorkspaceActivationFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.trackCLIActivation(request, joinCurrentActivation: true))
+    await store.send(.activationCompleted(
+      workspaceId: workspace.id,
+      display: Self.display,
+      generation: 1,
+    ))
+    #expect(completions.value.isEmpty)
+
+    await store.send(.activationTailFinished(generation: 1))
+    await store.finish()
+
+    #expect(completions.value == [nil])
+  }
+
+  @Test
+  func `external deliberate activation supersedes profile CLI restore exactly once`() async throws {
+    let display = Self.display
+    let current = Workspace(name: "Current")
+    let target = Workspace(name: "Target")
+    let state = Self.makeState(workspaces: [current, target]) {
+      $0.isActivating = true
+      $0.activationGeneration = 1
+      $0.activeActivationGeneration = 1
+      $0.activeWorkspacesByDisplay[display] = target.id
+      $0.focusedDisplay = display
+      $0.tilingTrees[target.id] = .leaf(
+        WindowKey(pid: 1, windowID: 101, bundleId: "app.target")
+      )
+    }
+    let completions = LockIsolated<[String?]>([])
+    let request = WorkspaceActivationFeature.CLIActivationRequest(
+      target: .profile(try #require(state.config.activeProfile?.id)),
+      complete: { error in completions.withValue { $0.append(error) } },
+    )
+    let store = TestStore(initialState: state) {
+      WorkspaceActivationFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.displays.current = { display }
+      $0.floatingOverlay.retainOnly = { _ in }
+      $0.floatingOverlay.setFloating = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.trackCLIActivation(request, joinCurrentActivation: true))
+    await store.send(.activate(workspaceId: target.id, setFocus: true))
+    await store.finish()
+
+    #expect(completions.value.count == 1)
+    #expect(completions.value.compactMap { $0 }.first?.contains("superseded") == true)
+    #expect(store.state.pendingCLIActivation == nil)
+    #expect(store.state.pendingCLIActivationBinding == nil)
+  }
+
+  @Test
+  func `stale completion and watchdog cannot terminate the current activation`() async {
+    let current = Workspace(name: "Current")
+    let stale = Workspace(name: "Stale")
+    let state = Self.makeState(workspaces: [current, stale]) {
+      $0.isActivating = true
+      $0.activationGeneration = 2
+      $0.activeActivationGeneration = 2
+      $0.activatingWorkspaceID = current.id
+      $0.activeWorkspacesByDisplay[Self.display] = current.id
+    }
+    let store = TestStore(initialState: state) {
+      WorkspaceActivationFeature()
+    }
+
+    await store.send(.activationCompleted(
+      workspaceId: stale.id,
+      display: Self.display,
+      generation: 1,
+    ))
+    await store.send(.activationTimedOut(generation: 1))
+
+    #expect(store.state.isActivating)
+    #expect(store.state.activeActivationGeneration == 2)
+    #expect(store.state.activatingWorkspaceID == current.id)
+    #expect(store.state.activeWorkspacesByDisplay[Self.display] == current.id)
+  }
+
+  @Test
+  func `removed workspace cannot complete from a stale active display mapping`() async {
+    let live = Workspace(name: "Live")
+    let removedID = UUID()
+    let completions = LockIsolated<[String?]>([])
+    let request = WorkspaceActivationFeature.CLIActivationRequest(
+      target: .workspace(removedID),
+      complete: { error in completions.withValue { $0.append(error) } },
+    )
+    let state = Self.makeState(workspaces: [live]) {
+      $0.activeWorkspacesByDisplay[Self.display] = removedID
+      $0.pendingCLIActivation = request
+    }
+    let store = TestStore(initialState: state) {
+      WorkspaceActivationFeature()
+    }
+    store.exhaustivity = .off
+
+    await store.send(.cliActivationEffectFinished(
+      workspaceId: removedID,
+      requestID: request.id,
+    ))
+    await store.finish()
+
+    #expect(completions.value == ["The requested workspace no longer exists"])
+    #expect(store.state.pendingCLIActivation == nil)
+  }
+
+  @Test(arguments: [false, true])
+  func `visible CLI activation supersedes an active generation`(
+    coreAlreadyCompleted: Bool
+  ) async {
+    let display = Self.display
+    let visible = Workspace(name: "Visible")
+    let inFlight = Workspace(name: "In Flight")
+    let window = WindowKey(pid: 1, windowID: 101, bundleId: "app.visible")
+    let profile = Profile(name: "Default", workspaces: [visible, inFlight])
+    let sharedConfig = Shared(value: AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+    var state = WorkspaceActivationFeature.State()
+    state.$config = sharedConfig
+    state.activeWorkspacesByDisplay[display] = visible.id
+    state.focusedDisplay = display
+    state.tilingTrees[visible.id] = .leaf(window)
+    state.isActivating = !coreAlreadyCompleted
+    state.activatingWorkspaceID = coreAlreadyCompleted ? nil : inFlight.id
+    state.activationGeneration = 1
+    state.activeActivationGeneration = 1
+    let completions = LockIsolated<[String?]>([])
+    let request = WorkspaceActivationFeature.CLIActivationRequest(
+      target: .workspace(visible.id),
+      complete: { error in completions.withValue { $0.append(error) } },
+    )
+    let (activationGate, activationGateContinuation) = AsyncStream<Void>.makeStream()
+    let store = TestStore(initialState: state) {
+      WorkspaceActivationFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.displays.current = { display }
+      $0.displays.workArea = { _ in CGRect(x: 0, y: 0, width: 1_000, height: 800) }
+      $0.workspaceManager.activate = { _ in
+        for await _ in activationGate { break }
+      }
+      $0.floatingOverlay.retainOnly = { _ in }
+      $0.floatingOverlay.setFloating = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.trackCLIActivation(request, joinCurrentActivation: false))
+    await store.send(.activateFromCLI(workspaceId: visible.id, requestID: request.id))
+
+    #expect(store.state.activationGeneration == 2)
+    #expect(store.state.activeActivationGeneration == 2)
+    #expect(store.state.activatingWorkspaceID == visible.id)
+    #expect(store.state.pendingCLIActivationBinding == .init(
+      requestID: request.id,
+      activationGeneration: 2,
+    ))
+    #expect(completions.value.isEmpty)
+
+    await store.send(.activationTailFinished(generation: 1))
+    #expect(completions.value.isEmpty)
+    await store.send(.activationTimedOut(generation: 2))
+    activationGateContinuation.finish()
+    await store.finish()
+
+    #expect(completions.value == ["Workspace activation timed out"])
+  }
+
+  @Test(arguments: [false, true])
+  func `missing restore fails its CLI request once and drains valid work`(
+    requestTargetWasRemoved: Bool
+  ) async {
+    let missingID = UUID()
+    let live = Workspace(name: "Live")
+    let profile = Profile(name: "Default", workspaces: [live])
+    let sharedConfig = Shared(value: AppConfig(
+      profiles: [profile],
+      activeProfileId: profile.id,
+    ))
+    let requestTarget: WorkspaceActivationFeature.CLIActivationRequest.Target =
+      requestTargetWasRemoved ? .workspace(missingID) : .profile(profile.id)
+    let expectedError = requestTargetWasRemoved
+      ? "The requested workspace no longer exists"
+      : "Configuration changed while activation was in progress"
+    let completions = LockIsolated<[String?]>([])
+    let request = WorkspaceActivationFeature.CLIActivationRequest(
+      target: requestTarget,
+      complete: { error in completions.withValue { $0.append(error) } },
+    )
+    let liveDisplay = DisplayName("Live Display")
+    var state = WorkspaceActivationFeature.State()
+    state.$config = sharedConfig
+    state.pendingCLIActivation = request
+    state.pendingDisplayRestores = [
+      DisplayAssignment(display: liveDisplay, workspace: live.id)
+    ]
+    let store = TestStore(initialState: state) {
+      WorkspaceActivationFeature()
+    } withDependencies: {
+      $0.continuousClock = TestClock()
+      $0.displays.workArea = { _ in CGRect(x: 0, y: 0, width: 1_000, height: 800) }
+      $0.floatingOverlay.retainOnly = { _ in }
+      $0.floatingOverlay.setFloating = { _ in }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.restoreDisplay(workspaceId: missingID, display: Self.display))
+    await store.receive(\.processDisplayRestores)
+    await store.receive {
+      guard case .restoreDisplay(let workspaceID, let display) = $0 else { return false }
+      return workspaceID == live.id && display == liveDisplay
+    }
+    await store.receive {
+      guard case .activationCompleted(let workspaceID, let display, _) = $0 else { return false }
+      return workspaceID == live.id && display == liveDisplay
+    }
+    await store.finish()
+
+    #expect(completions.value == [expectedError])
+    #expect(store.state.pendingCLIActivation == nil)
+    #expect(store.state.pendingDisplayRestores.isEmpty)
+    #expect(store.state.activeWorkspacesByDisplay[liveDisplay] == live.id)
+  }
+
+  @Test(arguments: [false, true])
+  func `empty profile reactivation invalidates the outgoing generation`(
+    hasOnlyScratchpad: Bool
+  ) async {
+    let display = Self.display
+    let removedWorkspaceID = UUID()
+    let scratchpad = Workspace(name: "Scratchpad", kind: .scratchpad)
+    let replacement = Profile(
+      name: "Replacement",
+      workspaces: hasOnlyScratchpad ? [scratchpad] : [],
+    )
+    let sharedConfig = Shared(value: AppConfig(
+      profiles: [replacement],
+      activeProfileId: replacement.id,
+    ))
+    let completions = LockIsolated<[String?]>([])
+    let request = WorkspaceActivationFeature.CLIActivationRequest(
+      target: .profile(replacement.id),
+      complete: { error in completions.withValue { $0.append(error) } },
+    )
+    var state = WorkspaceActivationFeature.State()
+    state.$config = sharedConfig
+    state.isActivating = true
+    state.activatingWorkspaceID = removedWorkspaceID
+    state.activationGeneration = 1
+    state.activeActivationGeneration = 1
+    state.activeWorkspacesByDisplay[display] = removedWorkspaceID
+    state.pendingCLIActivation = request
+    state.pendingDisplayRestores = [
+      DisplayAssignment(display: display, workspace: removedWorkspaceID)
+    ]
+    let store = TestStore(initialState: state) {
+      WorkspaceActivationFeature()
+    } withDependencies: {
+      $0.displays.all = { [display] }
+    }
+    store.exhaustivity = .off
+
+    await store.send(.reactivateActiveProfile(focus: nil))
+    await store.finish()
+
+    #expect(completions.value == [nil])
+    #expect(!store.state.isActivating)
+    #expect(store.state.activatingWorkspaceID == nil)
+    #expect(store.state.activeActivationGeneration == nil)
+    #expect(store.state.activeWorkspacesByDisplay.isEmpty)
+    #expect(store.state.pendingDisplayRestores.isEmpty)
+    #expect(store.state.pendingCLIActivation == nil)
+
+    await store.send(.activationCompleted(
+      workspaceId: removedWorkspaceID,
+      display: display,
+      generation: 1,
+    ))
+    await store.send(.activationTailFinished(generation: 1))
+
+    #expect(completions.value == [nil])
+    #expect(store.state.activeWorkspacesByDisplay.isEmpty)
+  }
+
+  @Test
+  func `restored workspace history keeps only valid normal workspaces`() async throws {
     let liveDisplay = DisplayName(uuid: "display-1", name: "Renamed Display")
     let savedDisplay = DisplayName(uuid: "display-1", name: "Old Display Name")
     let first = Workspace(name: "First")
@@ -1605,7 +1921,7 @@ struct WorkspaceActivationFeatureTests {
     } withDependencies: {
       $0.displays.all = { [liveDisplay] }
     }
-    let activeProfileId = store.state.config.activeProfile!.id
+    let activeProfileId = try #require(store.state.config.activeProfile?.id)
 
     await store.send(.restoreStartupSession(
       lastUsedProfileId: activeProfileId,
@@ -1739,7 +2055,7 @@ struct WorkspaceActivationFeatureTests {
       return workspaceId == workspaceA.id && display == displayA
     }
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == workspaceA.id && display == displayA
     }
     await store.receive(\.processDisplayRestores)
@@ -1748,7 +2064,7 @@ struct WorkspaceActivationFeatureTests {
       return workspaceId == workspaceB.id && display == displayB
     }
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == workspaceB.id && display == displayB
     }
     await store.finish()
@@ -1800,7 +2116,7 @@ struct WorkspaceActivationFeatureTests {
       return workspaceId == frontmost.id && owner == display
     }
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let owner) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let owner, _) = $0 else { return false }
       return workspaceId == frontmost.id && owner == display
     }
     await store.finish()
@@ -1813,16 +2129,19 @@ struct WorkspaceActivationFeatureTests {
     let ws1 = Workspace(name: "one")
     let state = Self.makeState(workspaces: [ws1]) {
       $0.isActivating = true
+      $0.activationGeneration = 1
+      $0.activeActivationGeneration = 1
     }
     let store = TestStore(initialState: state) {
       WorkspaceActivationFeature()
     }
 
-    await store.send(.activationTimedOut) {
+    await store.send(.activationTimedOut(generation: 1)) {
       $0.isActivating = false
+      $0.activeActivationGeneration = nil
     }
     // Idempotent when nothing is in flight.
-    await store.send(.activationTimedOut)
+    await store.send(.activationTimedOut(generation: 1))
   }
 
   @Test
@@ -3591,7 +3910,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activate(workspaceId: other.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, _) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, _, _) = $0 else { return false }
       return workspaceId == other.id
     }
     #expect(store.state.mruWindows[browser.id] == [work, personal])
@@ -3599,7 +3918,7 @@ struct WorkspaceActivationFeatureTests {
     liveFocus.withValue { $0 = nil }
     await store.send(.activate(workspaceId: browser.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, _) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, _, _) = $0 else { return false }
       return workspaceId == browser.id
     }
     await store.finish()
@@ -3634,7 +3953,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activate(workspaceId: other.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, _) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, _, _) = $0 else { return false }
       return workspaceId == other.id
     }
     await store.finish()
@@ -3672,7 +3991,7 @@ struct WorkspaceActivationFeatureTests {
     // workspace on B and must not be pulled back to the pointer monitor.
     await store.send(.activate(workspaceId: target.id, setFocus: false))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == target.id && display == displayB
     }
     await store.finish()
@@ -3711,7 +4030,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.activate(workspaceId: target.id, setFocus: true))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == target.id && display == displayA
     }
     await store.finish()
@@ -3752,7 +4071,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.dismissBorrow(display: displayB))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let display) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let display, _) = $0 else { return false }
       return workspaceId == host.id && display == displayB
     }
     await store.finish()
@@ -3813,7 +4132,7 @@ struct WorkspaceActivationFeatureTests {
 
     activationGate.continuation.yield()
     await store.receive {
-      guard case .activationCompleted(let workspaceId, _) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, _, _) = $0 else { return false }
       return workspaceId == borrowed.id
     }
     let targetsAfterCompletion = await markerIterator.next()
@@ -3852,7 +4171,7 @@ struct WorkspaceActivationFeatureTests {
 
     await store.send(.beginBorrowDirection(workspaceId: borrowed.id))
     await store.receive {
-      guard case .activationCompleted(let workspaceId, let owner) = $0 else { return false }
+      guard case .activationCompleted(let workspaceId, let owner, _) = $0 else { return false }
       return workspaceId == host.id && owner == display
     }
     await store.finish()

--- a/Tuist/Package.resolved
+++ b/Tuist/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "841bd62702f4e1449a30f32b4be73203ddc8c1565cf739e58248cca39d4bee1e",
+  "originHash" : "319aca4853b8689c4680d57d6ad6ff226b5aa486c307fb431585885147390c23",
   "pins" : [
     {
       "identity" : "combine-schedulers",
@@ -155,12 +155,30 @@
       }
     },
     {
+      "identity" : "swift-subprocess",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swiftlang/swift-subprocess.git",
+      "state" : {
+        "revision" : "b3937ab85dd32f6e9435914599c1519074769c1a",
+        "version" : "1.0.0"
+      }
+    },
+    {
       "identity" : "swift-syntax",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
         "revision" : "f99ae8aa18f0cf0d53481901f88a0991dc3bd4a2",
         "version" : "601.0.1"
+      }
+    },
+    {
+      "identity" : "swift-system",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-system",
+      "state" : {
+        "revision" : "869129b7bf4ecc57b97d0193ad29690ca2134750",
+        "version" : "1.8.1"
       }
     },
     {

--- a/Tuist/Package.swift
+++ b/Tuist/Package.swift
@@ -28,6 +28,7 @@ let package = Package(
     .package(url: "https://github.com/apple/swift-collections", from: "1.5.1"),
     .package(url: "https://github.com/mattt/swift-toml", from: "2.0.0"),
     .package(url: "https://github.com/SFSafeSymbols/SFSafeSymbols", from: "5.3.0"),
+    .package(url: "https://github.com/swiftlang/swift-subprocess.git", from: "1.0.0"),
     .package(url: "https://github.com/mattt/swift-yyjson", from: "0.6.0"),
   ]
 )

--- a/demo/README.md
+++ b/demo/README.md
@@ -30,7 +30,7 @@ Tatami can assign each to a workspace, keep it always on top, and so on.
 open demo/build/Terminal.app demo/build/Code.app demo/build/Safari.app
 ```
 
-(Builds with `swiftc` into hand-assembled `.app` bundles — no Xcode/Tuist
+(Builds with `swiftc` into hand-assembled `.app` bundles. No Xcode/Tuist
 project. `build/` is git-ignored.)
 
 ## Config (keeps YOUR settings)
@@ -55,18 +55,18 @@ Borrow **Chat** with **⌃⌥⌘3**. Summon the **AI Assistant** scratchpad with
 
 ## Recording the demo (mirrors the website animation)
 
-1. **Tiling reveal** — on **Code**, open the apps one at a time
+1. **Tiling reveal:** On **Code**, open the apps one at a time
    (`open …/Terminal.app`, then Code, Safari). Each new window splits off
-   the focused tile — the dwindle layout keeps the first window largest.
+   the focused tile. The dwindle layout keeps the first window largest.
    (**⌘N** in an app adds another of its own windows; **⌘W** closes one and the
    rest re-tile.)
-2. **Manipulate** — directional focus, swap into a bigger tile, zoom to fill,
-   rotate — with your own Tatami keybindings.
-3. **Borrow** — borrow **Chat** on the right. Its three-window BSP stays separate
+2. **Manipulate:** Use directional focus, swap into a bigger tile, zoom to fill,
+   and rotate with your own Tatami keybindings.
+3. **Borrow:** Borrow **Chat** on the right. Its three-window BSP stays separate
    from Code while directional focus crosses the shared edge.
-4. **Shared + scratchpad** — keep Notes above both layouts, then summon and
+4. **Shared + scratchpad:** Keep Notes above both layouts, then summon and
    dismiss the **AI Assistant** without replacing Code.
-5. **Workspaces** — switch to **Design** (Figma, Photos), then show the Work and
+5. **Workspaces:** Switch to **Design** (Figma, Photos), then show the Work and
    Personal profiles in Tatami's settings.
 
 Open each workspace's apps (above) before switching to it so there's something

--- a/demo/Sources/Panels.swift
+++ b/demo/Sources/Panels.swift
@@ -85,7 +85,7 @@ private struct TerminalPanel: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 6) {
-      line("~/Tatami", "tatami list-workspaces")
+      line("~/Tatami", "tatami workspace list")
       Group {
         plain("Browser")
         plain("Coding")
@@ -93,7 +93,7 @@ private struct TerminalPanel: View {
         plain("Figma")
         plain("Notion")
       }
-      line("~/Tatami", "tatami activate Coding")
+      line("~/Tatami", "tatami workspace activate Coding")
       (Text("Activated: ").foregroundStyle(.secondary) + Text("Coding").foregroundStyle(.green))
         .font(font)
       HStack(spacing: 0) {
@@ -502,7 +502,7 @@ private struct MessagesPanel: View {
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
       bubble("Did Tatami tile that for you?", incoming: true)
-      bubble("Yep — opened the window and it just snapped in", incoming: false)
+      bubble("Yep. Opened the window and it just snapped in", incoming: false)
       bubble("⌘ a couple keys and it's a full BSP layout", incoming: false)
       bubble("No SIP, no scripting?", incoming: true)
       bubble("None. Native app.", incoming: false)
@@ -557,11 +557,11 @@ private struct MailPanel: View {
       .background(Color(nsColor: .windowBackgroundColor))
       Divider()
       VStack(alignment: .leading, spacing: 12) {
-        Text("Tatami 1.11.0 is out").font(.system(size: 20, weight: .semibold))
+        Text("Tatami 1.12.0 is out").font(.system(size: 20, weight: .semibold))
         Text("from  Sparkle Updates").font(.system(size: 12)).foregroundStyle(.secondary)
         Divider()
-        Text("This release restores each display's last workspace and keeps hidden or "
-          + "reappearing windows in sync. Update from the menu bar.")
+        Text("This release adds the domain-based CLI, lifecycle hooks, and reviewable "
+          + "profile and workspace duplication. Update from the menu bar.")
           .font(.system(size: 14)).foregroundStyle(.primary.opacity(0.85))
         Spacer()
       }
@@ -574,9 +574,9 @@ private struct MailPanel: View {
   // MARK: Private
 
   private let rows: [(String, String)] = [
-    ("Sparkle Updates", "Tatami 1.11.0 is out"),
-    ("GitHub", "Your release v1.11.0 published"),
-    ("Homebrew", "tatami 1.11.0 cask updated"),
+    ("Sparkle Updates", "Tatami 1.12.0 is out"),
+    ("GitHub", "Your release v1.12.0 published"),
+    ("Homebrew", "tatami 1.12.0 cask updated"),
     ("PangMo5", "Re: demo footage"),
   ]
 
@@ -604,7 +604,7 @@ private struct CalendarPanel: View {
           Color(nsColor: .textBackgroundColor)
           event("Standup", colW * 0 + 4, 24, colW - 8, 50, .blue)
           event("Record demo", colW * 2 + 4, 70, colW - 8, 110, .orange)
-          event("Ship 1.11.0", colW * 4 + 4, 40, colW - 8, 80, .green)
+          event("Ship 1.12.0", colW * 4 + 4, 40, colW - 8, 80, .green)
           event("Review", colW * 1 + 4, 150, colW - 8, 60, .purple)
         }
       }

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -1,0 +1,251 @@
+# Tatami command-line reference
+
+Tatami ships a `tatami` executable inside the app bundle. The CLI talks to the
+running app, so launch Tatami before sending commands.
+
+## Install
+
+Open **Settings → General → Command Line → Install**. Tatami creates a symlink
+at `/usr/local/bin/tatami`; macOS asks for an administrator password when the
+link is installed or removed. The link points into the app bundle, so replacing
+Tatami at the same path also updates the CLI. Reinstall the link after moving
+or renaming the app.
+
+Verify both the executable and the running app:
+
+```sh
+tatami --version     # bundled CLI version, no app connection required
+tatami version       # version reported by the running Tatami app
+```
+
+## Command overview
+
+```text
+tatami version [--json]
+
+tatami profile list [--json]
+tatami profile activate <profile> [--json]
+tatami profile rename <profile> <new-name> [--json]
+tatami profile duplicate <profile> [--name <new-name>] [--json]
+
+tatami workspace list [--profile <profile>] [--json]
+tatami workspace apps <workspace> [--profile <profile>] [--json]
+tatami workspace activate <workspace> [--profile <profile>] [--json]
+tatami workspace rename <workspace> <new-name> [--profile <profile>] [--json]
+tatami workspace duplicate <workspace> [--profile <profile>] [--name <new-name>] [--json]
+tatami workspace next|previous|recent [--json]
+tatami workspace move-app next|previous [--json]
+tatami workspace assign-app to <workspace> [--profile <profile>] [--json]
+tatami workspace assign-app next|previous|recent [--json]
+tatami workspace borrow from <workspace> [--json]
+tatami workspace borrow next|previous|recent [--json]
+tatami workspace dismiss-borrow [--json]
+
+tatami window focus left|right|up|down [--json]
+tatami window cycle next|previous [--json]
+tatami window resize grow|shrink [--json]
+tatami window swap left|right|up|down [--json]
+tatami window toggle-fullscreen|toggle-floating|toggle-shared-floating [--json]
+tatami display focus next|previous [--json]
+
+tatami layout toggle-orientation|balance|toggle-tiling [--json]
+
+tatami app toggle-workspace|toggle-shared [--json]
+
+tatami hook list [--json]
+```
+
+Run `tatami help`, `tatami help <command>`, or append `--help` to a command for
+ArgumentParser's current usage text.
+
+## Select profiles and workspaces
+
+Every `<profile>` and `<workspace>` selector accepts either its current name or
+UUID. A workspace name is resolved inside the active profile unless
+`--profile` is supplied. A workspace UUID is globally unique and can therefore
+select an inactive profile without `--profile`.
+
+If a name is duplicated in the search scope, Tatami fails without changing
+anything and prints every candidate UUID. Use one of those UUIDs to retry.
+
+The original flat commands remain available as compatibility aliases for
+existing scripts. They are intentionally hidden from root help so new usage is
+organized by domain:
+
+- `tatami list-workspaces` is `tatami workspace list` for the active profile.
+- `tatami list-apps <workspace>` is `tatami workspace apps <workspace>` for the
+  active profile.
+- `tatami activate <workspace>` is `tatami workspace activate <workspace>` for
+  the active profile.
+
+Profile/workspace rename and duplicate commands update `config.toml`
+transactionally. Duplication also copies saved layouts before publishing the
+new config; a layout-copy failure leaves the configuration unchanged.
+
+CLI duplication copies the complete item rather than opening the app's
+selection sheet. `workspace duplicate` clears the new workspace's key
+equivalent and explicit activate/assign/borrow shortcuts because the copy lives
+in the same profile. `profile duplicate` clears the new profile's switch
+shortcut and auto-activation rule, but keeps its workspaces' shortcuts because
+workspace bindings are isolated by profile. Use Duplicate in the app when you
+want to choose individual workspaces, apps, settings, or saved layouts.
+
+## Run dispatcher commands by domain
+
+The `profile`, `workspace`, `window`, `display`, `layout`, and `app` domains
+cover every executable capability available to three- and four-finger gesture
+bindings. Non-activation operational leaves map through `GestureAction` and use
+the same `HotKeyAction` dispatcher as gestures and global shortcuts; there is no
+generic `action` escape hatch.
+
+Most operational commands return status `accepted`. This means the running app
+validated the command and handed it to the shared reducer dispatcher. It does
+not claim that a later Accessibility or window-manager operation changed a
+window: for example, `window focus left` can have no neighbor and a workspace
+app command can arrive when no app is focused.
+
+`profile activate` and `workspace activate` instead wait for the full activation
+pipeline and return status `completed`, or report terminal failure. Scratchpads
+are Borrow-only, so use `workspace borrow from <workspace>` for them.
+
+Toggle commands are non-idempotent. Do not blindly retry one after an
+interrupted or unknown client-side result; inspect state first or the retry may
+undo the first invocation.
+
+### Profiles and workspaces
+
+| Command | Behavior |
+| --- | --- |
+| `profile activate <profile>` | Activate the profile and wait for terminal completion. |
+| `workspace activate <workspace> [--profile …]` | Activate the workspace and its owning profile when necessary, then wait for completion. |
+| `workspace next` / `previous` / `recent` | Switch relative to workspace history/order. |
+| `workspace move-app next` / `previous` | Move the focused app to an adjacent workspace and switch. |
+| `workspace assign-app to <workspace> [--profile …]` | Assign the focused app, switch profiles when necessary, and activate the workspace. |
+| `workspace assign-app next` / `previous` / `recent` | Assign the focused app to a relative workspace and switch. |
+| `workspace borrow from <workspace>` | Start the interactive Borrow direction picker for a workspace in the active profile. |
+| `workspace borrow next` / `previous` / `recent` | Borrow a relative workspace. |
+| `workspace dismiss-borrow` | Dismiss Borrow on the pointer display. |
+
+### Windows and displays
+
+| Command | Behavior |
+| --- | --- |
+| `window focus left` / `right` / `up` / `down` | Focus a neighboring tiled window. |
+| `window cycle next` / `previous` | Cycle inside the visible Tatami workspace. |
+| `window resize grow` / `shrink` | Adjust the focused BSP split by one step. |
+| `window swap left` / `right` / `up` / `down` | Swap the focused tiled window directionally. |
+| `window toggle-fullscreen` | Toggle Tatami's layout fullscreen for the focused window. |
+| `window toggle-floating` / `toggle-shared-floating` | Toggle the focused app's tiled/floating layout in its workspace or Shared Apps. |
+| `display focus next` / `previous` | Focus the workspace on an adjacent display. |
+
+CLI and gesture window cycling is immediate. The held-modifier switcher session
+is specific to a real global shortcut.
+
+### Layout and tiling
+
+| Command | Behavior |
+| --- | --- |
+| `layout toggle-orientation` | Toggle the focused split orientation. |
+| `layout balance` | Rebalance the active layout. |
+| `layout toggle-tiling` | Pause or resume Tatami tiling globally. |
+
+### Focused app
+
+| Command | Behavior |
+| --- | --- |
+| `app toggle-workspace` | Add or remove the focused app in the active workspace. |
+| `app toggle-shared` | Add or remove the focused app in Shared Apps. |
+
+### Hooks
+
+`tatami hook list` reports every configured hook, including disabled and
+invalid entries. Add, edit, delete, enable, or disable hooks from
+**Settings → Hooks**, or edit `[[hooks]]` directly in `config.toml`. Hand edits
+remain supported and are picked up live.
+
+Supported events are `tatamiLaunched`, `profileChanged`, and
+`workspaceActivated`. `tatamiLaunched` is published once per Tatami process
+after startup has resolved the active profile. Its payload contains that
+profile and omits `previousProfile`, `workspace`, and `display`. It is separate
+from the startup `profileChanged` event, so hooks can subscribe to either or
+both.
+
+The Settings editor keeps the executable and every argument in separate
+fields. They map directly to `command[0]` and its remaining argv values. Tatami
+does not combine them into a shell command, split arguments on spaces,
+interpret quotes, or expand variables. Choose a shell explicitly when shell
+syntax is required, such as an executable of `/bin/zsh` with separate `-lc`
+and script arguments.
+
+The full event, standard-input, environment, working-directory, and timeout
+contracts are documented in the
+[configuration reference](https://pangmo5.dev/Tatami/configuration.html#hooks).
+
+## JSON output and exit status
+
+Append `--json` to a leaf command. The option belongs after that command; parent
+positions such as `tatami --json profile list` are not accepted.
+
+Examples:
+
+```sh
+tatami profile list --json
+tatami workspace apps "Coding" --profile "Dual" --json
+tatami window focus left --json
+```
+
+Successful JSON is written to standard output. A dispatcher result has this
+shape:
+
+```json
+{
+  "command": "window.focus.left",
+  "title": "Focus left",
+  "status": "accepted"
+}
+```
+
+`command` and `status` are stable scripting fields; `title` follows the running
+app's language and is for display.
+Profile, workspace, app, hook, and mutation commands return structured objects
+with their identifiers and relevant metadata rather than wrapping plain text.
+
+After arguments have parsed, failures use `{"error":"…"}` on standard error
+and exit nonzero. ArgumentParser usage/help diagnostics remain plain text. A new
+CLI also rejects plain output from an older running Tatami when `--json` was
+requested, instead of silently treating it as machine-readable data.
+
+## Socket and development isolation
+
+By default both processes use `tatami.socket` in the current user's Darwin
+temporary directory. Set `TATAMI_SOCKET_PATH` to an absolute path to isolate a
+development app/CLI pair; the app and CLI must receive exactly the same value.
+
+```sh
+socket="${TMPDIR%/}/tatami-example.socket"
+TATAMI_SOCKET_PATH="$socket" /path/to/Tatami.app/Contents/MacOS/Tatami &
+TATAMI_SOCKET_PATH="$socket" /path/to/tatami workspace list
+```
+
+The app owns the socket. If it is not running, the CLI exits nonzero and asks
+whether Tatami is running.
+
+## Scripting examples
+
+Select by UUID and let `jq` validate the JSON contract:
+
+```sh
+profile_id="$(tatami profile list --json | jq -r '.[] | select(.isActive).id')"
+tatami workspace list --profile "$profile_id" --json \
+  | jq -r '.[] | [.id, .name, .kind] | @tsv'
+```
+
+Fail fast when an accepted dispatcher command cannot be submitted:
+
+```sh
+if ! result="$(tatami layout balance --json)"; then
+  printf 'Tatami layout command failed\n' >&2
+  exit 1
+fi
+printf '%s\n' "$result" | jq -e '.status == "accepted"' >/dev/null
+```

--- a/docs/CLI.md
+++ b/docs/CLI.md
@@ -63,7 +63,9 @@ ArgumentParser's current usage text.
 Every `<profile>` and `<workspace>` selector accepts either its current name or
 UUID. A workspace name is resolved inside the active profile unless
 `--profile` is supplied. A workspace UUID is globally unique and can therefore
-select an inactive profile without `--profile`.
+select an inactive profile without `--profile`. `workspace borrow from` is the
+exception: Borrow only accepts a workspace in the active profile, so switch
+profiles first when necessary.
 
 If a name is duplicated in the search scope, Tatami fails without changing
 anything and prints every candidate UUID. Use one of those UUIDs to retry.
@@ -120,8 +122,8 @@ undo the first invocation.
 | `workspace activate <workspace> [--profile …]` | Activate the workspace and its owning profile when necessary, then wait for completion. |
 | `workspace next` / `previous` / `recent` | Switch relative to workspace history/order. |
 | `workspace move-app next` / `previous` | Move the focused app to an adjacent workspace and switch. |
-| `workspace assign-app to <workspace> [--profile …]` | Assign the focused app, switch profiles when necessary, and activate the workspace. |
-| `workspace assign-app next` / `previous` / `recent` | Assign the focused app to a relative workspace and switch. |
+| `workspace assign-app to <workspace> [--profile …]` | Add the focused app without removing its existing workspace memberships, switch profiles when necessary, and activate the target. |
+| `workspace assign-app next` / `previous` / `recent` | Add the focused app without removing existing memberships, then switch to the relative workspace. |
 | `workspace borrow from <workspace>` | Start the interactive Borrow direction picker for a workspace in the active profile. |
 | `workspace borrow next` / `previous` / `recent` | Borrow a relative workspace. |
 | `workspace dismiss-borrow` | Dismiss Borrow on the pointer display. |
@@ -153,8 +155,8 @@ is specific to a real global shortcut.
 
 | Command | Behavior |
 | --- | --- |
-| `app toggle-workspace` | Add or remove the focused app in the active workspace. |
-| `app toggle-shared` | Add or remove the focused app in Shared Apps. |
+| `app toggle-workspace` | Remove the focused app if it is already in the active workspace. Otherwise move it from any other workspace in the active profile into this one as Tiled. |
+| `app toggle-shared` | Add the focused app to Shared Apps as Tiled, or remove it if it is already shared. |
 
 ### Hooks
 
@@ -175,7 +177,10 @@ fields. They map directly to `command[0]` and its remaining argv values. Tatami
 does not combine them into a shell command, split arguments on spaces,
 interpret quotes, or expand variables. Choose a shell explicitly when shell
 syntax is required, such as an executable of `/bin/zsh` with separate `-lc`
-and script arguments.
+and script arguments. For fish, use the path returned by `which fish`, then add
+`-c` and the command text as separate arguments. For example, `command ls`
+bypasses a user-defined `ls` function. Tatami sends the hook event on standard
+input, so a command that consumes standard input receives that JSON event.
 
 The full event, standard-input, environment, working-directory, and timeout
 contracts are documented in the

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -11,16 +11,27 @@ The path is XDG-aware. If `$XDG_CONFIG_HOME` is set, the file lives at
 written back whenever you change something in the app. Hand edits are picked up
 live, so you can keep it in your dotfiles and edit it in your editor.
 
+External writers must either participate in `NSFileCoordinator` or write a
+temporary file and atomically replace `config.toml`. Tatami detects and rejects
+an atomic replacement that races one of its own configuration transactions.
+In-place writers that keep the live file descriptor open across a rename (for
+example, opening `config.toml`, then continuing to truncate or write that same
+descriptor while another process replaces the path) are not supported: POSIX
+rename cannot redirect future writes on an already-open descriptor to the new
+file. Editors that save through a temporary file and atomic replace satisfy the
+supported contract.
+
 Prefer a guided start? Tatami's first launch opens **Guided Setup**, which
 builds a draft from app metadata and connected displays and teaches each major
 feature in a safe virtual display. It writes this file only when you choose
 **Apply Setup**. Run it again from **Settings → General → Run Guided Setup**.
 
-The file has three top-level parts:
+The file has four top-level parts:
 
 - **`[settings.*]`:** Global preferences described below
 - **`[[sharedApps]]`:** Apps that are part of every workspace, either tiled or kept on top
 - **`[[profiles]]`:** Workspaces and their app assignments
+- **`[[hooks]]`:** Programs triggered by profile and workspace lifecycle events
 
 ## Shortcut syntax
 
@@ -320,6 +331,86 @@ Editable in the app under **Workspaces → Shared Apps** (Tiled / Always on Top 
 Legacy configs with `[[floatingApps]]` migrate automatically on first load:
 each entry becomes a shared app with `layout = "floating"`. A pre-1.4 `floating`
 bool on any app or shared app also migrates (`true` → `floating`, else `tiled`).
+
+## `[[hooks]]`
+
+Hooks run a program when Tatami publishes one of these lifecycle events:
+
+- `tatamiLaunched`: published once per Tatami process after startup has
+  resolved the active profile. Matching hooks receive that profile;
+  `previousProfile`, `workspace`, and `display` are absent. The event is not
+  replayed for hooks added later in the same process.
+- `profileChanged`: the active profile selection changed. On startup,
+  `previousProfile` is absent.
+- `workspaceActivated`: a workspace activation published its visible state on
+  a display. Failed or timed-out activations do not emit it.
+
+The startup `tatamiLaunched` and `profileChanged` events are separate. Configure
+either or both depending on whether the hook needs process startup or profile
+lifecycle changes.
+
+Open **Settings → Hooks** to add, edit, delete, enable, or disable hooks. The
+editor exposes the executable, each argument, working directory, timeout, and
+environment variables as separate fields. It writes the same `[[hooks]]`
+entries documented below, so editing `config.toml` by hand remains fully
+supported and external changes are still picked up live.
+
+**Run Test** validates and executes the current editor draft once with a sample
+event. It does not add or update the hook and does not write `config.toml`;
+choose **Save** separately to keep the draft.
+
+```toml
+[[hooks]]
+id = "notify-context"
+event = "workspaceActivated"
+enabled = true
+command = ["/Users/me/.config/tatami/hooks/notify-context", "--compact"]
+timeoutMs = 5000
+workingDirectory = "/Users/me"
+environment = { MODE = "desktop" }
+```
+
+| Key | Type | Default | Description |
+| --- | --- | --- | --- |
+| `id` | string | _(required)_ | Unique diagnostic identifier using ASCII letters, numbers, `.`, `_`, or `-` (up to 64 characters). |
+| `event` | string | _(required)_ | `tatamiLaunched`, `profileChanged`, or `workspaceActivated`. |
+| `enabled` | bool | `true` | Whether this hook runs. Disabled hooks remain visible to `tatami hook list`. |
+| `command` | string[] | _(required)_ | Executable followed by its arguments. Each element is one argv value. |
+| `timeoutMs` | int | `5000` | Runtime limit from 100 through 300000 milliseconds. |
+| `workingDirectory` | string? | Tatami config directory | Absolute path, or a path beginning with `~/`. |
+| `environment` | table | `{}` | Values added to the app's inherited environment. Tatami context values below take precedence. |
+
+Tatami executes `command` directly; it does not invoke a shell, split words,
+interpret quotes, or expand variables. The Settings editor preserves the same
+contract: the executable is `command[0]`, and every argument row becomes one
+subsequent argv value. To use shell syntax, opt in explicitly, for example
+`command = ["/bin/zsh", "-lc", "your pipeline"]`. An executable containing `/`
+is treated as a path (with leading `~/` expanded); a bare name is resolved from
+the app's inherited `PATH`. An absolute executable path is the most predictable
+choice when Tatami was opened from Finder.
+
+Each hook receives one versioned JSON object on standard input. The object has
+`schemaVersion`, `event`, `occurredAt`, `profile`, and, when applicable,
+`previousProfile`, `workspace`, and `display`. Tatami also sets these convenience
+variables:
+
+- `TATAMI_HOOK_ID`, `TATAMI_HOOK_EVENT`
+- `TATAMI_PROFILE_ID`, `TATAMI_PROFILE_NAME`
+- `TATAMI_WORKSPACE_ID`, `TATAMI_WORKSPACE_NAME`, `TATAMI_WORKSPACE_KIND`
+  for a workspace event
+- `TATAMI_DISPLAY_UUID`, `TATAMI_DISPLAY_NAME` when a display is known
+
+Standard output and error are each limited to 64 KiB. A nonzero exit, signal,
+spawn error, excessive output, or timeout is reported under Problems and in the
+debug log when debug logging is enabled. Hook failures never roll back or block
+the profile/workspace change. Hook commands run in an isolated process session.
+On timeout or app shutdown, Tatami first sends a graceful termination and then
+force-kills remaining descendants, including shell background-job groups. A
+hook must not detach itself into a new process session. If a newer event arrives
+while the same hook `id` is still running, both published events run
+independently; only the newest invocation updates that hook's standing Problem.
+Changing, disabling, or removing a hook cancels executions of the old definition
+and clears its standing Problem.
 
 ## `[[profiles]]` and workspaces
 

--- a/docs/CONFIGURATION.md
+++ b/docs/CONFIGURATION.md
@@ -31,7 +31,7 @@ The file has four top-level parts:
 - **`[settings.*]`:** Global preferences described below
 - **`[[sharedApps]]`:** Apps that are part of every workspace, either tiled or kept on top
 - **`[[profiles]]`:** Workspaces and their app assignments
-- **`[[hooks]]`:** Programs triggered by profile and workspace lifecycle events
+- **`[[hooks]]`:** Programs triggered by Tatami, profile, and workspace lifecycle events
 
 ## Shortcut syntax
 
@@ -132,7 +132,7 @@ layout without writing the temporary wake-up state back to disk.
 | Key | Type | Default | Description |
 | --- | --- | --- | --- |
 | `enabled` | bool | `false` | Recognize configured three- and four-finger trackpad swipes. |
-| `threshold` | double | `0.3` | Swipe distance required to trigger a switch (lower = more sensitive). Kept to two decimal places. |
+| `threshold` | double | `0.3` | Swipe distance required before the bound action runs (lower = more sensitive). Kept to two decimal places. |
 | `threeFinger` | table | left → `nextWorkspace`, right → `previousWorkspace` | Actions for three-finger `left`, `right`, `up`, and `down` swipes. Missing directions are `none`. |
 | `fourFinger` | table | all directions → `none` | Actions for four-finger `left`, `right`, `up`, and `down` swipes. |
 
@@ -236,6 +236,12 @@ the modifier + key combo:
 
 - Per workspace: `activateShortcut`, `assignAppShortcut`, `borrowShortcut` (see workspaces below).
 - **Per navigation target:** `switchTo{Recent,Next,Previous}Workspace`, `assign{Recent,Next,Previous}Workspace`, and `borrow{Recent,Next,Previous}Workspace`. All use skhd strings.
+
+Workspace key equivalents and explicit workspace shortcuts are active only in
+their profile, so different profiles may reuse the same keys. Global shortcuts
+remain global and are checked against every profile. Copy and Duplicate also
+validate the selected shortcut changes before saving them into the target
+profile.
 
 Borrowing waits for a direction key (h/j/k/l or arrows) to place the workspace,
 unless a default edge is set (`settings.switching.borrowDefaultEdge` or the
@@ -384,10 +390,14 @@ Tatami executes `command` directly; it does not invoke a shell, split words,
 interpret quotes, or expand variables. The Settings editor preserves the same
 contract: the executable is `command[0]`, and every argument row becomes one
 subsequent argv value. To use shell syntax, opt in explicitly, for example
-`command = ["/bin/zsh", "-lc", "your pipeline"]`. An executable containing `/`
-is treated as a path (with leading `~/` expanded); a bare name is resolved from
-the app's inherited `PATH`. An absolute executable path is the most predictable
-choice when Tatami was opened from Finder.
+`command = ["/bin/zsh", "-lc", "your pipeline"]`. With fish, use the path from
+`which fish` and keep the flag and command separate, such as
+`command = ["/opt/homebrew/bin/fish", "-c", "command ls"]`. Tatami sends the
+event JSON on standard input, so a command that reads standard input receives
+that event. An executable containing `/` is treated as a path (with leading
+`~/` expanded); a bare name is resolved from the app's inherited `PATH`. An
+absolute executable path is the most predictable choice when Tatami was opened
+from Finder.
 
 Each hook receives one versioned JSON object on standard input. The object has
 `schemaVersion`, `event`, `occurredAt`, `profile`, and, when applicable,

--- a/docs/LOCALIZATION.md
+++ b/docs/LOCALIZATION.md
@@ -132,6 +132,8 @@ over a technical transliteration such as `플로팅`.
 - Preserve format placeholders and let each locale reorder them.
 - Use locale-aware `FormatStyle` for user-visible numbers and dates.
 - Do not uppercase localized copy at runtime.
+- Do not use em dashes in interface copy. Split the thought into sentences or
+  use punctuation that fits the locale.
 
 ## Review checklist
 
@@ -149,9 +151,9 @@ over a technical transliteration such as `플로팅`.
 ## Public references
 
 - Toss: <https://toss.tech/article/21022>
-- Apple Human Interface Guidelines — Writing:
+- Apple Human Interface Guidelines: Writing:
   <https://developer.apple.com/design/human-interface-guidelines/writing>
-- Apple WWDC25 — Make a big impact with small writing changes:
+- Apple WWDC25: Make a big impact with small writing changes:
   <https://developer.apple.com/videos/play/wwdc2025/404/>
 - LINE Voice: <https://designsystem.line.me/about/line-voice-ja>
 - SmartHR writing style:

--- a/web/cli.html
+++ b/web/cli.html
@@ -3,8 +3,8 @@
 <head>
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
-<title>Configuration: Tatami</title>
-<meta name="description" content="Tatami configuration reference: every config.toml key, its default, and the shortcut syntax." />
+<title>Command Line: Tatami</title>
+<meta name="description" content="Tatami CLI reference: profile and workspace management, gesture-equivalent domain commands, JSON output, and scripting." />
 <meta name="theme-color" content="#000000" />
 <link rel="icon" type="image/png" href="./icon.png" />
 <link rel="stylesheet" href="./style.css" />
@@ -17,8 +17,8 @@
     <input type="checkbox" id="nav-toggle" class="nav-toggle" />
     <label for="nav-toggle" class="nav-burger" aria-label="Menu"><span></span></label>
     <div class="nav-links">
-      <a href="./cli.html">CLI</a>
-      <a href="./configuration.html" class="active">Configuration</a>
+      <a href="./cli.html" class="active">CLI</a>
+      <a href="./configuration.html">Configuration</a>
       <a href="./releases.html">Releases</a>
       <a href="https://github.com/PangMo5/Tatami">GitHub</a>
     </div>
@@ -28,13 +28,13 @@
 
 <div class="doc">
   <aside class="doc-side" id="side" hidden>
-    <div class="side-title">Configuration</div>
+    <div class="side-title">Command Line</div>
     <nav id="side-nav"></nav>
   </aside>
   <main class="doc-main">
     <p class="doc-eyebrow">Reference</p>
     <div class="md" id="content">
-      <p class="state">Loading configuration…</p>
+      <p class="state">Loading CLI reference…</p>
     </div>
   </main>
 </div>
@@ -44,13 +44,13 @@
     <div class="footer-links">
       <a href="https://github.com/PangMo5/Tatami">GitHub</a>
       <a href="./releases.html">Releases</a>
-      <a href="./cli.html">CLI</a>
-      <a href="https://github.com/PangMo5/Tatami/blob/main/docs/CONFIGURATION.md">Source (main)</a>
+      <a href="./configuration.html">Configuration</a>
+      <a href="https://github.com/PangMo5/Tatami/blob/main/docs/CLI.md">Source (main)</a>
       <a href="https://github.com/PangMo5/Tatami/blob/main/LICENSE">License</a>
       <a href="https://github.com/PangMo5/Tatami/blob/main/NOTICE.md">Project notices</a>
       <a href="https://github.com/PangMo5/Tatami/blob/main/THIRD_PARTY_NOTICES.md">Third-party notices</a>
     </div>
-    <p>This page renders <code>docs/CONFIGURATION.md</code> from the <code>main</code> branch as the single source of truth. Not affiliated with Apple Inc.</p>
+    <p>This page renders <code>docs/CLI.md</code> from the <code>main</code> branch as the single source of truth. Not affiliated with Apple Inc.</p>
     <p class="footer-apps">Apps by <a href="https://pangmo5.dev/">PangMo5</a>: <a href="https://pangmo5.dev/SwiftyCrow/">SwiftyCrow</a> · <span class="cur" aria-current="page">Tatami</span> · <a href="https://pangmo5.dev/Amado/">Amado</a></p>
   </div>
 </footer>
@@ -62,7 +62,7 @@
   integrity="sha384-XQqX/4yiUGu+oyr87jvWzRuqBUK/adrY0DunhL+tID9m/9dwSpV8h9Fk/Sg6ifVQ"
   crossorigin="anonymous"></script>
 <script>
-  const SRC = "https://raw.githubusercontent.com/PangMo5/Tatami/main/docs/CONFIGURATION.md";
+  const SRC = "https://raw.githubusercontent.com/PangMo5/Tatami/main/docs/CLI.md";
   const content = document.getElementById("content");
 
   function slug(text) {
@@ -85,7 +85,6 @@
 
     content.innerHTML = DOMPurify.sanitize(marked.parse(md));
 
-    // Assign stable ids and build the DocC-style sidebar from headings.
     const sideNav = document.getElementById("side-nav");
     const used = {};
     const headings = content.querySelectorAll("h2, h3");
@@ -102,14 +101,11 @@
     });
     if (headings.length) document.getElementById("side").hidden = false;
 
-    // The markdown renders after load, so the browser's initial jump to a
-    // `#hash` found no target yet. Now that headings have ids, honor it.
     if (location.hash) {
       const target = document.getElementById(decodeURIComponent(location.hash.slice(1)));
       if (target) target.scrollIntoView();
     }
 
-    // Scroll-spy: highlight the section currently in view.
     const links = Array.from(sideNav.querySelectorAll("a"));
     const byId = Object.fromEntries(links.map((a) => [a.dataset.target, a]));
     const observer = new IntersectionObserver((entries) => {
@@ -125,8 +121,8 @@
 
   function fail() {
     content.innerHTML =
-      '<p class="state">Couldn\'t load the configuration reference. ' +
-      'Read it on <a href="https://github.com/PangMo5/Tatami/blob/main/docs/CONFIGURATION.md">GitHub</a>.</p>';
+      '<p class="state">Couldn\'t load the CLI reference. ' +
+      'Read it on <a href="https://github.com/PangMo5/Tatami/blob/main/docs/CLI.md">GitHub</a>.</p>';
   }
 
   load();

--- a/web/index.html
+++ b/web/index.html
@@ -4,12 +4,12 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Tatami: macOS workspace manager with BSP window tiling</title>
-<meta name="description" content="Tatami is a macOS workspace manager with BSP window tiling, profiles, CLI automation, lifecycle hooks, and reviewable duplication." />
+<meta name="description" content="Tatami is a native macOS workspace manager with BSP window tiling. Group apps into virtual workspaces, switch instantly, and restore each layout automatically." />
 <meta name="theme-color" content="#000000" />
 <link rel="icon" type="image/png" href="./icon.png" />
 <link rel="stylesheet" href="./style.css" />
 <meta property="og:title" content="Tatami" />
-<meta property="og:description" content="A macOS workspace manager with BSP window tiling, CLI automation, and lifecycle hooks." />
+<meta property="og:description" content="A macOS workspace manager for switching and restoring virtual workspaces with native BSP window tiling." />
 <meta property="og:image" content="./icon.png" />
 <meta property="og:type" content="website" />
 </head>
@@ -27,8 +27,6 @@
       <a href="#tiling">Tiling</a>
       <a href="#floating">Always on Top</a>
       <a href="#guided-setup">Guided Setup</a>
-      <a href="#automation">Automation</a>
-      <a href="./cli.html">CLI</a>
       <a href="./configuration.html">Configuration</a>
       <a href="./releases.html">Releases</a>
       <a href="https://github.com/PangMo5/Tatami">GitHub</a>
@@ -89,7 +87,7 @@
     >
       <source src="tatami-demo.mp4" type="video/mp4" />
     </video>
-    <p class="sub">Recorded on an earlier version. Commands and some labels differ in 1.12. See the <a href="./cli.html">current CLI reference</a>.</p>
+    <p class="sub">Recorded on an earlier version. Some labels and controls have changed since this recording.</p>
   </div>
 </section>
 
@@ -127,7 +125,7 @@
       <div class="feature">
         <div class="ico">🗄️</div>
         <h3>A setup for every situation</h3>
-        <p>Each profile has its own workspaces, app assignments, and shortcuts. Workspace shortcuts can reuse the same keys across profiles, while global shortcuts stay unique. Switch by hotkey or from the menu bar, then return to the setup that fits your connected displays after relaunch.</p>
+        <p>Each profile has its own workspaces, app assignments, and shortcuts. Switch by hotkey or from the menu bar, then return to the setup that fits your connected displays after relaunch.</p>
       </div>
       <div class="feature">
         <div class="ico">🔌</div>
@@ -136,8 +134,8 @@
       </div>
       <div class="feature">
         <div class="ico">📋</div>
-        <h3>Review copies and duplicates</h3>
-        <p>Copy from or duplicate a profile or workspace through the same preview. Choose its workspaces, apps, settings, and saved layouts, with shortcuts checked before anything changes.</p>
+        <h3>Start from an existing setup</h3>
+        <p>Copy selected workspaces and settings from another profile, or duplicate one as a starting point. Review what will be brought over before applying.</p>
       </div>
     </div>
   </div>
@@ -243,26 +241,23 @@
   </div>
 </section>
 
-<section class="section-gray" id="automation">
+<section class="supporting-section" id="automation">
   <div class="wrap">
-    <p class="eyebrow">Automation</p>
-    <h2>Control Tatami beyond the app.</h2>
-    <p class="sub">Use the bundled command-line tool or run your own programs when Tatami launches, changes profile, or activates a workspace.</p>
-    <div class="features">
-      <div class="feature">
-        <div class="ico">⌨️</div>
-        <h3>One CLI, organized by domain</h3>
-        <p>Manage profiles and workspaces, run every action available to trackpad gestures, and request stable JSON for scripts.</p>
+    <div class="supporting-panel">
+      <div class="supporting-copy">
+        <p class="eyebrow">For power users</p>
+        <h2>Optional automation for custom workflows.</h2>
+        <p>Use Tatami's CLI in scripts, or run a hook when Tatami launches, changes profile, or makes a workspace visible.</p>
       </div>
-      <div class="feature">
-        <div class="ico">⚡</div>
-        <h3>Lifecycle hooks</h3>
-        <p>Configure and test hooks in Settings. Every run receives versioned JSON, useful environment variables, an explicit working directory, and a bounded timeout.</p>
-      </div>
-      <div class="feature">
-        <div class="ico">📖</div>
-        <h3>Reference where you need it</h3>
-        <p>Open the bundled CLI guide inside Tatami or read the live reference rendered from <code>docs/CLI.md</code> on this site.</p>
+      <div class="supporting-links">
+        <a href="./cli.html">
+          <strong>Command line</strong>
+          <span>Run workspace and window commands or request JSON.</span>
+        </a>
+        <a href="./configuration.html#hooks">
+          <strong>Lifecycle hooks</strong>
+          <span>Run a program when Tatami launches, profiles change, or workspaces appear.</span>
+        </a>
       </div>
     </div>
   </div>

--- a/web/index.html
+++ b/web/index.html
@@ -27,6 +27,7 @@
       <a href="#tiling">Tiling</a>
       <a href="#floating">Always on Top</a>
       <a href="#guided-setup">Guided Setup</a>
+      <a href="./cli.html">CLI</a>
       <a href="./configuration.html">Configuration</a>
       <a href="./releases.html">Releases</a>
       <a href="https://github.com/PangMo5/Tatami">GitHub</a>
@@ -261,6 +262,7 @@
     <div class="footer-links">
       <a href="https://github.com/PangMo5/Tatami">GitHub</a>
       <a href="./releases.html">Releases</a>
+      <a href="./cli.html">CLI</a>
       <a href="./configuration.html">Configuration</a>
       <a href="https://github.com/PangMo5/Tatami/blob/main/LICENSE">License</a>
       <a href="https://github.com/PangMo5/Tatami/blob/main/NOTICE.md">Project notices</a>

--- a/web/index.html
+++ b/web/index.html
@@ -4,12 +4,12 @@
 <meta charset="UTF-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1" />
 <title>Tatami: macOS workspace manager with BSP window tiling</title>
-<meta name="description" content="Tatami is a macOS workspace manager with BSP window tiling. Group apps into virtual workspaces and tile their windows automatically, with no SIP changes or shell scripting." />
+<meta name="description" content="Tatami is a macOS workspace manager with BSP window tiling, profiles, CLI automation, lifecycle hooks, and reviewable duplication." />
 <meta name="theme-color" content="#000000" />
 <link rel="icon" type="image/png" href="./icon.png" />
 <link rel="stylesheet" href="./style.css" />
 <meta property="og:title" content="Tatami" />
-<meta property="og:description" content="A macOS workspace manager with BSP window tiling." />
+<meta property="og:description" content="A macOS workspace manager with BSP window tiling, CLI automation, and lifecycle hooks." />
 <meta property="og:image" content="./icon.png" />
 <meta property="og:type" content="website" />
 </head>
@@ -27,6 +27,7 @@
       <a href="#tiling">Tiling</a>
       <a href="#floating">Always on Top</a>
       <a href="#guided-setup">Guided Setup</a>
+      <a href="#automation">Automation</a>
       <a href="./cli.html">CLI</a>
       <a href="./configuration.html">Configuration</a>
       <a href="./releases.html">Releases</a>
@@ -88,6 +89,7 @@
     >
       <source src="tatami-demo.mp4" type="video/mp4" />
     </video>
+    <p class="sub">Recorded on an earlier version. Commands and some labels differ in 1.12. See the <a href="./cli.html">current CLI reference</a>.</p>
   </div>
 </section>
 
@@ -125,7 +127,7 @@
       <div class="feature">
         <div class="ico">🗄️</div>
         <h3>A setup for every situation</h3>
-        <p>Each profile has its own workspaces, app assignments, and shortcuts. Switch by hotkey or from the menu bar, then return to the setup that fits your connected displays after relaunch.</p>
+        <p>Each profile has its own workspaces, app assignments, and shortcuts. Workspace shortcuts can reuse the same keys across profiles, while global shortcuts stay unique. Switch by hotkey or from the menu bar, then return to the setup that fits your connected displays after relaunch.</p>
       </div>
       <div class="feature">
         <div class="ico">🔌</div>
@@ -134,8 +136,8 @@
       </div>
       <div class="feature">
         <div class="ico">📋</div>
-        <h3>Copy between profiles</h3>
-        <p>Copy apps and settings from one profile or workspace into another with a reviewable diff. Keep or skip each change while profiles stay independent.</p>
+        <h3>Review copies and duplicates</h3>
+        <p>Copy from or duplicate a profile or workspace through the same preview. Choose its workspaces, apps, settings, and saved layouts, with shortcuts checked before anything changes.</p>
       </div>
     </div>
   </div>
@@ -236,6 +238,31 @@
         <div class="ico">✨</div>
         <h3>Bring your preferred AI</h3>
         <p>Review a workspace proposal from ChatGPT, Claude, Gemini, another AI, or on-device Apple Intelligence on supported Macs. Tatami shares app metadata and display geometry, never screen contents.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+<section class="section-gray" id="automation">
+  <div class="wrap">
+    <p class="eyebrow">Automation</p>
+    <h2>Control Tatami beyond the app.</h2>
+    <p class="sub">Use the bundled command-line tool or run your own programs when Tatami launches, changes profile, or activates a workspace.</p>
+    <div class="features">
+      <div class="feature">
+        <div class="ico">⌨️</div>
+        <h3>One CLI, organized by domain</h3>
+        <p>Manage profiles and workspaces, run every action available to trackpad gestures, and request stable JSON for scripts.</p>
+      </div>
+      <div class="feature">
+        <div class="ico">⚡</div>
+        <h3>Lifecycle hooks</h3>
+        <p>Configure and test hooks in Settings. Every run receives versioned JSON, useful environment variables, an explicit working directory, and a bounded timeout.</p>
+      </div>
+      <div class="feature">
+        <div class="ico">📖</div>
+        <h3>Reference where you need it</h3>
+        <p>Open the bundled CLI guide inside Tatami or read the live reference rendered from <code>docs/CLI.md</code> on this site.</p>
       </div>
     </div>
   </div>

--- a/web/releases.html
+++ b/web/releases.html
@@ -17,6 +17,7 @@
     <input type="checkbox" id="nav-toggle" class="nav-toggle" />
     <label for="nav-toggle" class="nav-burger" aria-label="Menu"><span></span></label>
     <div class="nav-links">
+      <a href="./cli.html">CLI</a>
       <a href="./configuration.html">Configuration</a>
       <a href="./releases.html" class="active">Releases</a>
       <a href="https://github.com/PangMo5/Tatami">GitHub</a>
@@ -40,6 +41,7 @@
     <div class="footer-links">
       <a href="https://github.com/PangMo5/Tatami">GitHub</a>
       <a href="https://github.com/PangMo5/Tatami/releases">All releases</a>
+      <a href="./cli.html">CLI</a>
       <a href="./configuration.html">Configuration</a>
       <a href="https://github.com/PangMo5/Tatami/blob/main/LICENSE">License</a>
       <a href="https://github.com/PangMo5/Tatami/blob/main/NOTICE.md">Project notices</a>

--- a/web/style.css
+++ b/web/style.css
@@ -178,6 +178,31 @@ footer p { line-height: 1.5; }
 .feature p { font-size: 16px; color: var(--text-secondary); margin-top: 8px; line-height: 1.4; }
 @media (max-width: 760px) { .features { grid-template-columns: 1fr; } }
 
+/* Automation is an optional extension point, so it stays visible without
+   competing with the primary workspace and tiling sections. */
+.supporting-section { padding: 56px 22px; background: var(--bg-gray); text-align: left; }
+.supporting-panel {
+  display: grid; grid-template-columns: minmax(0, 1.25fr) minmax(280px, 0.75fr); gap: 48px;
+  align-items: center; padding: 34px 38px; border: 1px solid var(--card-border);
+  border-radius: var(--radius); background: var(--card-bg); box-shadow: var(--card-shadow);
+}
+.supporting-copy .eyebrow { font-size: 15px; margin-bottom: 5px; }
+.supporting-copy h2 { font-size: clamp(26px, 3.4vw, 36px); }
+.supporting-copy > p:last-child {
+  max-width: 620px; margin-top: 12px; color: var(--text-secondary); font-size: 17px; line-height: 1.45;
+}
+.supporting-links { display: grid; gap: 10px; }
+.supporting-links a {
+  display: grid; gap: 2px; padding: 12px 14px; border-radius: 12px;
+  color: var(--text); background: var(--pill-bg);
+}
+.supporting-links a:hover { text-decoration: none; }
+.supporting-links strong { font-size: 15px; font-weight: 600; }
+.supporting-links span { color: var(--text-secondary); font-size: 13px; line-height: 1.35; }
+@media (max-width: 760px) {
+  .supporting-panel { grid-template-columns: 1fr; gap: 24px; padding: 28px 24px; }
+}
+
 /* Animated showcase: a looping product demo that walks through tiling,
 directional focus, swap, zoom, workspace switching, and always-on-top windows.
    A small JS state machine in index.html drives the stages; CSS transitions


### PR DESCRIPTION
## Summary

- Add the domain-based CLI with gesture-equivalent commands and structured JSON output
- Add lifecycle hooks with native Settings management and bounded process execution
- Add reviewable profile and workspace duplication with transactional conflict checks
- Refine release notes, documentation, localization, and evergreen product hierarchy

## Validation

- `tuist test`: 458 passed, 0 failed across 38 suites
- macOS Release build: succeeded as a universal arm64/x86_64 app
- Bundled CLI: `1.12.0`, universal arm64/x86_64
- UI localization: 1,121 keys, five locales, no missing translations or placeholder mismatches
- `git diff --check`: passed
- Gitleaks staged diff scan: no leaks found

## Release

`Project.swift` and `CHANGELOG.md` are prepared for 1.12.0. Create and push the annotated `v1.12.0` tag from the merged `main` commit.