### PR TITLE
fix(web): link source CTAs to GitHub repository

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -42,7 +42,7 @@
     <p class="sub">A macOS workspace manager,<br />with BSP window tiling.</p>
     <div class="cta">
       <a class="btn btn-primary download-link" href="https://github.com/PangMo5/Tatami/releases/download/v__VERSION__/Tatami-__VERSION__.dmg">Download for macOS</a>
-      <a class="btn btn-link source-link" href="https://github.com/PangMo5/Tatami/archive/refs/tags/v__VERSION__.tar.gz">Source code&nbsp;&rsaquo;</a>
+      <a class="btn btn-link" href="https://github.com/PangMo5/Tatami">View on GitHub&nbsp;&rsaquo;</a>
     </div>
     <div class="brew">
       <code id="brew-cmd">brew install --cask pangmo5/tap/tatami</code>
@@ -270,7 +270,7 @@
     <div class="cta">
       <a class="btn btn-primary download-link" href="https://github.com/PangMo5/Tatami/releases/download/v__VERSION__/Tatami-__VERSION__.dmg">Download for macOS</a>
       <a class="btn btn-link" href="./releases.html">Release notes&nbsp;&rsaquo;</a>
-      <a class="btn btn-link source-link" href="https://github.com/PangMo5/Tatami/archive/refs/tags/v__VERSION__.tar.gz">Source code&nbsp;&rsaquo;</a>
+      <a class="btn btn-link" href="https://github.com/PangMo5/Tatami">View on GitHub&nbsp;&rsaquo;</a>
     </div>
     <div class="brew">
       <code id="brew-cmd-2">brew install --cask pangmo5/tap/tatami</code>
@@ -405,10 +405,6 @@
       // Only trust an https github.com asset URL before rewriting the button.
       if (dmg && /^https:\/\/github\.com\//.test(dmg.browser_download_url)) {
         document.querySelectorAll("a.download-link").forEach((a) => { a.href = dmg.browser_download_url; });
-      }
-      if (/^v?\d+\.\d+\.\d+$/.test(rel.tag_name || "")) {
-        const sourceURL = "https://github.com/PangMo5/Tatami/archive/refs/tags/" + encodeURIComponent(rel.tag_name) + ".tar.gz";
-        document.querySelectorAll("a.source-link").forEach((a) => { a.href = sourceURL; });
       }
     } catch (e) { /* keep the static fallback */ }
   })();


### PR DESCRIPTION
## Summary

- Rename the top and bottom source actions to `View on GitHub`
- Link both actions to the Tatami GitHub repository
- Remove release-time rewrites to source archive downloads

## Validation

- JavaScript syntax checked with `node --check`
- Verified exactly two GitHub CTAs and no remaining source archive rewrites
- `git diff --check` passed