### PR TITLE
fix(ci): sign and verify release disk images

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -127,6 +127,14 @@ jobs:
             "$RUNNER_TEMP/Tatami-${{ steps.version.outputs.version }}.dmg" \
             "$RUNNER_TEMP/Tatami.app"
 
+      - name: Sign disk image
+        run: |
+          set -euo pipefail
+          DMG="$RUNNER_TEMP/Tatami-${{ steps.version.outputs.version }}.dmg"
+          codesign --sign "Developer ID Application" --timestamp \
+            --identifier "dev.PangMo5.Tatami.dmg" "$DMG"
+          codesign --verify --strict --verbose=2 "$DMG"
+
       - name: Notarize + staple
         env:
           AC_API_KEY_ID: ${{ secrets.AC_API_KEY_ID }}
@@ -153,6 +161,8 @@ jobs:
             exit 1
           fi
           xcrun stapler staple "$DMG"
+          xcrun stapler validate "$DMG"
+          spctl --assess --type open --context context:primary-signature --verbose=4 "$DMG"
 
       - name: Sign for Sparkle + build appcast
         env:


### PR DESCRIPTION
The release workflow notarizes the disk image without signing the container itself. Sign the completed DMG with Developer ID and a secure timestamp before notarization, then validate its signature, stapled ticket, and Gatekeeper assessment before publishing.

Validation: `actionlint .github/workflows/release.yml` and `git diff --check` pass. The signing and notarization steps will run on the next version tag; this change does not publish a release.
