### PR TITLE
fix: release input and update settings when permissions are revoked

### DIFF
--- a/Tatami/Sources/AppRootView.swift
+++ b/Tatami/Sources/AppRootView.swift
@@ -28,6 +28,7 @@ struct AppRootView: View {
         .padding()
       }
     }
+    .frame(minWidth: 800, minHeight: 600)
     .task { store.send(.task) }
     .onChange(of: store.onboarding.presentationRequest) { _, request in
       if request > 0 {

--- a/Tatami/Sources/TatamiApp.swift
+++ b/Tatami/Sources/TatamiApp.swift
@@ -27,7 +27,8 @@ struct TatamiApp: App {
       AppRootView(store: appStore)
         .regularWhileOpen(id: "main", coordinator: windowActivation)
     }
-    .windowResizability(.contentSize)
+    .defaultSize(width: 1040, height: 720)
+    .windowResizability(.contentMinSize)
     .commands {
       // Standard ⌘, opens the main Tatami window (the Workspaces / Settings /
       // About tab view).

--- a/TatamiKit/Sources/Dependencies/AccessibilityClient.swift
+++ b/TatamiKit/Sources/Dependencies/AccessibilityClient.swift
@@ -2,22 +2,22 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 
 import AppKit
-import ApplicationServices
 import Dependencies
 import DependenciesMacros
 import Foundation
 import OSLog
 
+// MARK: - AccessibilityClient
+
 /// Accessibility (AX) permission: status, prompting, and applying a new grant.
 ///
-/// macOS does not apply a *new* grant to the already-running process —
-/// `AXIsProcessTrusted()` stays stale until relaunch (revokes do apply live).
-/// So a fresh grant is applied by relaunching, the same way yabai/AeroSpace
-/// require. There is no reliable in-process "grant detected" signal, hence no
-/// polling.
+/// Permission queries can remain cached for the process. A fresh grant needs
+/// relaunch, and deleting a permission record can leave an existing trusted
+/// process reporting true. Reads and change notifications share EventTapAccess's
+/// session state so a known revocation cannot appear granted in the UI.
 @DependencyClient
 struct AccessibilityClient: Sendable {
-  /// Current trust state (non-prompting). Reflects revokes immediately.
+  /// Effective AX availability for this session, closed until relaunch after loss.
   var isTrusted: @Sendable () -> Bool = { false }
   /// Prompt for Accessibility access (shows the system dialog if untrusted).
   var requestAccess: @Sendable () async -> Void
@@ -25,83 +25,116 @@ struct AccessibilityClient: Sendable {
   var openSettings: @Sendable () async -> Void
   /// Relaunch the app so a freshly-granted permission takes effect.
   var relaunch: @Sendable () async -> Void
-  /// Ticks whenever the trust DB changes or the app re-activates — a cue to
-  /// re-read `isTrusted()`. (The broadcast is global, so callers just re-read;
-  /// it carries no per-app payload.)
+  /// Ticks on subscription, session closure, Accessibility broadcasts, and app
+  /// reactivation. Re-read `isTrusted()`; system broadcasts alone miss deletion.
   var changes: @Sendable () -> AsyncStream<Void> = { .finished }
 }
+
+// MARK: - PermissionObserverTokens
 
 /// Holds notification observers so they can be torn down from the stream's
 /// `@Sendable` termination handler. The tokens/centers aren't `Sendable`, but
 /// they're only ever touched on the notification machinery, so the box is a
 /// documented `@unchecked Sendable`.
-private final class ObserverTokens: @unchecked Sendable {
+final class PermissionObserverTokens: @unchecked Sendable {
+
+  // MARK: Lifecycle
+
+  init(local: NotificationCenter) {
+    self.local = local
+  }
+
+  deinit { removeAll() }
+
+  // MARK: Internal
+
   let distributed = DistributedNotificationCenter.default()
-  let local = NotificationCenter.default
-  var tokens: [any NSObjectProtocol] = []
+  let local: NotificationCenter
+  var tokens = [any NSObjectProtocol]()
+
   func removeAll() {
-    for token in tokens { distributed.removeObserver(token); local.removeObserver(token) }
+    for token in tokens { distributed.removeObserver(token)
+      local.removeObserver(token)
+    }
     tokens = []
   }
+
 }
 
+// MARK: - AccessibilityClient + DependencyKey
+
 extension AccessibilityClient: DependencyKey {
-  static let liveValue = AccessibilityClient(
-    isTrusted: { AXIsProcessTrusted() },
-    requestAccess: {
-      await MainActor.run { _ = ensureAccessibilityTrust() }
-    },
-    openSettings: {
-      await MainActor.run {
-        guard let url = URL(
-          string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
-        ) else { return }
-        NSWorkspace.shared.open(url)
-      }
-    },
-    relaunch: {
-      await MainActor.run {
-        // `open -n` runs independently, so it survives this process exiting.
-        let task = Process()
-        task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
-        task.arguments = ["-n", Bundle.main.bundleURL.path]
-        do {
-          try task.run()
-        } catch {
-          // Don't terminate if the relauncher never started — that would
-          // turn "relaunch" into a plain quit with no explanation.
-          logger.error("relaunch failed to spawn open: \(error.localizedDescription, privacy: .public)")
-          return
-        }
-        NSApp.terminate(nil)
-      }
-    },
-    changes: {
-      AsyncStream { continuation in
-        let observers = ObserverTokens()
-        observers.tokens = [
-          observers.distributed.addObserver(
-            forName: Notification.Name("com.apple.accessibility.api"),
-            object: nil, queue: nil
-          ) { _ in continuation.yield() },
-          observers.local.addObserver(
-            forName: NSApplication.didBecomeActiveNotification,
-            object: nil, queue: nil
-          ) { _ in continuation.yield() },
-        ]
-        continuation.onTermination = { _ in observers.removeAll() }
-      }
-    }
-  )
+  static let liveValue = live(access: .shared, notificationCenter: .default)
 
   static let testValue = AccessibilityClient(
     isTrusted: { true },
-    requestAccess: {},
-    openSettings: {},
-    relaunch: {},
-    changes: { .finished }
+    requestAccess: { },
+    openSettings: { },
+    relaunch: { },
+    changes: { .finished },
   )
   static let previewValue = testValue
+
+  static func live(access: EventTapAccess, notificationCenter: NotificationCenter) -> Self {
+    AccessibilityClient(
+      isTrusted: { access.permitsInput() },
+      requestAccess: {
+        await MainActor.run { _ = ensureAccessibilityTrust() }
+      },
+      openSettings: {
+        await MainActor.run {
+          guard
+            let url = URL(
+              string: "x-apple.systempreferences:com.apple.preference.security?Privacy_Accessibility"
+            )
+          else { return }
+          NSWorkspace.shared.open(url)
+        }
+      },
+      relaunch: {
+        await MainActor.run {
+          // `open -n` runs independently, so it survives this process exiting.
+          let task = Process()
+          task.executableURL = URL(fileURLWithPath: "/usr/bin/open")
+          task.arguments = ["-n", Bundle.main.bundleURL.path]
+          do {
+            try task.run()
+          } catch {
+            // Don't terminate if the relauncher never started — that would
+            // turn "relaunch" into a plain quit with no explanation.
+            logger.error("relaunch failed to spawn open: \(error.localizedDescription, privacy: .public)")
+            return
+          }
+          NSApp.terminate(nil)
+        }
+      },
+      changes: {
+        AsyncStream { continuation in
+          let observers = PermissionObserverTokens(local: notificationCenter)
+          observers.tokens = [
+            observers.local.addObserver(
+              forName: EventTapAccess.didCloseNotification,
+              object: nil,
+              queue: nil,
+            ) { _ in continuation.yield() },
+            observers.distributed.addObserver(
+              forName: Notification.Name("com.apple.accessibility.api"),
+              object: nil,
+              queue: nil,
+            ) { _ in continuation.yield() },
+            observers.local.addObserver(
+              forName: NSApplication.didBecomeActiveNotification,
+              object: nil,
+              queue: nil,
+            ) { _ in continuation.yield() },
+          ]
+          continuation.onTermination = { _ in observers.removeAll() }
+          // Close the gap between the feature's initial read and subscription.
+          continuation.yield()
+        }
+      },
+    )
+  }
 }
 
 extension DependencyValues {

--- a/TatamiKit/Sources/Dependencies/BorrowChordClient.swift
+++ b/TatamiKit/Sources/Dependencies/BorrowChordClient.swift
@@ -51,12 +51,13 @@ extension DependencyValues {
 }
 
 /// Owns the keyDown `CGEventTap`. Mirrors `MirrorClickTap`: same shared
-/// `EventTapThread`, same re-enable dance, install/teardown routed through the
+/// `EventTapThread`, same permission lifetime, install/teardown routed through the
 /// tap thread.
 final class BorrowChordTap: @unchecked Sendable {
   @Dependency(\.debugLog) private var debugLog
 
   private var eventTap: CFMachPort?
+  private var accessRegistration: UUID?
   private var runLoopSource: CFRunLoopSource?
   private let emit: @Sendable (BorrowChordKey) -> Void
 
@@ -76,6 +77,10 @@ final class BorrowChordTap: @unchecked Sendable {
 
   /// Runs on the event-tap thread.
   private func install() {
+    guard EventTapAccess.shared.permitsInput() else {
+      emit(.cancel)
+      return
+    }
     let mask =
       (1 << CGEventType.keyDown.rawValue) |
       (1 << CGEventType.tapDisabledByTimeout.rawValue) |
@@ -96,6 +101,7 @@ final class BorrowChordTap: @unchecked Sendable {
       return
     }
     guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+      CFMachPortInvalidate(tap)
       logger.error("borrow chord tap: failed to create run loop source")
       return
     }
@@ -103,11 +109,27 @@ final class BorrowChordTap: @unchecked Sendable {
     CGEvent.tapEnable(tap: tap, enable: true)
     eventTap = tap
     runLoopSource = source
+    accessRegistration = EventTapAccess.shared.register { [weak self] in
+      EventTapThread.shared.perform { [weak self] in
+        self?.teardown()
+        self?.emit(.cancel)
+      }
+    }
+    guard accessRegistration != nil else {
+      teardown()
+      emit(.cancel)
+      return
+    }
     debugLog.log("BorrowChord", "direction tap armed")
   }
 
   private func teardown() {
-    if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: false) }
+    EventTapAccess.shared.unregister(accessRegistration)
+    accessRegistration = nil
+    if let tap = eventTap {
+      CGEvent.tapEnable(tap: tap, enable: false)
+      CFMachPortInvalidate(tap)
+    }
     if let source = runLoopSource { EventTapThread.shared.removeSource(source) }
     eventTap = nil
     runLoopSource = nil
@@ -115,6 +137,7 @@ final class BorrowChordTap: @unchecked Sendable {
   }
 
   fileprivate func reEnable() {
+    guard EventTapAccess.shared.permitsInput() else { return }
     if let tap = eventTap {
       debugLog.log("BorrowChord", "tap disabled by system — re-enabling")
       CGEvent.tapEnable(tap: tap, enable: true)
@@ -151,6 +174,7 @@ private func borrowChordTapCallback(
   event: CGEvent,
   refcon: UnsafeMutableRawPointer?
 ) -> Unmanaged<CGEvent>? {
+  guard EventTapAccess.shared.permitsInput() else { return Unmanaged.passUnretained(event) }
   guard let refcon else { return Unmanaged.passUnretained(event) }
   let tap = Unmanaged<BorrowChordTap>.fromOpaque(refcon).takeUnretainedValue()
   switch type {

--- a/TatamiKit/Sources/Dependencies/EventTapAccess.swift
+++ b/TatamiKit/Sources/Dependencies/EventTapAccess.swift
@@ -1,0 +1,79 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ApplicationServices
+import Foundation
+import OSLog
+
+/// Input capture and replay require the same live Accessibility grant. Check
+/// at event admission and after asynchronous preparation, not only when macOS
+/// disables a tap: revocation does not reliably send a tap-disabled callback.
+///
+/// A revoked session stays closed until relaunch, matching AccessibilityClient's
+/// grant lifecycle. Owners cancel their work on their own run loops; callbacks
+/// already in progress pass input through as soon as this gate closes.
+final class EventTapAccess: @unchecked Sendable {
+
+  // MARK: Lifecycle
+
+  init(isTrusted: @escaping @Sendable () -> Bool) {
+    self.isTrusted = isTrusted
+  }
+
+  // MARK: Internal
+
+  static let shared = EventTapAccess(isTrusted: { AXIsProcessTrusted() })
+
+  /// Warm the initial TCC query off-main before installing AppKit gesture taps.
+  func prepare() async -> Bool {
+    await withCheckedContinuation { continuation in
+      EventTapThread.shared.perform { [self] in
+        continuation.resume(returning: permitsInput())
+      }
+    }
+  }
+
+  func permitsInput() -> Bool {
+    guard lock.withLock({ !revoked }) else { return false }
+    // Never hold a lock needed by an input callback across a system query.
+    // The first TCC lookup is warmed during installation; steady-state lookups
+    // are cached by macOS, including live revocation, without our own timer.
+    let trusted = isTrusted()
+    let callbacks = lock.withLock { () -> [@Sendable () -> Void] in
+      guard !revoked, !trusted else { return [] }
+      revoked = true
+      defer { observers.removeAll() }
+      return Array(observers.values)
+    }
+    if !callbacks.isEmpty {
+      Logger(subsystem: "dev.PangMo5.Tatami", category: "Accessibility")
+        .notice("Accessibility access lost; stopping all event taps")
+      for callback in callbacks { callback() }
+    }
+    return lock.withLock { !revoked }
+  }
+
+  /// Register only after installation succeeds. A revocation racing with
+  /// installation rejects the new owner; the caller tears it down immediately.
+  func register(_ onRevoked: @escaping @Sendable () -> Void) -> UUID? {
+    lock.withLock {
+      guard !revoked else { return nil }
+      let id = UUID()
+      observers[id] = onRevoked
+      return id
+    }
+  }
+
+  func unregister(_ id: UUID?) {
+    guard let id else { return }
+    _ = lock.withLock { observers.removeValue(forKey: id) }
+  }
+
+  // MARK: Private
+
+  private let isTrusted: @Sendable () -> Bool
+  private let lock = NSLock()
+  private var revoked = false
+  private var observers = [UUID: @Sendable () -> Void]()
+
+}

--- a/TatamiKit/Sources/Dependencies/EventTapAccess.swift
+++ b/TatamiKit/Sources/Dependencies/EventTapAccess.swift
@@ -5,24 +5,71 @@ import ApplicationServices
 import Foundation
 import OSLog
 
-/// Input capture and replay require the same live Accessibility grant. Check
-/// at event admission and after asynchronous preparation, not only when macOS
-/// disables a tap: revocation does not reliably send a tap-disabled callback.
+// MARK: - EventTapAccess
+
+/// Owns the lifetime of input capture and replay. A denied Accessibility check
+/// closes input immediately, but deleting the permission record can leave all
+/// in-process permission APIs cached as allowed. While taps exist, independently
+/// verify that WindowServer still admits a new active keyboard tap.
 ///
-/// A revoked session stays closed until relaunch, matching AccessibilityClient's
-/// grant lifecycle. Owners cancel their work on their own run loops; callbacks
-/// already in progress pass input through as soon as this gate closes.
+/// A closed session stays closed until relaunch. Owners cancel their work on
+/// their own run loops, and callbacks already in progress pass physical input
+/// through as soon as this gate closes.
 final class EventTapAccess: @unchecked Sendable {
 
   // MARK: Lifecycle
 
-  init(isTrusted: @escaping @Sendable () -> Bool) {
+  init(
+    isTrusted: @escaping @Sendable () -> Bool,
+    canCaptureInput: @escaping @Sendable () -> Bool,
+    startMonitoring: @escaping @Sendable (@escaping @Sendable () -> Void) -> Cancellation,
+    notificationCenter: NotificationCenter = .default,
+  ) {
     self.isTrusted = isTrusted
+    self.canCaptureInput = canCaptureInput
+    self.startMonitoring = startMonitoring
+    self.notificationCenter = notificationCenter
+  }
+
+  deinit {
+    stopMonitoring?()
   }
 
   // MARK: Internal
 
-  static let shared = EventTapAccess(isTrusted: { AXIsProcessTrusted() })
+  typealias Cancellation = @Sendable () -> Void
+
+  static let didCloseNotification = Notification.Name("dev.PangMo5.Tatami.inputAccessDidClose")
+
+  static let shared = EventTapAccess(
+    isTrusted: { AXIsProcessTrusted() },
+    canCaptureInput: {
+      // No run-loop source is installed. Invalidate immediately so the probe
+      // cannot retain input. Unlike cached permission APIs, creation checks the
+      // current server-side permission, including a deleted TCC record.
+      guard
+        let tap = CGEvent.tapCreate(
+          tap: .cgSessionEventTap,
+          place: .tailAppendEventTap,
+          options: .defaultTap,
+          eventsOfInterest: 1 << CGEventType.keyDown.rawValue,
+          callback: { _, _, event, _ in Unmanaged.passUnretained(event) },
+          userInfo: nil,
+        )
+      else { return false }
+      CFMachPortInvalidate(tap)
+      return true
+    },
+    startMonitoring: { check in
+      let monitor = EventTapAccessMonitor(check: check)
+      return { monitor.cancel() }
+    },
+  )
+
+  /// A cheap session snapshot for UI admission; never queries TCC or WindowServer.
+  var isClosed: Bool {
+    lock.withLock { revoked }
+  }
 
   /// Warm the initial TCC query off-main before installing AppKit gesture taps.
   func prepare() async -> Bool {
@@ -36,44 +83,125 @@ final class EventTapAccess: @unchecked Sendable {
   func permitsInput() -> Bool {
     guard lock.withLock({ !revoked }) else { return false }
     // Never hold a lock needed by an input callback across a system query.
-    // The first TCC lookup is warmed during installation; steady-state lookups
-    // are cached by macOS, including live revocation, without our own timer.
-    let trusted = isTrusted()
-    let callbacks = lock.withLock { () -> [@Sendable () -> Void] in
-      guard !revoked, !trusted else { return [] }
-      revoked = true
-      defer { observers.removeAll() }
-      return Array(observers.values)
-    }
-    if !callbacks.isEmpty {
-      Logger(subsystem: "dev.PangMo5.Tatami", category: "Accessibility")
-        .notice("Accessibility access lost; stopping all event taps")
-      for callback in callbacks { callback() }
+    if !isTrusted() {
+      revoke(reason: "Accessibility access lost")
     }
     return lock.withLock { !revoked }
   }
 
-  /// Register only after installation succeeds. A revocation racing with
-  /// installation rejects the new owner; the caller tears it down immediately.
+  /// Only installed tap owners keep the monitor alive. A registration racing
+  /// with revocation is rejected and must be torn down by the caller.
   func register(_ onRevoked: @escaping @Sendable () -> Void) -> UUID? {
-    lock.withLock {
+    let registration = lock.withLock { () -> (UUID, UInt64?)? in
       guard !revoked else { return nil }
       let id = UUID()
       observers[id] = onRevoked
-      return id
+      guard !monitoring else { return (id, nil) }
+      monitoring = true
+      monitorGeneration &+= 1
+      return (id, monitorGeneration)
     }
+    guard let (id, generation) = registration else { return nil }
+    if let generation {
+      let stop = startMonitoring { [weak self] in
+        self?.checkCaptureAccess(generation: generation)
+      }
+      let keep = lock.withLock {
+        guard !revoked, monitoring, monitorGeneration == generation else { return false }
+        stopMonitoring = stop
+        return true
+      }
+      if !keep { stop() }
+    }
+    return lock.withLock { observers[id] == nil ? nil : id }
   }
 
   func unregister(_ id: UUID?) {
     guard let id else { return }
-    _ = lock.withLock { observers.removeValue(forKey: id) }
+    let stop = lock.withLock { () -> Cancellation? in
+      observers.removeValue(forKey: id)
+      guard observers.isEmpty, monitoring else { return nil }
+      monitoring = false
+      monitorGeneration &+= 1
+      defer { stopMonitoring = nil }
+      return stopMonitoring
+    }
+    stop?()
   }
 
   // MARK: Private
 
   private let isTrusted: @Sendable () -> Bool
+  private let canCaptureInput: @Sendable () -> Bool
+  private let startMonitoring: @Sendable (@escaping @Sendable () -> Void) -> Cancellation
+  private let notificationCenter: NotificationCenter
   private let lock = NSLock()
   private var revoked = false
   private var observers = [UUID: @Sendable () -> Void]()
+  private var monitoring = false
+  private var monitorGeneration: UInt64 = 0
+  private var stopMonitoring: Cancellation?
+
+  private func checkCaptureAccess(generation: UInt64) {
+    guard lock.withLock({ !revoked && monitoring && monitorGeneration == generation }) else { return }
+    guard isTrusted(), canCaptureInput() else {
+      revoke(reason: "WindowServer input capture unavailable", generation: generation)
+      return
+    }
+  }
+
+  private func revoke(reason: String, generation: UInt64? = nil) {
+    let cleanup = lock.withLock { () -> ([Cancellation], Cancellation?)? in
+      guard !revoked else { return nil }
+      if let generation {
+        guard monitoring, monitorGeneration == generation else { return nil }
+      }
+      revoked = true
+      monitoring = false
+      monitorGeneration &+= 1
+      defer {
+        observers.removeAll()
+        stopMonitoring = nil
+      }
+      return (Array(observers.values), stopMonitoring)
+    }
+    guard let (callbacks, stop) = cleanup else { return }
+    stop?()
+    Logger(subsystem: "dev.PangMo5.Tatami", category: "Accessibility")
+      .notice("\(reason, privacy: .public); stopping all event taps")
+    for callback in callbacks { callback() }
+    notificationCenter.post(name: Self.didCloseNotification, object: nil)
+  }
+
+}
+
+// MARK: - EventTapAccessMonitor
+
+/// TCC record deletion sends no reliable notification and may stop event
+/// delivery before a tap callback runs. Bound detection independently of input
+/// and the main run loop; stop this work when the last tap owner unregisters.
+/// Dispatch sources support cancellation from any thread.
+private final class EventTapAccessMonitor: @unchecked Sendable {
+
+  // MARK: Lifecycle
+
+  init(check: @escaping @Sendable () -> Void) {
+    timer = DispatchSource.makeTimerSource(queue: Self.queue)
+    timer.schedule(deadline: .now() + .milliseconds(250), repeating: .milliseconds(250))
+    timer.setEventHandler(handler: check)
+    timer.resume()
+  }
+
+  // MARK: Internal
+
+  func cancel() {
+    timer.cancel()
+  }
+
+  // MARK: Private
+
+  private static let queue = DispatchQueue(label: "dev.PangMo5.Tatami.input-access", qos: .utility)
+
+  private let timer: any DispatchSourceTimer
 
 }

--- a/TatamiKit/Sources/Dependencies/FloatingOverlayController.swift
+++ b/TatamiKit/Sources/Dependencies/FloatingOverlayController.swift
@@ -757,6 +757,11 @@ final class FloatingOverlayController {
       finishNativeInput: { [weak self] id in
         Task { @MainActor [weak self] in await self?.finishNativeInput(id: id) }
       },
+      onAccessRevoked: { [weak self] in
+        // A mirror cannot retain presentation after its input route disappears.
+        // This also cancels capture discovery and pending native preparations.
+        Task { @MainActor [weak self] in self?.setFloating([]) }
+      },
       onFailure: { [weak self] reason in
         Task { @MainActor [weak self] in self?.reportNativeInputFailure(reason) }
       },

--- a/TatamiKit/Sources/Dependencies/FloatingOverlayController.swift
+++ b/TatamiKit/Sources/Dependencies/FloatingOverlayController.swift
@@ -769,11 +769,33 @@ final class FloatingOverlayController {
         Task { @MainActor [weak self] in await self?.handleOutsideClick() }
       },
     )
+    permissionObservers.tokens = [NotificationCenter.default.addObserver(
+      forName: ScreenRecordingAccess.didCloseNotification,
+      object: nil,
+      queue: nil,
+    ) { [weak self] _ in
+      Task { @MainActor [weak self] in
+        guard let self else { return }
+        let hadMirrors = !desired.isEmpty
+        setFloating([])
+        if hadMirrors {
+          @Dependency(\.errorReporter) var reporter
+          reporter.report(
+            "Floating",
+            String(localized: "Always-on-top mirrors are unavailable — check Screen Recording"),
+            "Screen Recording access was lost. Relaunch Tatami after granting access.",
+          )
+        }
+      }
+    }]
   }
 
   // MARK: Internal
 
   func setFloating(_ windows: Set<WindowKey>) {
+    // Reducer updates can arrive after revocation cleanup. Keep the closed
+    // session empty instead of repeatedly starting and stopping capture streams.
+    let windows = EventTapAccess.shared.isClosed || ScreenRecordingAccess.shared.isClosed ? [] : windows
     let changed = desired != windows
     if !changed {
       if
@@ -804,10 +826,12 @@ final class FloatingOverlayController {
       let generation = addGeneration
       addTask = Task { @MainActor [weak self] in
         guard let self else { return }
+        // A cancelled generation may have acquired input before discovery.
+        // Keep it only when current panels or a newer add still own it.
+        defer { disableInputIfIdle() }
         await addMirrors(for: toAdd)
         guard addGeneration == generation else { return }
         addTask = nil
-        disableInputIfIdle()
       }
     }
     requestGeometryReconcile()
@@ -1006,6 +1030,7 @@ final class FloatingOverlayController {
   /// and the didActivate notification arrives after the z-order already
   /// changed (the intermittent "floating dips behind, then pops back up").
   private var clickTap: MirrorClickTap?
+  private let permissionObservers = PermissionObserverTokens(local: .default)
   private let debugLog: DebugLogClient
 
   /// Floating pids by focus recency, most recent first. Mirrors stack in
@@ -1024,13 +1049,17 @@ final class FloatingOverlayController {
   }
 
   private func addMirrors(for keys: Set<WindowKey>) async {
+    guard await ScreenRecordingAccess.shared.prepare(), !Task.isCancelled else { return }
+    // Acquire the input lifetime before starting capture. Revocation now owns
+    // cancellation even while ScreenCaptureKit discovery/startup is suspended.
+    guard await clickTap?.enable() == true, !Task.isCancelled else { return }
     let content: SCShareableContent
     @Dependency(\.errorReporter) var reporter
     do {
       content = try await SCShareableContent.current
-      reporter.resolve("Floating")
     } catch {
       guard !Task.isCancelled else { return }
+      ScreenRecordingAccess.shared.captureFailed(error)
       logger.error(
         "SCShareableContent failed (screen-recording permission?): \(error.localizedDescription, privacy: .public)"
       )
@@ -1041,7 +1070,8 @@ final class FloatingOverlayController {
       )
       return
     }
-    guard !Task.isCancelled else { return }
+    guard !Task.isCancelled, !ScreenRecordingAccess.shared.isClosed else { return }
+    reporter.resolve("Floating")
     var byID = [CGWindowID: SCWindow]()
     for window in content.windows { byID[window.windowID] = window }
 
@@ -1576,6 +1606,7 @@ final class FloatingOverlayController {
   /// key is (re-)suppressed.
   private func showPanel(_ key: WindowKey) {
     guard
+      !ScreenRecordingAccess.shared.isClosed,
       nativeInputLeases[key] == nil,
       !suppressed.contains(key),
       !geometryUnavailable.contains(key),
@@ -1967,6 +1998,7 @@ final class FloatingOverlayController {
     captureResumeTokens[key] = token
     let framesPerSecond = maxFPS
     Task { @MainActor [weak self, capture] in
+      guard await ScreenRecordingAccess.shared.prepare(), !Task.isCancelled else { return }
       guard
         let self,
         captures[key] === capture,
@@ -2060,6 +2092,7 @@ final class FloatingOverlayController {
 
   private func scheduleCaptureRecovery(for key: WindowKey) {
     guard
+      !ScreenRecordingAccess.shared.isClosed,
       panels[key] != nil,
       captureUnavailable.contains(key),
       !suppressed.contains(key),

--- a/TatamiKit/Sources/Dependencies/FocusFollowsMouseClient.swift
+++ b/TatamiKit/Sources/Dependencies/FocusFollowsMouseClient.swift
@@ -113,6 +113,7 @@ private final class LiveFocusFollowsMouseController: @unchecked Sendable {
   /// by sending a `tapDisabledByTimeout` event and turning the tap off.
   /// Flip it back on so focus-follows-mouse keeps working.
   fileprivate func reEnableTap() {
+    guard EventTapAccess.shared.permitsInput() else { return }
     if let tap = eventTap {
       debugLog.log("FocusDiag", "ffm tap disabled by system — re-enabling")
       CGEvent.tapEnable(tap: tap, enable: true)
@@ -178,7 +179,10 @@ private final class LiveFocusFollowsMouseController: @unchecked Sendable {
       let windows = readWindowServerWindows([.optionOnScreenOnly, .excludeDesktopElements])
       let displays = Self.currentDisplayBounds()
       EventTapThread.shared.perform { [self] in
-        guard let latest = pointerInputs.takeLatest(), config.enabled else { return }
+        guard
+          EventTapAccess.shared.permitsInput(),
+          let latest = pointerInputs.takeLatest(), config.enabled
+        else { return }
         applyHitTest(latest, windows: windows, displays: displays)
       }
     }
@@ -198,6 +202,7 @@ private final class LiveFocusFollowsMouseController: @unchecked Sendable {
   private let hitTestQueue = DispatchQueue(label: "dev.PangMo5.Tatami.ffm-hit-test", qos: .userInteractive)
   private var pointerInputs = LatestFocusInputBuffer<PointerSample>()
   private var eventTap: CFMachPort?
+  private var accessRegistration: UUID?
   private var runLoopSource: CFRunLoopSource?
   /// The in-flight focus hop. A newer fire cancels it so only the latest
   /// cursor target is applied — touched only on the event-tap thread, like
@@ -295,6 +300,7 @@ private final class LiveFocusFollowsMouseController: @unchecked Sendable {
   }
 
   private func install() {
+    guard EventTapAccess.shared.permitsInput() else { return }
     // Listen for mouseMoved + the two tap-disabled signals so we can
     // re-enable if the system hangs the tap.
     let mask =
@@ -324,6 +330,7 @@ private final class LiveFocusFollowsMouseController: @unchecked Sendable {
       return
     }
     guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+      CFMachPortInvalidate(tap)
       logger.error("focus-follows-mouse: failed to create run loop source")
       debugLog.log("FocusDiag", "ffm tap: run loop source FAILED")
       return
@@ -332,11 +339,23 @@ private final class LiveFocusFollowsMouseController: @unchecked Sendable {
     CGEvent.tapEnable(tap: tap, enable: true)
     eventTap = tap
     runLoopSource = source
+    accessRegistration = EventTapAccess.shared.register { [weak self] in
+      EventTapThread.shared.perform { [weak self] in self?.teardown() }
+    }
+    guard accessRegistration != nil else {
+      teardown()
+      return
+    }
     debugLog.log("FocusDiag", "ffm tap installed")
   }
 
   private func teardown() {
-    if let tap = eventTap { CGEvent.tapEnable(tap: tap, enable: false) }
+    EventTapAccess.shared.unregister(accessRegistration)
+    accessRegistration = nil
+    if let tap = eventTap {
+      CGEvent.tapEnable(tap: tap, enable: false)
+      CFMachPortInvalidate(tap)
+    }
     if let src = runLoopSource {
       EventTapThread.shared.removeSource(src)
     }
@@ -458,6 +477,7 @@ private func focusFollowsMouseCallback(
   event: CGEvent,
   refcon: UnsafeMutableRawPointer?,
 ) -> Unmanaged<CGEvent>? {
+  guard EventTapAccess.shared.permitsInput() else { return Unmanaged.passUnretained(event) }
   guard let refcon else { return Unmanaged.passUnretained(event) }
   let controller = Unmanaged<LiveFocusFollowsMouseController>
     .fromOpaque(refcon).takeUnretainedValue()

--- a/TatamiKit/Sources/Dependencies/GestureClient.swift
+++ b/TatamiKit/Sources/Dependencies/GestureClient.swift
@@ -74,6 +74,8 @@ private final class TrackpadSwipeRecognizer: @unchecked Sendable {
   @Dependency(\.debugLog) private var debugLog
 
   private var tap: CFMachPort?
+  private var accessRegistration: UUID?
+  private var installationGeneration: UInt64 = 0
   private var runLoopSource: CFRunLoopSource?
   private var threshold = 0.3
 
@@ -92,9 +94,18 @@ private final class TrackpadSwipeRecognizer: @unchecked Sendable {
   }
 
   @MainActor
-  func start(threshold: Double) {
+  func start(threshold: Double) async {
+    installationGeneration &+= 1
+    let generation = installationGeneration
     self.threshold = threshold
     guard tap == nil else { return }
+    // A stop or newer configuration can arrive during the initial TCC query.
+    // It must invalidate this request before a tap can be installed.
+    guard
+      await EventTapAccess.shared.prepare(),
+      installationGeneration == generation,
+      !Task.isCancelled
+    else { return }
 
     let context = Unmanaged.passUnretained(self).toOpaque()
     // ACTIVE tap (`.defaultTap`), deliberately not `.listenOnly`: TCC
@@ -132,6 +143,13 @@ private final class TrackpadSwipeRecognizer: @unchecked Sendable {
     let source = CFMachPortCreateRunLoopSource(nil, created, 0)
     CFRunLoopAddSource(CFRunLoopGetMain(), source, .commonModes)
     runLoopSource = source
+    accessRegistration = EventTapAccess.shared.register { [weak self] in
+      Task { @MainActor [weak self] in self?.stop() }
+    }
+    guard accessRegistration != nil else {
+      stop()
+      return
+    }
     CGEvent.tapEnable(tap: created, enable: true)
     debugLog.log(
       "Gesture",
@@ -141,6 +159,9 @@ private final class TrackpadSwipeRecognizer: @unchecked Sendable {
 
   @MainActor
   func stop() {
+    installationGeneration &+= 1
+    EventTapAccess.shared.unregister(accessRegistration)
+    accessRegistration = nil
     guard let tap else { return }
     CGEvent.tapEnable(tap: tap, enable: false)
     // Remove the source explicitly (matches BorrowChordTap/MirrorClickTap);
@@ -167,6 +188,7 @@ private final class TrackpadSwipeRecognizer: @unchecked Sendable {
   /// macOS 26. The other CGEvent taps (BorrowChordClient/MirrorClickTap) also
   /// handle events straight in the callout with no actor hop.
   fileprivate func consume(type: CGEventType, event: CGEvent) {
+    guard EventTapAccess.shared.permitsInput() else { return }
     if type == .tapDisabledByUserInput || type == .tapDisabledByTimeout {
       debugLog.log("Gesture", "tap disabled by system (\(type.rawValue)) — re-enabling")
       if let tap { CGEvent.tapEnable(tap: tap, enable: true) }

--- a/TatamiKit/Sources/Dependencies/MirrorClickTap.swift
+++ b/TatamiKit/Sources/Dependencies/MirrorClickTap.swift
@@ -191,16 +191,20 @@ final class MirrorClickTap: @unchecked Sendable {
     hitTestWindow: @escaping @Sendable (CGPoint) -> CGWindowID?,
     prepareNativeWindow: @escaping @Sendable (UUID, MirrorWindowRegistry.Target) async -> Bool,
     finishNativeInput: @escaping @Sendable (UUID) -> Void,
+    onAccessRevoked: @escaping @Sendable () -> Void,
     onFailure: @escaping @Sendable (String) -> Void,
     onOutsideClick: @escaping @Sendable () -> Void,
     makeEventSource: @escaping @Sendable () -> CGEventSource? = { CGEventSource(stateID: .combinedSessionState) },
+    access: EventTapAccess = .shared,
   ) {
     self.hitTestWindow = hitTestWindow
     self.prepareNativeWindow = prepareNativeWindow
     self.finishNativeInput = finishNativeInput
+    self.onAccessRevoked = onAccessRevoked
     self.onFailure = onFailure
     self.onOutsideClick = onOutsideClick
     self.makeEventSource = makeEventSource
+    self.access = access
   }
 
   // MARK: Internal
@@ -211,7 +215,7 @@ final class MirrorClickTap: @unchecked Sendable {
     await withCheckedContinuation { continuation in
       EventTapThread.shared.perform { [self] in
         if eventTap == nil { install() }
-        continuation.resume(returning: eventTap != nil && acknowledgmentTap != nil)
+        continuation.resume(returning: access.permitsInput() && eventTap != nil && acknowledgmentTap != nil)
       }
     }
   }
@@ -228,9 +232,15 @@ final class MirrorClickTap: @unchecked Sendable {
     event.getIntegerValueField(.eventSourceUserData) & -0x100000000 == wakePrefix
   }
 
+  fileprivate func permitsInput() -> Bool {
+    access.permitsInput()
+  }
+
   fileprivate func reEnable(acknowledgment: Bool = false) {
+    guard access.permitsInput() else { return }
     if let tap = acknowledgment ? acknowledgmentTap : eventTap {
       cancelInput(reason: "The system interrupted native window input delivery.")
+      guard access.permitsInput() else { return }
       CGEvent.tapEnable(tap: tap, enable: true)
     }
   }
@@ -324,9 +334,12 @@ final class MirrorClickTap: @unchecked Sendable {
   private let hitTestQueue = DispatchQueue(label: "dev.PangMo5.Tatami.mirror-input-hit-test", qos: .userInteractive)
   private let prepareNativeWindow: @Sendable (UUID, MirrorWindowRegistry.Target) async -> Bool
   private let finishNativeInput: @Sendable (UUID) -> Void
+  private let onAccessRevoked: @Sendable () -> Void
   private let onFailure: @Sendable (String) -> Void
   private let onOutsideClick: @Sendable () -> Void
   private let makeEventSource: @Sendable () -> CGEventSource?
+  private let access: EventTapAccess
+  private var accessRegistration: UUID?
   private var transportSource: CGEventSource?
   private var eventTap: CFMachPort?
   private var acknowledgmentTap: CFMachPort?
@@ -349,6 +362,10 @@ final class MirrorClickTap: @unchecked Sendable {
   }
 
   private func install() {
+    guard access.permitsInput() else {
+      onFailure("Accessibility access is unavailable. Relaunch Tatami after granting access.")
+      return
+    }
     guard let source = makeEventSource() else {
       onFailure("Could not create the native window input source.")
       return
@@ -395,17 +412,37 @@ final class MirrorClickTap: @unchecked Sendable {
         eventsOfInterest: mask,
         callback: mirrorInputAcknowledgmentCallback,
         userInfo: Unmanaged.passUnretained(self).toOpaque(),
-      ), let captureSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0),
-      let acknowledgmentSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, acknowledgmentTap, 0)
+      )
     else {
       CFMachPortInvalidate(tap)
       onFailure("Could not observe native window input delivery.")
+      return
+    }
+    guard
+      let captureSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0),
+      let acknowledgmentSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, acknowledgmentTap, 0)
+    else {
+      CFMachPortInvalidate(tap)
+      CFMachPortInvalidate(acknowledgmentTap)
+      onFailure("Could not create the native window input run loop sources.")
       return
     }
     eventTap = tap
     self.acknowledgmentTap = acknowledgmentTap
     runLoopSource = captureSource
     self.acknowledgmentSource = acknowledgmentSource
+    accessRegistration = access.register { [weak self] in
+      EventTapThread.shared.perform { [weak self] in
+        guard let self else { return }
+        teardown()
+        onAccessRevoked()
+        onFailure("Accessibility access was lost. Relaunch Tatami after granting access.")
+      }
+    }
+    guard accessRegistration != nil else {
+      teardown()
+      return
+    }
     EventTapThread.shared.addSource(captureSource)
     EventTapThread.shared.addSource(acknowledgmentSource)
     CGEvent.tapEnable(tap: acknowledgmentTap, enable: true)
@@ -414,6 +451,8 @@ final class MirrorClickTap: @unchecked Sendable {
   }
 
   private func teardown() {
+    access.unregister(accessRegistration)
+    accessRegistration = nil
     cancelInput(reason: nil)
     let taps = [eventTap, acknowledgmentTap].compactMap { $0 }
     let sources = [runLoopSource, acknowledgmentSource].compactMap { $0 }
@@ -443,7 +482,7 @@ final class MirrorClickTap: @unchecked Sendable {
     hitTestQueue.async { [weak self] in
       let windowID = hitTestWindow(point)
       EventTapThread.shared.perform { [weak self] in
-        guard let self, preparingID == id else { return }
+        guard let self, access.permitsInput(), preparingID == id else { return }
         preparingID = nil
         guard let windowID else {
           cancelInput(reason: "Could not identify the window receiving this click.")
@@ -483,7 +522,7 @@ final class MirrorClickTap: @unchecked Sendable {
     preparationTask = Task { [weak self] in
       let ready = await prepareNativeWindow(id, target)
       EventTapThread.shared.perform { [weak self] in
-        guard let self, preparingID == id else { return }
+        guard let self, access.permitsInput(), preparingID == id else { return }
         preparingID = nil
         preparationTask = nil
         guard ready else {
@@ -498,6 +537,7 @@ final class MirrorClickTap: @unchecked Sendable {
   }
 
   private func pump() {
+    guard access.permitsInput() else { return }
     guard preparingID == nil, inFlight == nil else { return }
     if let event = input.popFirst() {
       inFlight = event
@@ -530,6 +570,7 @@ final class MirrorClickTap: @unchecked Sendable {
   /// retained outside its callback; the wake packet is swallowed before it can
   /// move the pointer or reach an application.
   private func postInFlight() {
+    guard access.permitsInput() else { return }
     guard
       let inFlight, let transportSource,
       let wake = CGEvent(
@@ -581,6 +622,12 @@ final class MirrorClickTap: @unchecked Sendable {
     }
     inFlight = nil
     acknowledgments.reset()
+    // Revocation removes our ability to post balancing packets too. Discard
+    // retained ownership and let subsequent physical releases pass natively.
+    if !access.permitsInput() {
+      buttonsToRelease.removeAll()
+      keysToRelease.removeAll()
+    }
     // Balance any native downs already delivered before a teardown. Buffered
     // clicks that never reached the source are discarded, never sent elsewhere.
     for number in buttonsToRelease {
@@ -626,6 +673,10 @@ private func mirrorClickTapCallback(
 ) -> Unmanaged<CGEvent>? {
   guard let refcon else { return Unmanaged.passUnretained(event) }
   let tap = Unmanaged<MirrorClickTap>.fromOpaque(refcon).takeUnretainedValue()
+  guard tap.permitsInput() else {
+    // A relay wake posted just before revocation is ours, not physical input.
+    return MirrorClickTap.isWake(event) ? nil : Unmanaged.passUnretained(event)
+  }
   switch type {
   case .tapDisabledByTimeout,
        .tapDisabledByUserInput:
@@ -651,6 +702,7 @@ private func mirrorInputAcknowledgmentCallback(
 ) -> Unmanaged<CGEvent>? {
   guard let refcon else { return Unmanaged.passUnretained(event) }
   let tap = Unmanaged<MirrorClickTap>.fromOpaque(refcon).takeUnretainedValue()
+  guard tap.permitsInput() else { return Unmanaged.passUnretained(event) }
   switch type {
   case .tapDisabledByTimeout,
        .tapDisabledByUserInput:

--- a/TatamiKit/Sources/Dependencies/ScreenRecordingAccess.swift
+++ b/TatamiKit/Sources/Dependencies/ScreenRecordingAccess.swift
@@ -1,0 +1,77 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CoreGraphics
+import Foundation
+import OSLog
+import ScreenCaptureKit
+
+/// Shares known Screen Recording denial between capture and permission UI.
+/// Screen capture has its own lifetime; closing it does not revoke AX input.
+/// No permission request or capture is created just to check access.
+final class ScreenRecordingAccess: @unchecked Sendable {
+
+  // MARK: Lifecycle
+
+  init(
+    preflight: @escaping @Sendable () -> Bool,
+    notificationCenter: NotificationCenter = .default,
+  ) {
+    self.preflight = preflight
+    self.notificationCenter = notificationCenter
+  }
+
+  // MARK: Internal
+
+  static let shared = ScreenRecordingAccess(preflight: { CGPreflightScreenCaptureAccess() })
+  static let didCloseNotification = Notification.Name("dev.PangMo5.Tatami.screenRecordingAccessDidClose")
+
+  var isClosed: Bool {
+    lock.withLock { closed }
+  }
+
+  func isGranted() -> Bool {
+    guard !isClosed else { return false }
+    // Do not hold the UI-readable lock over a system permission query.
+    if !preflight() { close() }
+    return !isClosed
+  }
+
+  /// Capture startup/resume checks execute away from MainActor and revalidate
+  /// their own request ownership after awaiting this result.
+  func prepare() async -> Bool {
+    await worker.run { self.isGranted() }
+  }
+
+  func captureFailed(_ error: any Error) {
+    let error = error as NSError
+    if error.domain == SCStreamErrorDomain, error.code == SCStreamError.Code.userDeclined.rawValue {
+      close()
+    } else {
+      // userStopped and operational failures are not permission denials.
+      // A fresh preflight can still identify a concurrent actual revocation.
+      Task { _ = await prepare() }
+    }
+  }
+
+  // MARK: Private
+
+  private let preflight: @Sendable () -> Bool
+  private let notificationCenter: NotificationCenter
+  private let worker = BlockingWorkQueue(label: "dev.PangMo5.Tatami.screen-recording-access", qos: .utility)
+  private let lock = NSLock()
+  private var closed = false
+
+  private func close() {
+    let changed = lock.withLock {
+      guard !closed else { return false }
+      closed = true
+      return true
+    }
+    guard changed else { return }
+    Logger(subsystem: "dev.PangMo5.Tatami", category: "ScreenRecording")
+      .notice("Screen Recording access lost; stopping floating captures")
+    notificationCenter.post(name: Self.didCloseNotification, object: nil)
+  }
+
+}

--- a/TatamiKit/Sources/Dependencies/ScreenRecordingClient.swift
+++ b/TatamiKit/Sources/Dependencies/ScreenRecordingClient.swift
@@ -7,13 +7,14 @@ import Dependencies
 import DependenciesMacros
 import Foundation
 
+// MARK: - ScreenRecordingClient
+
 /// Screen Recording (TCC) permission: status, prompting, and the System
 /// Settings deep link. Tatami needs it only for floating windows — their
 /// always-on-top mirrors are ScreenCaptureKit captures.
 ///
-/// Like Accessibility, a *new* grant doesn't reach the running process:
-/// `SCStream` keeps failing until relaunch (revokes apply live). The
-/// Settings UI pairs the grant button with the existing relaunch row.
+/// Preflight reads and ScreenCaptureKit permission failures share one session
+/// state. A known denial stays closed until relaunch after granting access.
 @DependencyClient
 struct ScreenRecordingClient: Sendable {
   /// Current grant state (non-prompting).
@@ -23,26 +24,60 @@ struct ScreenRecordingClient: Sendable {
   var requestAccess: @Sendable () async -> Void
   /// Open System Settings → Privacy & Security → Screen Recording.
   var openSettings: @Sendable () async -> Void
+  /// Initial state, capture permission denial, or app reactivation.
+  var changes: @Sendable () -> AsyncStream<Void> = { .finished }
 }
 
-extension ScreenRecordingClient: DependencyKey {
-  static let liveValue = ScreenRecordingClient(
-    isGranted: { CGPreflightScreenCaptureAccess() },
-    requestAccess: {
-      await MainActor.run { _ = CGRequestScreenCaptureAccess() }
-    },
-    openSettings: {
-      await MainActor.run {
-        guard let url = URL(
-          string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
-        ) else { return }
-        NSWorkspace.shared.open(url)
-      }
-    }
-  )
+// MARK: DependencyKey
 
-  static let testValue = ScreenRecordingClient()
+extension ScreenRecordingClient: DependencyKey {
+  static let liveValue = live(access: .shared, notificationCenter: .default)
+
+  static let testValue = ScreenRecordingClient(
+    isGranted: { false },
+    requestAccess: { },
+    openSettings: { },
+    changes: { .finished },
+  )
   static let previewValue = testValue
+
+  static func live(access: ScreenRecordingAccess, notificationCenter: NotificationCenter) -> Self {
+    ScreenRecordingClient(
+      isGranted: { access.isGranted() },
+      requestAccess: {
+        await MainActor.run { _ = CGRequestScreenCaptureAccess() }
+      },
+      openSettings: {
+        await MainActor.run {
+          guard
+            let url = URL(
+              string: "x-apple.systempreferences:com.apple.preference.security?Privacy_ScreenCapture"
+            )
+          else { return }
+          NSWorkspace.shared.open(url)
+        }
+      },
+      changes: {
+        AsyncStream { continuation in
+          let observers = PermissionObserverTokens(local: notificationCenter)
+          observers.tokens = [
+            observers.local.addObserver(
+              forName: ScreenRecordingAccess.didCloseNotification,
+              object: nil,
+              queue: nil,
+            ) { _ in continuation.yield() },
+            observers.local.addObserver(
+              forName: NSApplication.didBecomeActiveNotification,
+              object: nil,
+              queue: nil,
+            ) { _ in continuation.yield() },
+          ]
+          continuation.onTermination = { _ in observers.removeAll() }
+          continuation.yield()
+        }
+      },
+    )
+  }
 }
 
 extension DependencyValues {

--- a/TatamiKit/Sources/Dependencies/WindowMirrorCapture.swift
+++ b/TatamiKit/Sources/Dependencies/WindowMirrorCapture.swift
@@ -64,6 +64,7 @@ final class WindowMirrorCapture: NSObject, @unchecked Sendable {
   /// Begin capturing `window`. No-op if already streaming or starting.
   @MainActor
   func start(window: SCWindow, maxFPS: Int) async -> Bool {
+    guard !ScreenRecordingAccess.shared.isClosed else { return false }
     guard stream == nil, !isStarting else { return stream != nil }
     isStarting = true
     startingStopSucceeded = true
@@ -101,6 +102,7 @@ final class WindowMirrorCapture: NSObject, @unchecked Sendable {
     } catch {
       retireFrameSource(ObjectIdentifier(stream))
       logger.error("mirror start failed: \(error.localizedDescription, privacy: .public)")
+      if generation == startedGeneration { ScreenRecordingAccess.shared.captureFailed(error) }
       self.stream = nil
       finishPendingFirstFrame(for: stream, outcome: .failed)
       return false
@@ -165,6 +167,10 @@ final class WindowMirrorCapture: NSObject, @unchecked Sendable {
     maxFPS: Int,
     onFirstFrame: (@MainActor (FirstFrameOutcome) -> Void)? = nil,
   ) async {
+    guard !ScreenRecordingAccess.shared.isClosed else {
+      onFirstFrame?(.failed)
+      return
+    }
     if isStarting {
       // A start/resume is already in flight; its frames will arrive.
       if let onFirstFrame, let startingStream {
@@ -218,6 +224,7 @@ final class WindowMirrorCapture: NSObject, @unchecked Sendable {
     } catch {
       retireFrameSource(ObjectIdentifier(stream))
       logger.error("mirror resume failed: \(error.localizedDescription, privacy: .public)")
+      if generation == startedGeneration { ScreenRecordingAccess.shared.captureFailed(error) }
       self.stream = nil
       finishPendingFirstFrame(for: stream, outcome: .failed)
     }
@@ -485,6 +492,7 @@ extension WindowMirrorCapture: SCStreamOutput, SCStreamDelegate {
   ) {
     guard
       type == .screen, sampleBuffer.isValid,
+      !ScreenRecordingAccess.shared.isClosed,
       frameGate.accepts(ObjectIdentifier(stream))
     else { return }
     // Apple explicitly supports background enqueuing through this renderer.
@@ -518,6 +526,7 @@ extension WindowMirrorCapture: SCStreamOutput, SCStreamDelegate {
           ObjectIdentifier($0) == stoppedStreamID ? $0 : nil
         }
         guard active != nil || starting != nil else { return }
+        ScreenRecordingAccess.shared.captureFailed(error)
         // Invalidate an in-flight start before invoking failure callbacks:
         // a retry may begin reentrantly from a callback, and the failed
         // attempt must not publish itself if its await later returns.

--- a/TatamiKit/Sources/Dependencies/WorkspaceHUDClient.swift
+++ b/TatamiKit/Sources/Dependencies/WorkspaceHUDClient.swift
@@ -1513,6 +1513,7 @@ private final class WindowSwitcherInputTap: @unchecked Sendable {
   // MARK: Fileprivate
 
   fileprivate func reEnable() {
+    guard EventTapAccess.shared.permitsInput() else { return }
     if let eventTap {
       CGEvent.tapEnable(tap: eventTap, enable: true)
     }
@@ -1542,12 +1543,17 @@ private final class WindowSwitcherInputTap: @unchecked Sendable {
   // MARK: Private
 
   private var eventTap: CFMachPort?
+  private var accessRegistration: UUID?
   private var runLoopSource: CFRunLoopSource?
   private let debugLog: DebugLogClient
   private let emit: @Sendable (WindowSwitcherInteraction) -> Void
 
   /// Runs on the event-tap thread.
   private func install() {
+    guard EventTapAccess.shared.permitsInput() else {
+      emit(.cancel)
+      return
+    }
     let mask =
       (1 << CGEventType.keyDown.rawValue)
         | (1 << CGEventType.tapDisabledByTimeout.rawValue)
@@ -1567,6 +1573,7 @@ private final class WindowSwitcherInputTap: @unchecked Sendable {
       return
     }
     guard let source = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, tap, 0) else {
+      CFMachPortInvalidate(tap)
       debugLog.log("HUDDiag", "window switcher input source create FAILED")
       return
     }
@@ -1574,11 +1581,27 @@ private final class WindowSwitcherInputTap: @unchecked Sendable {
     CGEvent.tapEnable(tap: tap, enable: true)
     eventTap = tap
     runLoopSource = source
+    accessRegistration = EventTapAccess.shared.register { [weak self] in
+      EventTapThread.shared.perform { [weak self] in
+        self?.teardown()
+        self?.emit(.cancel)
+      }
+    }
+    guard accessRegistration != nil else {
+      teardown()
+      emit(.cancel)
+      return
+    }
     debugLog.log("HUDDiag", "window switcher input armed")
   }
 
   private func teardown() {
-    if let eventTap { CGEvent.tapEnable(tap: eventTap, enable: false) }
+    EventTapAccess.shared.unregister(accessRegistration)
+    accessRegistration = nil
+    if let eventTap {
+      CGEvent.tapEnable(tap: eventTap, enable: false)
+      CFMachPortInvalidate(eventTap)
+    }
     if let runLoopSource { EventTapThread.shared.removeSource(runLoopSource) }
     eventTap = nil
     runLoopSource = nil
@@ -1593,6 +1616,7 @@ private func windowSwitcherInputTapCallback(
   event: CGEvent,
   refcon: UnsafeMutableRawPointer?,
 ) -> Unmanaged<CGEvent>? {
+  guard EventTapAccess.shared.permitsInput() else { return Unmanaged.passUnretained(event) }
   guard let refcon else { return Unmanaged.passUnretained(event) }
   let tap = Unmanaged<WindowSwitcherInputTap>.fromOpaque(refcon).takeUnretainedValue()
   switch type {

--- a/TatamiKit/Sources/Features/Onboarding/OnboardingFeature.swift
+++ b/TatamiKit/Sources/Features/Onboarding/OnboardingFeature.swift
@@ -589,6 +589,7 @@ public struct OnboardingFeature {
     case alert(PresentationAction<Alert>)
     case confirmationSuppressionChanged(Bool)
     case accessibilityChanged
+    case screenRecordingChanged
     case addProfileButtonTapped
     case addScratchpadButtonTapped
     case addWorkspaceButtonTapped
@@ -775,6 +776,12 @@ public struct OnboardingFeature {
             }
           }
           .cancellable(id: CancelID.permissionChanges, cancelInFlight: true),
+          .run { [screenRecording] send in
+            for await _ in screenRecording.changes() {
+              await send(.screenRecordingChanged)
+            }
+          }
+          .cancellable(id: CancelID.screenRecordingChanges, cancelInFlight: true),
         )
 
       case .viewDisappeared:
@@ -782,6 +789,7 @@ public struct OnboardingFeature {
         return .merge(
           persist(state),
           .cancel(id: CancelID.permissionChanges),
+          .cancel(id: CancelID.screenRecordingChanges),
           .send(.delegate(.gesturePreviewEnded)),
           .send(.delegate(.shortcutPreviewEnded)),
           .send(.delegate(.borrowChordPreviewChanged(false))),
@@ -789,6 +797,10 @@ public struct OnboardingFeature {
 
       case .accessibilityChanged:
         state.hasAccessibility = accessibility.isTrusted()
+        state.hasScreenRecording = screenRecording.isGranted()
+        return persist(state)
+
+      case .screenRecordingChanged:
         state.hasScreenRecording = screenRecording.isGranted()
         return persist(state)
 
@@ -1450,6 +1462,7 @@ public struct OnboardingFeature {
   private enum CancelID {
     case aiRecommendation
     case permissionChanges
+    case screenRecordingChanges
     case saveProgress
   }
 

--- a/TatamiKit/Sources/Features/Settings/SettingsFeature.swift
+++ b/TatamiKit/Sources/Features/Settings/SettingsFeature.swift
@@ -44,6 +44,7 @@ public struct SettingsFeature {
     case uninstallCLITapped
     /// A trust-DB change (or app re-activation) — re-read permission status.
     case accessibilityChanged
+    case screenRecordingChanged
     case grantAccessibilityTapped
     case openAccessibilitySettingsTapped
     case grantScreenRecordingTapped
@@ -88,6 +89,11 @@ public struct SettingsFeature {
               // the Screen Recording pane of System Settings).
               for await _ in accessibility.changes() {
                 await send(.accessibilityChanged)
+              }
+            },
+            .run { [screenRecording] send in
+              for await _ in screenRecording.changes() {
+                await send(.screenRecordingChanged)
               }
             },
           )
@@ -136,6 +142,10 @@ public struct SettingsFeature {
 
         case .accessibilityChanged:
           state.hasAXPermission = accessibility.isTrusted()
+          state.hasScreenRecordingPermission = screenRecording.isGranted()
+          return .none
+
+        case .screenRecordingChanged:
           state.hasScreenRecordingPermission = screenRecording.isGranted()
           return .none
 

--- a/TatamiTests/Sources/EventTapAccessTests.swift
+++ b/TatamiTests/Sources/EventTapAccessTests.swift
@@ -1,0 +1,97 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import CustomDump
+import Dependencies
+import Foundation
+import Testing
+@testable import TatamiKit
+
+struct EventTapAccessTests {
+  @Test
+  func `revocation stops every owner once and forbids capture and reinstall`() {
+    let trusted = LockIsolated(true)
+    let stopped = LockIsolated<[String]>([])
+    let access = EventTapAccess(isTrusted: { trusted.value })
+    #expect(access.permitsInput())
+    let capture = access.register { stopped.withValue { $0.append("capture") } }
+    let observer = access.register { stopped.withValue { $0.append("observer") } }
+    #expect(capture != nil && observer != nil)
+    trusted.setValue(false)
+    #expect(!access.permitsInput())
+    expectNoDifference(Set(stopped.value), ["capture", "observer"])
+    #expect(!access.permitsInput())
+    expectNoDifference(stopped.value.count, 2)
+    let late = access.register { stopped.withValue { $0.append("late") } }
+    #expect(late == nil)
+    // A later grant belongs to a fresh process, never a stale input session.
+    trusted.setValue(true)
+    #expect(!access.permitsInput())
+    expectNoDifference(stopped.value.count, 2)
+  }
+
+  @Test
+  func `normal teardown unregisters its owner without closing other taps`() {
+    let trusted = LockIsolated(true)
+    let stopped = LockIsolated<[String]>([])
+    let access = EventTapAccess(isTrusted: { trusted.value })
+    let old = access.register { stopped.withValue { $0.append("old") } }
+    access.unregister(old)
+    #expect(access.permitsInput())
+    _ = access.register { stopped.withValue { $0.append("current") } }
+    trusted.setValue(false)
+    #expect(!access.permitsInput())
+    expectNoDifference(stopped.value, ["current"])
+  }
+
+  @Test
+  func `revocation callbacks can unregister and check access without a lock cycle`() {
+    let trusted = LockIsolated(true)
+    let access = EventTapAccess(isTrusted: { trusted.value })
+    let registration = LockIsolated<UUID?>(nil)
+    let observed = LockIsolated<Bool?>(nil)
+    registration.setValue(access.register {
+      access.unregister(registration.value)
+      observed.setValue(access.permitsInput())
+    })
+    trusted.setValue(false)
+    #expect(!access.permitsInput())
+    expectNoDifference(observed.value, false)
+  }
+
+  @Test
+  func `a stale successful query cannot reopen access after concurrent revocation`() async {
+    let calls = LockIsolated(0)
+    let (started, continuation) = AsyncStream<Void>.makeStream()
+    let release = DispatchSemaphore(value: 0)
+    let access = EventTapAccess {
+      let call = calls.withValue { $0 += 1
+        return $0
+      }
+      if call == 1 {
+        continuation.yield()
+        _ = release.wait(timeout: .now() + 5)
+        return true
+      }
+      return false
+    }
+    let first = Task.detached { access.permitsInput() }
+    var iterator = started.makeAsyncIterator()
+    await iterator.next()
+    #expect(!access.permitsInput())
+    release.signal()
+    #expect(await !first.value)
+    continuation.finish()
+  }
+
+  @Test @MainActor
+  func `initial permission preparation runs outside the main thread`() async {
+    let onMain = LockIsolated<Bool?>(nil)
+    let access = EventTapAccess {
+      onMain.setValue(Thread.isMainThread)
+      return true
+    }
+    #expect(await access.prepare())
+    expectNoDifference(onMain.value, false)
+  }
+}

--- a/TatamiTests/Sources/EventTapAccessTests.swift
+++ b/TatamiTests/Sources/EventTapAccessTests.swift
@@ -1,13 +1,192 @@
 // SPDX-FileCopyrightText: 2026 PangMo5 and contributors
 // SPDX-License-Identifier: AGPL-3.0-only
 
+import ComposableArchitecture
 import CustomDump
 import Dependencies
 import Foundation
 import Testing
 @testable import TatamiKit
 
+// MARK: - EventTapAccessTests
+
 struct EventTapAccessTests {
+  @Test @MainActor
+  func `settings refreshes a deleted grant without an OS permission notification`() async {
+    let captureAllowed = LockIsolated(true)
+    let monitor = EventTapAccessTestMonitor()
+    let notifications = NotificationCenter()
+    let access = EventTapAccess(
+      isTrusted: { true },
+      canCaptureInput: { captureAllowed.value },
+      startMonitoring: monitor.start,
+      notificationCenter: notifications,
+    )
+    #expect(access.register { } != nil)
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.accessibility = .live(access: access, notificationCenter: notifications)
+      $0.screenRecording.isGranted = { true }
+    }
+    store.exhaustivity = .off
+    let task = await store.send(.task)
+    // The initial stream tick establishes a live subscription before deletion.
+    await store.receive(\.accessibilityChanged)
+    #expect(store.state.hasAXPermission)
+    captureAllowed.setValue(false)
+    monitor.checks.value[0]()
+    await store.receive(\.accessibilityChanged) {
+      $0.hasAXPermission = false
+    }
+    #expect(store.state.hasScreenRecordingPermission)
+    await task.cancel()
+    await store.finish()
+  }
+
+  @Test
+  func `a permission subscriber catches closure between its initial read and subscription`() async {
+    let captureAllowed = LockIsolated(true)
+    let monitor = EventTapAccessTestMonitor()
+    let notifications = NotificationCenter()
+    let access = EventTapAccess(
+      isTrusted: { true },
+      canCaptureInput: { captureAllowed.value },
+      startMonitoring: monitor.start,
+      notificationCenter: notifications,
+    )
+    let client = AccessibilityClient.live(access: access, notificationCenter: notifications)
+    #expect(client.isTrusted())
+    #expect(access.register { } != nil)
+    captureAllowed.setValue(false)
+    monitor.checks.value[0]()
+    var changes = client.changes().makeAsyncIterator()
+    #expect(await changes.next() != nil)
+    #expect(!client.isTrusted())
+  }
+
+  @Test
+  func `observing permission status does not acquire input capture ownership`() async {
+    let monitor = EventTapAccessTestMonitor()
+    let notifications = NotificationCenter()
+    let access = EventTapAccess(
+      isTrusted: { true },
+      canCaptureInput: { true },
+      startMonitoring: monitor.start,
+      notificationCenter: notifications,
+    )
+    let client = AccessibilityClient.live(access: access, notificationCenter: notifications)
+    var changes = client.changes().makeAsyncIterator()
+    #expect(await changes.next() != nil)
+    #expect(client.isTrusted())
+    #expect(monitor.checks.value.isEmpty)
+  }
+
+  @Test
+  func `a deleted permission record closes input even when trust remains cached`() {
+    let captureAllowed = LockIsolated(true)
+    let stopped = LockIsolated(0)
+    let monitor = EventTapAccessTestMonitor()
+    let access = EventTapAccess(
+      isTrusted: { true },
+      canCaptureInput: { captureAllowed.value },
+      startMonitoring: monitor.start,
+    )
+    #expect(access.register { stopped.withValue { $0 += 1 } } != nil)
+    #expect(access.register { stopped.withValue { $0 += 1 } } != nil)
+    expectNoDifference(monitor.checks.value.count, 1)
+    captureAllowed.setValue(false)
+    monitor.checks.value[0]()
+    #expect(!access.permitsInput())
+    expectNoDifference(stopped.value, 2)
+    expectNoDifference(monitor.cancellations.value, 1)
+    captureAllowed.setValue(true)
+    monitor.checks.value[0]()
+    #expect(access.register { } == nil)
+    expectNoDifference(stopped.value, 2)
+  }
+
+  @Test
+  func `only live tap owners keep permission monitoring alive`() {
+    let queries = LockIsolated(0)
+    let monitor = EventTapAccessTestMonitor()
+    let access = EventTapAccess(
+      isTrusted: { true },
+      canCaptureInput: { queries.withValue { $0 += 1 }
+        return true
+      },
+      startMonitoring: monitor.start,
+    )
+    let first = access.register { }
+    let second = access.register { }
+    access.unregister(first)
+    expectNoDifference(monitor.cancellations.value, 0)
+    monitor.checks.value[0]()
+    expectNoDifference(queries.value, 1)
+    access.unregister(second)
+    expectNoDifference(monitor.cancellations.value, 1)
+    #expect(access.register { } != nil)
+    monitor.checks.value[0]()
+    expectNoDifference(queries.value, 1)
+    monitor.checks.value[1]()
+    expectNoDifference(queries.value, 2)
+  }
+
+  @Test
+  func `an in-flight check cannot close a newer tap ownership generation`() async {
+    let queries = LockIsolated(0)
+    let stopped = LockIsolated(false)
+    let monitor = EventTapAccessTestMonitor()
+    let (started, continuation) = AsyncStream<Void>.makeStream()
+    let release = DispatchSemaphore(value: 0)
+    let access = EventTapAccess(
+      isTrusted: { true },
+      canCaptureInput: {
+        let count = queries.withValue { $0 += 1
+          return $0
+        }
+        if count == 1 {
+          continuation.yield()
+          _ = release.wait(timeout: .now() + 5)
+          return false
+        }
+        return true
+      },
+      startMonitoring: monitor.start,
+    )
+    let first = access.register { }
+    let pending = Task.detached { monitor.checks.value[0]() }
+    var iterator = started.makeAsyncIterator()
+    await iterator.next()
+    access.unregister(first)
+    #expect(access.register { stopped.setValue(true) } != nil)
+    release.signal()
+    await pending.value
+    #expect(access.permitsInput())
+    #expect(!stopped.value)
+    monitor.checks.value[1]()
+    #expect(access.permitsInput())
+    continuation.finish()
+  }
+
+  @Test
+  func `revocation during monitor startup cancels the returned monitor`() {
+    let cancelled = LockIsolated(false)
+    let stopped = LockIsolated(false)
+    let access = EventTapAccess(
+      isTrusted: { true },
+      canCaptureInput: { false },
+      startMonitoring: { check in
+        check()
+        return { cancelled.setValue(true) }
+      },
+    )
+    #expect(access.register { stopped.setValue(true) } == nil)
+    #expect(stopped.value)
+    #expect(cancelled.value)
+    #expect(!access.permitsInput())
+  }
+
   @Test
   func `revocation stops every owner once and forbids capture and reinstall`() {
     let trusted = LockIsolated(true)
@@ -93,5 +272,24 @@ struct EventTapAccessTests {
     }
     #expect(await access.prepare())
     expectNoDifference(onMain.value, false)
+  }
+}
+
+/// Existing gate-only tests inject trust without touching WindowServer or timers.
+extension EventTapAccess {
+  convenience init(isTrusted: @escaping @Sendable () -> Bool) {
+    self.init(isTrusted: isTrusted, canCaptureInput: { true }, startMonitoring: { _ in { } })
+  }
+}
+
+// MARK: - EventTapAccessTestMonitor
+
+private struct EventTapAccessTestMonitor: Sendable {
+  let checks = LockIsolated<[@Sendable () -> Void]>([])
+  let cancellations = LockIsolated(0)
+
+  func start(_ check: @escaping @Sendable () -> Void) -> EventTapAccess.Cancellation {
+    checks.withValue { $0.append(check) }
+    return { cancellations.withValue { $0 += 1 } }
   }
 }

--- a/TatamiTests/Sources/MirrorInputHandoverTests.swift
+++ b/TatamiTests/Sources/MirrorInputHandoverTests.swift
@@ -11,15 +11,39 @@ struct MirrorInputHandoverTests {
   // MARK: Internal
 
   @Test
+  func `untrusted mirror installation never creates an input source`() async {
+    let sourceRequests = LockIsolated(0)
+    let failures = LockIsolated<[String]>([])
+    let tap = MirrorClickTap(
+      hitTestWindow: { _ in nil },
+      prepareNativeWindow: { _, _ in false },
+      finishNativeInput: { _ in },
+      onAccessRevoked: {},
+      onFailure: { reason in failures.withValue { $0.append(reason) } },
+      onOutsideClick: {},
+      makeEventSource: {
+        sourceRequests.withValue { $0 += 1 }
+        return nil
+      },
+      access: EventTapAccess(isTrusted: { false }),
+    )
+    #expect(await !tap.enable())
+    #expect(sourceRequests.value == 0)
+    #expect(failures.value.count == 1)
+  }
+
+  @Test
   func `failed native input installation never reports readiness for a mirror`() async {
     let failures = LockIsolated<[String]>([])
     let tap = MirrorClickTap(
       hitTestWindow: { _ in nil },
       prepareNativeWindow: { _, _ in false },
       finishNativeInput: { _ in },
+      onAccessRevoked: { },
       onFailure: { reason in failures.withValue { $0.append(reason) } },
       onOutsideClick: { },
       makeEventSource: { nil },
+      access: EventTapAccess(isTrusted: { true }),
     )
     let ready = await tap.enable()
     #expect(!ready)

--- a/TatamiTests/Sources/ScreenRecordingAccessTests.swift
+++ b/TatamiTests/Sources/ScreenRecordingAccessTests.swift
@@ -1,0 +1,92 @@
+// SPDX-FileCopyrightText: 2026 PangMo5 and contributors
+// SPDX-License-Identifier: AGPL-3.0-only
+
+import ComposableArchitecture
+import Dependencies
+import Foundation
+import ScreenCaptureKit
+import Testing
+@testable import TatamiKit
+
+struct ScreenRecordingAccessTests {
+  @Test @MainActor
+  func `capture permission denial updates Settings without revoking Accessibility`() async {
+    let notifications = NotificationCenter()
+    let access = ScreenRecordingAccess(preflight: { true }, notificationCenter: notifications)
+    let store = TestStore(initialState: SettingsFeature.State()) {
+      SettingsFeature()
+    } withDependencies: {
+      $0.accessibility.isTrusted = { true }
+      $0.screenRecording = .live(access: access, notificationCenter: notifications)
+    }
+    store.exhaustivity = .off
+    let task = await store.send(.task)
+    await store.receive(\.screenRecordingChanged)
+    #expect(store.state.hasScreenRecordingPermission)
+    access.captureFailed(NSError(domain: SCStreamErrorDomain, code: SCStreamError.Code.userDeclined.rawValue))
+    await store.receive(\.screenRecordingChanged) {
+      $0.hasScreenRecordingPermission = false
+    }
+    #expect(store.state.hasAXPermission)
+    await task.cancel()
+    await store.finish()
+  }
+
+  @Test
+  func `a revoked preflight stays closed even if the process later reports allowed`() async {
+    let granted = LockIsolated(true)
+    let notifications = NotificationCenter()
+    let access = ScreenRecordingAccess(preflight: { granted.value }, notificationCenter: notifications)
+    let client = ScreenRecordingClient.live(access: access, notificationCenter: notifications)
+    var changes = client.changes().makeAsyncIterator()
+    #expect(await changes.next() != nil)
+    #expect(client.isGranted())
+    granted.setValue(false)
+    #expect(await !access.prepare())
+    #expect(await changes.next() != nil)
+    granted.setValue(true)
+    #expect(!client.isGranted())
+  }
+
+  @Test
+  func `operational errors and stopping sharing do not imply revoked permission`() async {
+    let access = ScreenRecordingAccess(preflight: { true }, notificationCenter: NotificationCenter())
+    access.captureFailed(NSError(domain: SCStreamErrorDomain, code: SCStreamError.Code.userStopped.rawValue))
+    #expect(await access.prepare())
+    access.captureFailed(NSError(domain: "Unrelated", code: SCStreamError.Code.userDeclined.rawValue))
+    #expect(await access.prepare())
+    access.captureFailed(NSError(domain: SCStreamErrorDomain, code: SCStreamError.Code.failedToStart.rawValue))
+    #expect(await access.prepare())
+    #expect(!access.isClosed)
+  }
+
+  @Test
+  func `a stale successful preflight cannot reopen a denied capture session`() async {
+    let (started, continuation) = AsyncStream<Void>.makeStream()
+    let release = DispatchSemaphore(value: 0)
+    let access = ScreenRecordingAccess(preflight: {
+      continuation.yield()
+      _ = release.wait(timeout: .now() + 5)
+      return true
+    }, notificationCenter: NotificationCenter())
+    let pending = Task { await access.prepare() }
+    var iterator = started.makeAsyncIterator()
+    await iterator.next()
+    access.captureFailed(NSError(domain: SCStreamErrorDomain, code: SCStreamError.Code.userDeclined.rawValue))
+    release.signal()
+    #expect(await !pending.value)
+    #expect(access.isClosed)
+    continuation.finish()
+  }
+
+  @Test @MainActor
+  func `capture preflight runs outside the main actor`() async {
+    let onMain = LockIsolated<Bool?>(nil)
+    let access = ScreenRecordingAccess(preflight: {
+      onMain.setValue(Thread.isMainThread)
+      return true
+    }, notificationCenter: NotificationCenter())
+    #expect(await access.prepare())
+    #expect(onMain.value == false)
+  }
+}


### PR DESCRIPTION
Revoking or deleting Accessibility access while Tatami is running can leave active event taps capturing system input, and Settings can continue showing cached permission grants. Bind input capture, mirror replay, and permission presentation to the same session lifetime so known permission loss releases input and remains denied until relaunch.

- Check WindowServer capture admission off the main thread while tap owners exist, tear down all input owners on denial, and discard stale callbacks and pending replay.
- Propagate Accessibility and Screen Recording denial to Settings and Onboarding. Stop floating captures on Screen Recording denial while preserving independent Accessibility state.
- Keep the main window usable across loading and tab changes with minimum dimensions and a default initial size.

Validation:
- XcodeBuildMCP macOS Debug suite: 762 passed, 0 failed or skipped; no build warnings or errors reported.
- SwiftFormat lint on changed Swift files and staged diff checks passed.
- The current Debug candidate was installed and its executable hashes verified before the user reported that it appeared to work. This is a manual confirmation, not exhaustive coverage of every permission/input combination.
- The five-minute QA watchdog and local evidence files are outside the repository and are not included.

Fixes #2.
